### PR TITLE
feat: add rise public release workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,75 @@
+name: Rise CI
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  release-order:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Validate release order
+        run: |
+          set -euo pipefail
+          git fetch origin "${GITHUB_BASE_REF}" --prune
+          uv run --script scripts/validate_release_order.py \
+            --base-ref "origin/${GITHUB_BASE_REF}" \
+            --head-ref HEAD \
+            --head-branch "${GITHUB_HEAD_REF}"
+
+  typescript:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ts
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type-check
+        run: bun run check
+
+      - name: Test
+        run: bun run test
+
+      - name: Build
+        run: bun run build
+
+  rust:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install 1.84.0 --profile minimal
+
+      - name: Test
+        run: cargo +1.84.0 test --locked

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        run: rustup toolchain install 1.84.0 --profile minimal
+        run: rustup toolchain install 1.91.1 --profile minimal
 
       - name: Test
-        run: cargo +1.84.0 test --locked
+        run: cargo +1.91.1 test --locked

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -173,7 +173,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        run: rustup toolchain install 1.84.0 --profile minimal
+        run: rustup toolchain install 1.91.1 --profile minimal
 
       - name: Check crates.io version
         id: crate-status
@@ -205,7 +205,7 @@ jobs:
 
       - name: Test
         if: steps.crate-status.outputs.publish == 'true'
-        run: cargo +1.84.0 test --locked
+        run: cargo +1.91.1 test --locked
 
       - name: Authenticate to crates.io
         if: >
@@ -225,7 +225,7 @@ jobs:
           if [[ "${DRY_RUN}" == "true" ]]; then
             args+=(--dry-run)
           fi
-          cargo +1.84.0 publish "${args[@]}"
+          cargo +1.91.1 publish "${args[@]}"
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.cargo-auth.outputs.token }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,278 @@
+name: Rise Release
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run publish commands in dry-run mode."
+        default: "true"
+        required: true
+        type: choice
+        options:
+          - "true"
+          - "false"
+      package:
+        description: "Package scope to publish."
+        default: "both"
+        required: true
+        type: choice
+        options:
+          - "both"
+          - "typescript"
+          - "rust"
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.plan.outputs.release_tag }}
+      release_title: ${{ steps.plan.outputs.release_title }}
+      rust_name: ${{ steps.plan.outputs.rust_name }}
+      rust_version: ${{ steps.plan.outputs.rust_version }}
+      ts_name: ${{ steps.plan.outputs.ts_name }}
+      ts_version: ${{ steps.plan.outputs.ts_version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Plan release
+        id: plan
+        run: uv run --script scripts/release_plan.py
+
+  publish-typescript:
+    needs: plan
+    if: >
+      github.event_name != 'workflow_dispatch' ||
+      inputs.package == 'both' ||
+      inputs.package == 'typescript'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: ts
+    env:
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
+      NPM_PUBLISH_ACCESS: ${{ vars.NPM_PUBLISH_ACCESS || 'public' }}
+      NPM_REGISTRY_URL: ${{ vars.NPM_REGISTRY_URL || 'https://registry.npmjs.org' }}
+      PUBLISH_ENABLED: ${{ vars.RISE_RELEASE_PUBLISH_ENABLED || 'false' }}
+      TS_NAME: ${{ needs.plan.outputs.ts_name }}
+      TS_VERSION: ${{ needs.plan.outputs.ts_version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+
+      - name: Configure npm registry
+        run: |
+          set -euo pipefail
+          printf 'registry=%s\n@ellipsis-labs:registry=%s\n' \
+            "${NPM_REGISTRY_URL}" \
+            "${NPM_REGISTRY_URL}" > .npmrc
+
+      - name: Check npm version
+        id: npm-status
+        run: |
+          set -euo pipefail
+          package_ref="${TS_NAME}@${TS_VERSION}"
+          output_file="$(mktemp)"
+          error_file="$(mktemp)"
+          trap 'rm -f "${output_file}" "${error_file}"' EXIT
+
+          if npm view "${package_ref}" version \
+            --registry "${NPM_REGISTRY_URL}" >"${output_file}" 2>"${error_file}"; then
+            echo "publish=false" >> "${GITHUB_OUTPUT}"
+            echo "${package_ref} is already published"
+            exit 0
+          fi
+
+          registry_output="$(cat "${error_file}" "${output_file}" | tr '[:upper:]' '[:lower:]')"
+          if grep -Eq 'e404|404 not found|is not in the npm registry|does not exist in this registry|no version of' <<<"${registry_output}"; then
+            echo "publish=true" >> "${GITHUB_OUTPUT}"
+            echo "${package_ref} is not yet published"
+            exit 0
+          fi
+
+          cat "${error_file}" >&2
+          cat "${output_file}" >&2
+          exit 1
+
+      - name: Install dependencies
+        if: steps.npm-status.outputs.publish == 'true'
+        run: bun install --frozen-lockfile
+
+      - name: Type-check
+        if: steps.npm-status.outputs.publish == 'true'
+        run: bun run check
+
+      - name: Test
+        if: steps.npm-status.outputs.publish == 'true'
+        run: bun run test
+
+      - name: Build
+        if: steps.npm-status.outputs.publish == 'true'
+        run: bun run build
+
+      - name: Publish npm package
+        if: >
+          steps.npm-status.outputs.publish == 'true' &&
+          (env.DRY_RUN == 'true' || env.PUBLISH_ENABLED == 'true')
+        run: |
+          set -euo pipefail
+          args=(
+            --registry "${NPM_REGISTRY_URL}"
+            --access "${NPM_PUBLISH_ACCESS}"
+            --provenance
+          )
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            args+=(--dry-run)
+          fi
+          npm publish "${args[@]}"
+
+      - name: Report disabled npm publish
+        if: >
+          steps.npm-status.outputs.publish == 'true' &&
+          env.DRY_RUN != 'true' &&
+          env.PUBLISH_ENABLED != 'true'
+        run: echo "RISE_RELEASE_PUBLISH_ENABLED is not true; skipping npm publish"
+
+  publish-rust:
+    needs: plan
+    if: >
+      github.event_name != 'workflow_dispatch' ||
+      inputs.package == 'both' ||
+      inputs.package == 'rust'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: rust
+    env:
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
+      PUBLISH_ENABLED: ${{ vars.RISE_RELEASE_PUBLISH_ENABLED || 'false' }}
+      RUST_NAME: ${{ needs.plan.outputs.rust_name }}
+      RUST_VERSION: ${{ needs.plan.outputs.rust_version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install 1.84.0 --profile minimal
+
+      - name: Check crates.io version
+        id: crate-status
+        run: |
+          set -euo pipefail
+          status="$(
+            curl \
+              -sS \
+              -o /tmp/crate-version.json \
+              -w '%{http_code}' \
+              -H 'User-Agent: Ellipsis-Labs/rise-release-ci' \
+              "https://crates.io/api/v1/crates/${RUST_NAME}/${RUST_VERSION}"
+          )"
+
+          case "${status}" in
+            200)
+              echo "publish=false" >> "${GITHUB_OUTPUT}"
+              echo "${RUST_NAME} ${RUST_VERSION} is already published"
+              ;;
+            404)
+              echo "publish=true" >> "${GITHUB_OUTPUT}"
+              echo "${RUST_NAME} ${RUST_VERSION} is not yet published"
+              ;;
+            *)
+              cat /tmp/crate-version.json >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Test
+        if: steps.crate-status.outputs.publish == 'true'
+        run: cargo +1.84.0 test --locked
+
+      - name: Authenticate to crates.io
+        if: >
+          steps.crate-status.outputs.publish == 'true' &&
+          env.DRY_RUN != 'true' &&
+          env.PUBLISH_ENABLED == 'true'
+        id: cargo-auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish crate
+        if: >
+          steps.crate-status.outputs.publish == 'true' &&
+          (env.DRY_RUN == 'true' || env.PUBLISH_ENABLED == 'true')
+        run: |
+          set -euo pipefail
+          args=(--locked)
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            args+=(--dry-run)
+          fi
+          cargo +1.84.0 publish "${args[@]}"
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.cargo-auth.outputs.token }}
+
+      - name: Report disabled crate publish
+        if: >
+          steps.crate-status.outputs.publish == 'true' &&
+          env.DRY_RUN != 'true' &&
+          env.PUBLISH_ENABLED != 'true'
+        run: echo "RISE_RELEASE_PUBLISH_ENABLED is not true; skipping crates.io publish"
+
+  release:
+    needs:
+      - plan
+      - publish-typescript
+      - publish-rust
+    if: |
+      always()
+      && needs.plan.result == 'success'
+      && (needs.publish-typescript.result == 'success' || needs.publish-typescript.result == 'skipped')
+      && (needs.publish-rust.result == 'success' || needs.publish-rust.result == 'skipped')
+      && vars.RISE_RELEASE_PUBLISH_ENABLED == 'true'
+      && (github.event_name != 'workflow_dispatch' || inputs.dry_run == 'false')
+      && (github.event_name != 'workflow_dispatch' || inputs.package == 'both')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ needs.plan.outputs.release_tag }}
+      RELEASE_TITLE: ${{ needs.plan.outputs.release_title }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Build release notes
+        run: uv run --script scripts/release_plan.py --release-notes release-notes.md
+
+      - name: Create GitHub release
+        run: |
+          set -euo pipefail
+          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "Release ${RELEASE_TAG} already exists"
+            exit 0
+          fi
+
+          gh release create "${RELEASE_TAG}" \
+            --target "${GITHUB_SHA}" \
+            --title "${RELEASE_TITLE}" \
+            --notes-file release-notes.md

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -210,7 +210,7 @@ license      = "MIT"
 publish      = true
 readme       = "CRATES.md"
 repository   = "https://github.com/Ellipsis-Labs/rise-public"
-rust-version = "1.84.0"
+rust-version = "1.86.0"
 version      = "0.1.4"
 
 [workspace.dependencies]

--- a/scripts/release_plan.py
+++ b/scripts/release_plan.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.13"
+# ///
+"""Emit release metadata for the standalone Rise repo."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import textwrap
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_ts_metadata() -> tuple[str, str]:
+    payload = json.loads((REPO_ROOT / "ts/package.json").read_text(encoding="utf-8"))
+    return payload["name"], payload["version"]
+
+
+def load_rust_metadata() -> tuple[str, str]:
+    payload = tomllib.loads((REPO_ROOT / "rust/Cargo.toml").read_text(encoding="utf-8"))
+    package = payload["package"]
+    version = package["version"]
+    if isinstance(version, dict) and version.get("workspace") is True:
+        version = payload["workspace"]["package"]["version"]
+    return package["name"], str(version)
+
+
+def latest_changelog_entry(path: Path) -> str:
+    changelog = REPO_ROOT / path
+    if not changelog.exists():
+        return f"No changelog entry was found in `{path}`."
+
+    lines = changelog.read_text(encoding="utf-8").splitlines()
+    heading_indexes = [
+        index
+        for index, line in enumerate(lines)
+        if line.startswith("## ") and not line.startswith("### ")
+    ]
+    if not heading_indexes:
+        return f"No versioned changelog entry was found in `{path}`."
+
+    start = heading_indexes[-1]
+    return "\n".join(lines[start:]).strip()
+
+
+def demote_headings(markdown: str) -> str:
+    lines = []
+    for line in markdown.splitlines():
+        if line.startswith("#"):
+            lines.append(f"#{line}")
+        else:
+            lines.append(line)
+    return "\n".join(lines)
+
+
+def write_output(key: str, value: str) -> None:
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if not output_file:
+        return
+    with open(output_file, "a", encoding="utf-8") as handle:
+        handle.write(f"{key}={value}\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--release-notes",
+        type=Path,
+        default=Path("release-notes.md"),
+        help="Path to write GitHub release notes",
+    )
+    args = parser.parse_args()
+
+    ts_name, ts_version = load_ts_metadata()
+    rust_name, rust_version = load_rust_metadata()
+    tag = f"rise-ts-v{ts_version}-rust-v{rust_version}"
+    title = f"Rise TS v{ts_version} / Rust v{rust_version}"
+    ts_changelog = latest_changelog_entry(Path("ts/CHANGELOG.md"))
+    rust_changelog = latest_changelog_entry(Path("rust/CHANGELOG.md"))
+    notes = textwrap.dedent(
+        f"""
+        # {title}
+
+        - TypeScript: `{ts_name}` v{ts_version}
+        - Rust: `{rust_name}` v{rust_version}
+
+        ## TypeScript
+
+        {demote_headings(ts_changelog)}
+
+        ## Rust
+
+        {demote_headings(rust_changelog)}
+        """
+    ).strip()
+
+    args.release_notes.write_text(notes + "\n", encoding="utf-8")
+
+    write_output("ts_name", ts_name)
+    write_output("ts_version", ts_version)
+    write_output("rust_name", rust_name)
+    write_output("rust_version", rust_version)
+    write_output("release_tag", tag)
+    write_output("release_title", title)
+    write_output("release_notes", str(args.release_notes))
+
+    print(f"TypeScript: {ts_name} v{ts_version}")
+    print(f"Rust: {rust_name} v{rust_version}")
+    print(f"Release tag: {tag}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_release_order.py
+++ b/scripts/validate_release_order.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.13"
+# ///
+"""Validate that a Rise public PR advances package versions in merge order."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import Callable, NoReturn
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclasses.dataclass(frozen=True)
+class Semver:
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[int | str, ...] | None
+
+    @classmethod
+    def parse(cls, value: str) -> "Semver":
+        pattern = re.compile(
+            r"^v?(?P<major>0|[1-9]\d*)\."
+            r"(?P<minor>0|[1-9]\d*)\."
+            r"(?P<patch>0|[1-9]\d*)"
+            r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?"
+            r"(?:\+[0-9A-Za-z.-]+)?$"
+        )
+        match = pattern.match(value)
+        if match is None:
+            fail(f"unsupported semver value: {value!r}")
+
+        prerelease = match.group("prerelease")
+        parsed_prerelease: tuple[int | str, ...] | None = None
+        if prerelease:
+            parts: list[int | str] = []
+            for part in prerelease.split("."):
+                if part.isdigit():
+                    parts.append(int(part))
+                else:
+                    parts.append(part)
+            parsed_prerelease = tuple(parts)
+
+        return cls(
+            major=int(match.group("major")),
+            minor=int(match.group("minor")),
+            patch=int(match.group("patch")),
+            prerelease=parsed_prerelease,
+        )
+
+    def core(self) -> tuple[int, int, int]:
+        return self.major, self.minor, self.patch
+
+    def compare(self, other: "Semver") -> int:
+        if self.core() != other.core():
+            return 1 if self.core() > other.core() else -1
+
+        if self.prerelease is None and other.prerelease is None:
+            return 0
+        if self.prerelease is None:
+            return 1
+        if other.prerelease is None:
+            return -1
+
+        for left, right in zip(self.prerelease, other.prerelease, strict=False):
+            if left == right:
+                continue
+            if isinstance(left, int) and isinstance(right, int):
+                return 1 if left > right else -1
+            if isinstance(left, int):
+                return -1
+            if isinstance(right, int):
+                return 1
+            return 1 if left > right else -1
+
+        if len(self.prerelease) == len(other.prerelease):
+            return 0
+        return 1 if len(self.prerelease) > len(other.prerelease) else -1
+
+
+@dataclasses.dataclass(frozen=True)
+class PackageSpec:
+    key: str
+    label: str
+    metadata_path: str
+    loader: Callable[[str], tuple[str, str]]
+
+
+@dataclasses.dataclass(frozen=True)
+class PackageMetadata:
+    key: str
+    label: str
+    name: str
+    version: str
+
+
+def fail(message: str, code: int = 1) -> NoReturn:
+    print(f"Error: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    if check and result.returncode != 0:
+        if result.stdout:
+            print(result.stdout.rstrip(), file=sys.stderr)
+        if result.stderr:
+            print(result.stderr.rstrip(), file=sys.stderr)
+        fail("command failed: " + " ".join(cmd))
+    return result
+
+
+def load_ts_metadata(text: str) -> tuple[str, str]:
+    payload = json.loads(text)
+    return payload["name"], payload["version"]
+
+
+def load_rust_metadata(text: str) -> tuple[str, str]:
+    payload = tomllib.loads(text)
+    package = payload["package"]
+    workspace_package = payload.get("workspace", {}).get("package", {})
+    name = package["name"]
+    version_value = package["version"]
+    if isinstance(version_value, dict):
+        if version_value.get("workspace") is True:
+            version_value = workspace_package["version"]
+        else:
+            fail(f"unsupported Cargo.toml version declaration: {version_value!r}")
+    return name, str(version_value)
+
+
+PACKAGE_SPECS = (
+    PackageSpec(
+        key="ts",
+        label="TypeScript",
+        metadata_path="ts/package.json",
+        loader=load_ts_metadata,
+    ),
+    PackageSpec(
+        key="rust",
+        label="Rust",
+        metadata_path="rust/Cargo.toml",
+        loader=load_rust_metadata,
+    ),
+)
+
+
+def git_show_text(ref: str, path: str) -> str | None:
+    result = run(
+        ["git", "-C", str(REPO_ROOT), "show", f"{ref}:{path}"],
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def metadata_for_ref(ref: str) -> dict[str, PackageMetadata]:
+    metadata: dict[str, PackageMetadata] = {}
+    for spec in PACKAGE_SPECS:
+        text = git_show_text(ref, spec.metadata_path)
+        if text is None:
+            continue
+        name, version = spec.loader(text)
+        metadata[spec.key] = PackageMetadata(
+            key=spec.key,
+            label=spec.label,
+            name=name,
+            version=version,
+        )
+    return metadata
+
+
+def is_allowed_next_version(base: Semver, head: Semver) -> bool:
+    if head.compare(base) <= 0:
+        return False
+
+    if base.prerelease is not None or head.prerelease is not None:
+        if head.core() == base.core():
+            return True
+        return head.core() in next_stable_cores(base)
+
+    return head.core() in next_stable_cores(base)
+
+
+def next_stable_cores(base: Semver) -> set[tuple[int, int, int]]:
+    return {
+        (base.major, base.minor, base.patch + 1),
+        (base.major, base.minor + 1, 0),
+        (base.major + 1, 0, 0),
+    }
+
+
+def validate_branch_name(branch: str, change: PackageMetadata) -> None:
+    if not branch.startswith("sync/rise-"):
+        return
+    expected = f"sync/rise-{change.key}-v{change.version}"
+    if branch != expected:
+        fail(
+            f"sync branch {branch!r} does not match changed package version; "
+            f"expected {expected!r}"
+        )
+
+
+def validate_release_order(base_ref: str, head_ref: str, head_branch: str) -> None:
+    base_versions = metadata_for_ref(base_ref)
+    head_versions = metadata_for_ref(head_ref)
+    changed: list[tuple[PackageMetadata | None, PackageMetadata]] = []
+
+    for spec in PACKAGE_SPECS:
+        base = base_versions.get(spec.key)
+        head = head_versions.get(spec.key)
+        if head is None:
+            continue
+        if base is None or base.version != head.version:
+            changed.append((base, head))
+
+    if not changed:
+        print("No Rise package versions changed.")
+        return
+
+    if len(changed) > 1:
+        fail(
+            "Rise public release PRs must change one package version at a time: "
+            + ", ".join(f"{head.label} v{head.version}" for _, head in changed)
+        )
+
+    base, head = changed[0]
+    if base is None:
+        validate_branch_name(head_branch, head)
+        print(f"{head.label} v{head.version} is an initial public package version.")
+        return
+
+    base_version = Semver.parse(base.version)
+    head_version = Semver.parse(head.version)
+    if not is_allowed_next_version(base_version, head_version):
+        fail(
+            f"{head.label} version {head.version} is not the next semver release "
+            f"after {base.version}; merge the missing patch, minor, or major "
+            "release first, or rebase this PR onto the updated master branch"
+        )
+
+    validate_branch_name(head_branch, head)
+    print(f"{head.label} release order is valid: {base.version} -> {head.version}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-ref", required=True)
+    parser.add_argument("--head-ref", default="HEAD")
+    parser.add_argument("--head-branch", default="")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    validate_release_order(args.base_ref, args.head_ref, args.head_branch)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI for PRs and pushes to `master`, covering release-order validation, TypeScript check/test/build, and Rust tests.
- Add a release workflow that plans TypeScript/Rust release metadata, skips already-published package versions, supports dry-run or package-scoped manual dispatches, and gates real publishing behind `RISE_RELEASE_PUBLISH_ENABLED`.
- Add release helper scripts for GitHub release notes and one-package-at-a-time semver release-order validation, including `sync/rise-*` branch-name checks.

## Testing
- GitHub Actions `release-order`: passed on PR #9.
- GitHub Actions `typescript`: passed on PR #9.
- GitHub Actions `rust`: failing on PR #9 because `cargo +1.84.0 test --locked` cannot parse transitive `block-buffer` v0.12.0, which requires Cargo's `edition2024` feature.
