### PR TITLE
fix: split Rise package release planning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,11 +16,11 @@ on:
           - "false"
       package:
         description: "Package scope to publish."
-        default: "both"
+        default: "changed"
         required: true
         type: choice
         options:
-          - "both"
+          - "changed"
           - "typescript"
           - "rust"
 
@@ -31,6 +31,9 @@ jobs:
   plan:
     runs-on: ubuntu-latest
     outputs:
+      should_release: ${{ steps.plan.outputs.should_release }}
+      package_key: ${{ steps.plan.outputs.package_key }}
+      package_scope: ${{ steps.plan.outputs.package_scope }}
       release_tag: ${{ steps.plan.outputs.release_tag }}
       release_title: ${{ steps.plan.outputs.release_title }}
       rust_name: ${{ steps.plan.outputs.rust_name }}
@@ -39,20 +42,23 @@ jobs:
       ts_version: ${{ steps.plan.outputs.ts_version }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
 
       - uses: astral-sh/setup-uv@v7
 
       - name: Plan release
         id: plan
-        run: uv run --script scripts/release_plan.py
+        env:
+          PACKAGE_SCOPE: ${{ inputs.package || 'changed' }}
+        run: uv run --script scripts/release_plan.py --package "${PACKAGE_SCOPE}"
 
   publish-typescript:
     needs: plan
-    if: >
-      github.event_name != 'workflow_dispatch' ||
-      inputs.package == 'both' ||
-      inputs.package == 'typescript'
+    if: needs.plan.outputs.should_release == 'true' && needs.plan.outputs.package_key == 'ts'
     runs-on: ubuntu-latest
+    outputs:
+      package_published: ${{ steps.publish-state.outputs.package_published }}
     permissions:
       contents: read
       id-token: write
@@ -151,13 +157,24 @@ jobs:
           env.PUBLISH_ENABLED != 'true'
         run: echo "RISE_RELEASE_PUBLISH_ENABLED is not true; skipping npm publish"
 
+      - name: Report npm publish result
+        id: publish-state
+        if: always()
+        env:
+          PACKAGE_NEEDS_PUBLISH: ${{ steps.npm-status.outputs.publish || 'false' }}
+        run: |
+          if [[ "${PACKAGE_NEEDS_PUBLISH}" == "true" && "${DRY_RUN}" != "true" && "${PUBLISH_ENABLED}" == "true" ]]; then
+            echo "package_published=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "package_published=false" >> "${GITHUB_OUTPUT}"
+          fi
+
   publish-rust:
     needs: plan
-    if: >
-      github.event_name != 'workflow_dispatch' ||
-      inputs.package == 'both' ||
-      inputs.package == 'rust'
+    if: needs.plan.outputs.should_release == 'true' && needs.plan.outputs.package_key == 'rust'
     runs-on: ubuntu-latest
+    outputs:
+      package_published: ${{ steps.publish-state.outputs.package_published }}
     permissions:
       contents: read
       id-token: write
@@ -236,6 +253,18 @@ jobs:
           env.PUBLISH_ENABLED != 'true'
         run: echo "RISE_RELEASE_PUBLISH_ENABLED is not true; skipping crates.io publish"
 
+      - name: Report crate publish result
+        id: publish-state
+        if: always()
+        env:
+          PACKAGE_NEEDS_PUBLISH: ${{ steps.crate-status.outputs.publish || 'false' }}
+        run: |
+          if [[ "${PACKAGE_NEEDS_PUBLISH}" == "true" && "${DRY_RUN}" != "true" && "${PUBLISH_ENABLED}" == "true" ]]; then
+            echo "package_published=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "package_published=false" >> "${GITHUB_OUTPUT}"
+          fi
+
   release:
     needs:
       - plan
@@ -244,16 +273,18 @@ jobs:
     if: |
       always()
       && needs.plan.result == 'success'
+      && needs.plan.outputs.should_release == 'true'
       && (needs.publish-typescript.result == 'success' || needs.publish-typescript.result == 'skipped')
       && (needs.publish-rust.result == 'success' || needs.publish-rust.result == 'skipped')
+      && (needs.publish-typescript.outputs.package_published == 'true' || needs.publish-rust.outputs.package_published == 'true')
       && vars.RISE_RELEASE_PUBLISH_ENABLED == 'true'
       && (github.event_name != 'workflow_dispatch' || inputs.dry_run == 'false')
-      && (github.event_name != 'workflow_dispatch' || inputs.package == 'both')
     runs-on: ubuntu-latest
     permissions:
       contents: write
     env:
       GH_TOKEN: ${{ github.token }}
+      PACKAGE_SCOPE: ${{ needs.plan.outputs.package_scope }}
       RELEASE_TAG: ${{ needs.plan.outputs.release_tag }}
       RELEASE_TITLE: ${{ needs.plan.outputs.release_title }}
     steps:
@@ -262,7 +293,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
 
       - name: Build release notes
-        run: uv run --script scripts/release_plan.py --release-notes release-notes.md
+        run: uv run --script scripts/release_plan.py --package "${PACKAGE_SCOPE}" --release-notes release-notes.md
 
       - name: Create GitHub release
         run: |

--- a/scripts/release_plan.py
+++ b/scripts/release_plan.py
@@ -7,22 +7,59 @@
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import json
 import os
-import textwrap
+import subprocess
+import sys
 import tomllib
 from pathlib import Path
+from typing import Callable, NoReturn
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
-def load_ts_metadata() -> tuple[str, str]:
-    payload = json.loads((REPO_ROOT / "ts/package.json").read_text(encoding="utf-8"))
+@dataclasses.dataclass(frozen=True)
+class PackageSpec:
+    key: str
+    scope: str
+    label: str
+    title_label: str
+    metadata_path: Path
+    changelog_path: Path
+    loader: Callable[[str], tuple[str, str]]
+
+
+@dataclasses.dataclass(frozen=True)
+class PackageMetadata:
+    spec: PackageSpec
+    name: str
+    version: str
+
+
+def fail(message: str, code: int = 1) -> NoReturn:
+    print(f"Error: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, check=False, capture_output=True, text=True)
+
+
+def git_show_text(ref: str, path: Path) -> str | None:
+    result = run(["git", "-C", str(REPO_ROOT), "show", f"{ref}:{path}"])
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def load_ts_metadata(text: str) -> tuple[str, str]:
+    payload = json.loads(text)
     return payload["name"], payload["version"]
 
 
-def load_rust_metadata() -> tuple[str, str]:
-    payload = tomllib.loads((REPO_ROOT / "rust/Cargo.toml").read_text(encoding="utf-8"))
+def load_rust_metadata(text: str) -> tuple[str, str]:
+    payload = tomllib.loads(text)
     package = payload["package"]
     version = package["version"]
     if isinstance(version, dict) and version.get("workspace") is True:
@@ -30,12 +67,102 @@ def load_rust_metadata() -> tuple[str, str]:
     return package["name"], str(version)
 
 
-def latest_changelog_entry(path: Path) -> str:
-    changelog = REPO_ROOT / path
-    if not changelog.exists():
+PACKAGE_SPECS = (
+    PackageSpec(
+        key="ts",
+        scope="typescript",
+        label="TypeScript",
+        title_label="TS",
+        metadata_path=Path("ts/package.json"),
+        changelog_path=Path("ts/CHANGELOG.md"),
+        loader=load_ts_metadata,
+    ),
+    PackageSpec(
+        key="rust",
+        scope="rust",
+        label="Rust",
+        title_label="Rust",
+        metadata_path=Path("rust/Cargo.toml"),
+        changelog_path=Path("rust/CHANGELOG.md"),
+        loader=load_rust_metadata,
+    ),
+)
+
+
+def metadata_for_spec(spec: PackageSpec) -> PackageMetadata:
+    text = (REPO_ROOT / spec.metadata_path).read_text(encoding="utf-8")
+    name, version = spec.loader(text)
+    return PackageMetadata(spec=spec, name=name, version=version)
+
+
+def metadata_for_ref(ref: str, spec: PackageSpec) -> PackageMetadata | None:
+    text = git_show_text(ref, spec.metadata_path)
+    if text is None:
+        return None
+    name, version = spec.loader(text)
+    return PackageMetadata(spec=spec, name=name, version=version)
+
+
+def metadata_for_output(spec: PackageSpec, source_ref: str | None) -> PackageMetadata:
+    if source_ref is not None:
+        metadata = metadata_for_ref(source_ref, spec)
+        if metadata is not None:
+            return metadata
+    return metadata_for_spec(spec)
+
+
+def changed_package_metadata(base_ref: str, head_ref: str) -> list[PackageMetadata]:
+    changed: list[PackageMetadata] = []
+    for spec in PACKAGE_SPECS:
+        base = metadata_for_ref(base_ref, spec)
+        head = metadata_for_ref(head_ref, spec)
+        if head is None:
+            continue
+        if base is None or base.version != head.version:
+            changed.append(head)
+    return changed
+
+
+def select_package_metadata(
+    package: str,
+    base_ref: str,
+    head_ref: str,
+) -> PackageMetadata | None:
+    for spec in PACKAGE_SPECS:
+        if package == spec.scope:
+            return metadata_for_spec(spec)
+
+    if package != "changed":
+        fail(f"unsupported package scope: {package!r}")
+
+    changed = changed_package_metadata(base_ref, head_ref)
+    if len(changed) == 1:
+        return changed[0]
+
+    if not changed:
+        return None
+
+    fail(
+        "Rise public releases must target one package at a time; changed packages: "
+        + ", ".join(metadata.spec.label for metadata in changed)
+    )
+
+
+def latest_changelog_entry(path: Path, source_ref: str | None = None) -> str:
+    if source_ref is None:
+        changelog = REPO_ROOT / path
+        if not changelog.exists():
+            return f"No changelog entry was found in `{path}`."
+        text = changelog.read_text(encoding="utf-8")
+    else:
+        text = git_show_text(source_ref, path)
+        if text is None:
+            return f"No changelog entry was found in `{path}`."
+
+    if not text:
         return f"No changelog entry was found in `{path}`."
 
-    lines = changelog.read_text(encoding="utf-8").splitlines()
+    lines = text.splitlines()
     heading_indexes = [
         index
         for index, line in enumerate(lines)
@@ -74,43 +201,79 @@ def main() -> None:
         default=Path("release-notes.md"),
         help="Path to write GitHub release notes",
     )
+    parser.add_argument(
+        "--package",
+        choices=("changed", "typescript", "rust"),
+        default="changed",
+        help="Package scope for the GitHub release",
+    )
+    parser.add_argument(
+        "--base-ref",
+        default="HEAD^",
+        help="Base ref used when --package changed needs to infer the package",
+    )
+    parser.add_argument(
+        "--head-ref",
+        default="HEAD",
+        help="Head ref used when --package changed needs to infer the package",
+    )
     args = parser.parse_args()
 
-    ts_name, ts_version = load_ts_metadata()
-    rust_name, rust_version = load_rust_metadata()
-    tag = f"rise-ts-v{ts_version}-rust-v{rust_version}"
-    title = f"Rise TS v{ts_version} / Rust v{rust_version}"
-    ts_changelog = latest_changelog_entry(Path("ts/CHANGELOG.md"))
-    rust_changelog = latest_changelog_entry(Path("rust/CHANGELOG.md"))
-    notes = textwrap.dedent(
-        f"""
-        # {title}
+    selected = select_package_metadata(args.package, args.base_ref, args.head_ref)
+    source_ref = args.head_ref if args.package == "changed" else None
+    ts_metadata = metadata_for_output(PACKAGE_SPECS[0], source_ref)
+    rust_metadata = metadata_for_output(PACKAGE_SPECS[1], source_ref)
 
-        - TypeScript: `{ts_name}` v{ts_version}
-        - Rust: `{rust_name}` v{rust_version}
+    if selected is None:
+        args.release_notes.write_text("No package release planned.\n", encoding="utf-8")
+        write_output("should_release", "false")
+        write_output("package_key", "")
+        write_output("package_scope", "")
+        write_output("package_name", "")
+        write_output("package_version", "")
+        write_output("ts_name", ts_metadata.name)
+        write_output("ts_version", ts_metadata.version)
+        write_output("rust_name", rust_metadata.name)
+        write_output("rust_version", rust_metadata.version)
+        write_output("release_tag", "")
+        write_output("release_title", "")
+        write_output("release_notes", str(args.release_notes))
 
-        ## TypeScript
+        print("No package version changed; skipping release.")
+        print(f"TypeScript: {ts_metadata.name} v{ts_metadata.version}")
+        print(f"Rust: {rust_metadata.name} v{rust_metadata.version}")
+        return
 
-        {demote_headings(ts_changelog)}
-
-        ## Rust
-
-        {demote_headings(rust_changelog)}
-        """
+    tag = f"rise-{selected.spec.key}-v{selected.version}"
+    title = f"Rise {selected.spec.title_label}"
+    changelog = latest_changelog_entry(selected.spec.changelog_path, source_ref)
+    notes = "\n\n".join(
+        [
+            f"# {title}",
+            f"- {selected.spec.label}: `{selected.name}` v{selected.version}",
+            f"## {selected.spec.label}",
+            demote_headings(changelog),
+        ]
     ).strip()
 
     args.release_notes.write_text(notes + "\n", encoding="utf-8")
 
-    write_output("ts_name", ts_name)
-    write_output("ts_version", ts_version)
-    write_output("rust_name", rust_name)
-    write_output("rust_version", rust_version)
+    write_output("should_release", "true")
+    write_output("package_key", selected.spec.key)
+    write_output("package_scope", selected.spec.scope)
+    write_output("package_name", selected.name)
+    write_output("package_version", selected.version)
+    write_output("ts_name", ts_metadata.name)
+    write_output("ts_version", ts_metadata.version)
+    write_output("rust_name", rust_metadata.name)
+    write_output("rust_version", rust_metadata.version)
     write_output("release_tag", tag)
     write_output("release_title", title)
     write_output("release_notes", str(args.release_notes))
 
-    print(f"TypeScript: {ts_name} v{ts_version}")
-    print(f"Rust: {rust_name} v{rust_version}")
+    print(f"Package: {selected.spec.label}")
+    print(f"TypeScript: {ts_metadata.name} v{ts_metadata.version}")
+    print(f"Rust: {rust_metadata.name} v{rust_metadata.version}")
     print(f"Release tag: {tag}")
 
 


### PR DESCRIPTION
## Summary

Split Rise release planning by package so TypeScript and Rust releases are published independently. This keeps GitHub release titles and markdown focused on the package that actually changed.

## Changes

- fix: split Rise package release planning

## User Impact

TS-only releases will no longer show a Rust version or an empty Rust changelog section. Non-release pushes to `master` skip the release workflow cleanly, and GitHub releases are created only after the selected TS or Rust package is actually published.

## Root Cause

The release planner always loaded both package manifests and produced a combined tag, title, and notes body. The workflow also treated `both` as the default publish scope and gated GitHub release creation on publish-job success, which allowed release creation even when the package version was already published.

## Fix

The planner now infers the single changed package, emits package-scoped release metadata, and exposes `should_release` so workflow-only pushes do not attempt a package release. The release workflow uses that metadata to run only the matching publish job, records whether that job actually published a package, and creates the GitHub release only when TS or Rust was published.

## Validation

- `uv run --script scripts/release_plan.py --package changed --base-ref ac4472e --head-ref HEAD --release-notes /tmp/rise-release-bump-notes.md`
- `uv run --script scripts/release_plan.py --package changed --base-ref HEAD --head-ref HEAD --release-notes /tmp/rise-no-release-notes.md`
- `uv run --script scripts/release_plan.py --package rust --release-notes /tmp/rise-rust-release-notes.md`
- `python3 -m py_compile scripts/release_plan.py scripts/validate_release_order.py`
- `git diff --check`
