### PR TITLE
fix: include version in Rise release titles

### DIFF
--- a/scripts/release_plan.py
+++ b/scripts/release_plan.py
@@ -245,7 +245,7 @@ def main() -> None:
         return
 
     tag = f"rise-{selected.spec.key}-v{selected.version}"
-    title = f"Rise {selected.spec.title_label}"
+    title = f"Rise {selected.spec.title_label} v{selected.version}"
     changelog = latest_changelog_entry(selected.spec.changelog_path, source_ref)
     notes = "\n\n".join(
         [


### PR DESCRIPTION
## Summary

Include the package version in generated Rise GitHub release titles.

## Changes

- fix: include version in Rise release titles

## User Impact

Future package-specific GitHub releases will show titles like `Rise TS v0.4.28` and `Rise Rust v0.1.5`, making the releases page easier to scan without relying only on tags.

## Root Cause

The release planner generated package-specific titles as only `Rise TS` or `Rise Rust`, while the version was present only in the tag and release body.

## Fix

Append the selected package version to the generated `release_title`.

## Validation

- `uv run --script scripts/release_plan.py --package rust --release-notes /tmp/rise-rust-title-notes.md`
- `uv run --script scripts/release_plan.py --package typescript --release-notes /tmp/rise-ts-title-notes.md`
- `python3 -m py_compile scripts/release_plan.py`
- `git diff --check HEAD`
