### PR TITLE
sync: Rise TypeScript v0.4.30

### DIFF
--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -53,3 +53,29 @@ Source Phoenix commit: `f0c4a154e63048a8517e72e8a6a8b806e3768cd0`
 - The `TraderCapabilityToggleTarget` enum and internal `buildSetTraderCapabilitiesDelegated*` names are intentionally absent from the public surface; use `buildOnboardTraderDelegated` instead.
 - Delegated onboarding always enables all six trader capabilities (limit orders, market orders, risk-increasing and risk-reducing trades, deposit, and withdrawal) in a single instruction — there is no partial-capability variant in this release.
 - The `permissionAccount` address must be derived from the current risk authority and the onboarder's key; see the new example for the full derivation pattern using `client.pda.getPermissionAddress`.
+
+## v0.4.30 - 2026-06-11
+
+Source Phoenix commit: `7b0e722849fbc44d2d34d481d208db0ea951b78e`
+
+- Package: `@ellipsis-labs/rise`
+- Target repo version: 0.4.28
+- Phoenix version: 0.4.28 -> 0.4.30
+
+### Summary
+
+- **Risk factor values in `RiskFactors` are now in basis points.** `PhoenixProjectedMarket.riskFactors` fields (`maintenance`, `backstop`, `highRisk`, `upnl`, `upnlForWithdrawals`, `cancelOrder`) now carry bps values (e.g. `5000` = 50%) instead of the previous percentage scale (e.g. `5` = 5%). The cache store, projected-market selector, and margin params builder all consistently prefer the new bps representation.
+- **Optional `*Bps` sibling fields added to `ExchangeRiskFactors` and `ExchangeLeverageTier`.** `maintenanceBps`, `backstopBps`, `highRiskBps`, `upnlBps`, `upnlForWithdrawalsBps`, `cancelOrderBps`, and `limitOrderRiskFactorBps` are now available on the HTTP API types; where present they take precedence over the legacy percentage fields.
+- **WebSocket risk-factor update events carry optional bps deltas.** `cancelRiskFactorUpdated`, `upnlRiskFactorUpdated`, and `upnlRiskFactorForWithdrawalsUpdated` now include `previousBps`/`newBps` (normalized from server snake_case `previous_bps`/`new_bps`).
+- **`buildMarketParamsFromSummary` now validates risk factor inputs strictly.** Passing a non-finite, negative, non-integer, or >10 000 bps value throws an explicit error instead of silently stringifying it.
+
+### Breaking Changes
+
+- **`RiskFactors` scale changed — downstream reads will be ~100× off.** Any code that reads `projectedMarket.riskFactors.*` and treats the value as a percentage (e.g. multiplying by 100 to convert, or comparing against a threshold like `> 50`) must be updated to expect bps (e.g. `> 5000`). TypeScript types compile unchanged because the field names are the same.
+- **Package registry moved to GitHub Packages (restricted).** The `publishConfig` registry changed from `registry.npmjs.org` (public) to `npm.pkg.github.com` (restricted). Consumers must add a scoped registry entry for `@ellipsis-labs` in their `.npmrc` and authenticate with a GitHub token that has `read:packages` scope.
+- **`buildMarketParamsFromSummary` can now throw.** If a `MarketSummary` contains risk factor values that are non-finite, negative, non-integer bps, or exceed 10 000 bps, the function throws instead of returning a params object. Callers that previously relied on unconditional success should wrap the call or validate inputs first.
+
+### Consumer Notes
+
+- The legacy percentage-scale fields on `ExchangeRiskFactors` (`maintenance`, `backstop`, etc.) remain present for backwards compatibility with older API responses; prefer the new `*Bps` fields when available.
+- WS consumers parsing `cancelRiskFactorUpdated`, `upnlRiskFactorUpdated`, or `upnlRiskFactorForWithdrawalsUpdated` events can now read `newBps`/`previousBps` directly; the wire adapter normalizes snake_case `new_bps`/`previous_bps` from the server automatically.

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -71,8 +71,6 @@ Source Phoenix commit: `7b0e722849fbc44d2d34d481d208db0ea951b78e`
 
 ### Breaking Changes
 
-- **`RiskFactors` scale changed — downstream reads will be ~100× off.** Any code that reads `projectedMarket.riskFactors.*` and treats the value as a percentage (e.g. multiplying by 100 to convert, or comparing against a threshold like `> 50`) must be updated to expect bps (e.g. `> 5000`). TypeScript types compile unchanged because the field names are the same.
-- **Package registry moved to GitHub Packages (restricted).** The `publishConfig` registry changed from `registry.npmjs.org` (public) to `npm.pkg.github.com` (restricted). Consumers must add a scoped registry entry for `@ellipsis-labs` in their `.npmrc` and authenticate with a GitHub token that has `read:packages` scope.
 - **`buildMarketParamsFromSummary` can now throw.** If a `MarketSummary` contains risk factor values that are non-finite, negative, non-integer bps, or exceed 10 000 bps, the function throws instead of returning a params object. Callers that previously relied on unconditional success should wrap the call or validate inputs first.
 
 ### Consumer Notes

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,90 +1,90 @@
 {
-    "name": "@ellipsis-labs/rise",
-    "version": "0.4.28",
-    "packageManager": "bun@1.3.13",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/Ellipsis-Labs/rise-public.git",
-        "directory": "rise/ts"
+  "name": "@ellipsis-labs/rise",
+  "version": "0.4.30",
+  "packageManager": "bun@1.3.13",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Ellipsis-Labs/phoenix.git",
+    "directory": "rise/ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
+  "engines": {
+    "bun": ">=1.3.13"
+  },
+  "license": "MIT",
+  "description": "Rise SDK - Phoenix HTTP client",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
-    "publishConfig": {
-        "registry": "https://registry.npmjs.org",
-        "access": "public"
-    },
-    "engines": {
-        "bun": ">=1.3.13"
-    },
-    "license": "MIT",
-    "description": "Rise SDK - Phoenix HTTP client",
-    "type": "module",
-    "files": [
-        "dist"
-    ],
-    "main": "./dist/index.js",
-    "module": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        },
-        "./package.json": "./package.json"
-    },
-    "scripts": {
-        "audit": "bun audit",
-        "build": "bun --bun run tsdown",
-        "check": "bun run type-check",
-        "circular-check": "bun --bun run madge --circular src/index.ts",
-        "dev": "bun --bun run tsdown --watch",
-        "fmt": "bun --bun run prettier --write .",
-        "fmt:check": "bun --bun run prettier --check .",
-        "lint": "bun --bun run eslint src --ext .ts",
-        "lint:fix": "bun --bun run eslint src --ext .ts --fix",
-        "publish:alpha": "bun --bun run scripts/publish-alpha.ts",
-        "prepare": "bun run build",
-        "prepublishOnly": "bun run build",
-        "test": "vitest run --passWithNoTests",
-        "test:sdk-localnet": "vitest run tests/sdk-localnet-*.test.ts",
-        "test:sdk-localnet:ci": "bun --bun run scripts/run-sdk-localnet-ci.ts",
-        "type-check": "bunx tsc --noEmit",
-        "type-check:margin-parity": "bunx tsc --noEmit -p scripts/tsconfig.margin-parity.json",
-        "upload:s3-tarball": "bun --bun run scripts/upload-s3-tarball.ts",
-        "version:patch": "bun --bun run scripts/version.ts patch",
-        "version:minor": "bun --bun run scripts/version.ts minor",
-        "version:major": "bun --bun run scripts/version.ts major"
-    },
-    "dependencies": {
-        "@noble/hashes": "^2.0.1",
-        "@scure/base": "^2.0.0",
-        "@solana/kit": "^4.0.0",
-        "fzstd": "^0.1.1",
-        "xstate": "^5.28.0",
-        "zod": "^4.3.6",
-        "zustand": "^5.0.12"
-    },
-    "overrides": {
-        "brace-expansion": ">=5.0.6",
-        "defu": "6.1.6",
-        "flatted": "3.4.2",
-        "minimatch": ">=10.2.3",
-        "postcss": ">=8.5.10",
-        "picomatch": ">=4.0.4",
-        "vite": "7.3.2",
-        "ws": ">=8.20.1"
-    },
-    "devDependencies": {
-        "@eslint/js": "^10.0.1",
-        "@solana/signers": "^4.0.0",
-        "@types/node": "^22.15.21",
-        "@typescript-eslint/eslint-plugin": "^8.56.1",
-        "@typescript-eslint/parser": "^8.56.1",
-        "eslint": "^10.0.2",
-        "eslint-plugin-unused-imports": "^4.4.1",
-        "litesvm": "1.0.0",
-        "madge": "^8.0.0",
-        "prettier": "^3.8.1",
-        "tsdown": "^0.20.0-beta.4",
-        "typescript": "^5.9.3",
-        "vitest": "^4.1.8"
-    }
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "audit": "bun audit",
+    "build": "bun --bun run tsdown",
+    "check": "bun run type-check",
+    "circular-check": "bun --bun run madge --circular src/index.ts",
+    "dev": "bun --bun run tsdown --watch",
+    "fmt": "bun --bun run prettier --write .",
+    "fmt:check": "bun --bun run prettier --check .",
+    "lint": "bun --bun run eslint src --ext .ts",
+    "lint:fix": "bun --bun run eslint src --ext .ts --fix",
+    "publish:alpha": "bun --bun run scripts/publish-alpha.ts",
+    "prepare": "bun run build",
+    "prepublishOnly": "bun run build",
+    "test": "vitest run --passWithNoTests",
+    "test:sdk-localnet": "vitest run tests/sdk-localnet-*.test.ts",
+    "test:sdk-localnet:ci": "bun --bun run scripts/run-sdk-localnet-ci.ts",
+    "type-check": "bunx tsc --noEmit",
+    "type-check:margin-parity": "bunx tsc --noEmit -p scripts/tsconfig.margin-parity.json",
+    "upload:s3-tarball": "bun --bun run scripts/upload-s3-tarball.ts",
+    "version:patch": "bun --bun run scripts/version.ts patch",
+    "version:minor": "bun --bun run scripts/version.ts minor",
+    "version:major": "bun --bun run scripts/version.ts major"
+  },
+  "dependencies": {
+    "@noble/hashes": "^2.0.1",
+    "@scure/base": "^2.0.0",
+    "@solana/kit": "^4.0.0",
+    "fzstd": "^0.1.1",
+    "xstate": "^5.28.0",
+    "zod": "^4.3.6",
+    "zustand": "^5.0.12"
+  },
+  "overrides": {
+    "brace-expansion": ">=5.0.6",
+    "defu": "6.1.6",
+    "flatted": "3.4.2",
+    "minimatch": ">=10.2.3",
+    "postcss": ">=8.5.10",
+    "picomatch": ">=4.0.4",
+    "vite": "7.3.2",
+    "ws": ">=8.20.1"
+  },
+  "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "@solana/signers": "^4.0.0",
+    "@types/node": "^22.15.21",
+    "@typescript-eslint/eslint-plugin": "^8.56.1",
+    "@typescript-eslint/parser": "^8.56.1",
+    "eslint": "^10.0.2",
+    "eslint-plugin-unused-imports": "^4.4.1",
+    "litesvm": "1.0.0",
+    "madge": "^8.0.0",
+    "prettier": "^3.8.1",
+    "tsdown": "^0.20.0-beta.4",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.8"
+  }
 }

--- a/ts/src/api/exchange/types.ts
+++ b/ts/src/api/exchange/types.ts
@@ -77,7 +77,10 @@ export const ExchangeStatusViewSchema: z.ZodType<ExchangeStatusView> = z.object(
 export interface ExchangeLeverageTier {
   maxLeverage: number;
   maxSizeBaseLots: number;
+  /** Limit order risk factor as a percentage (e.g. 60 = 60%). */
   limitOrderRiskFactor: number;
+  /** Limit order risk factor in basis points (e.g. 6000 = 60%). */
+  limitOrderRiskFactorBps?: number;
 }
 
 export const ExchangeLeverageTierSchema: z.ZodType<ExchangeLeverageTier> =
@@ -85,25 +88,50 @@ export const ExchangeLeverageTierSchema: z.ZodType<ExchangeLeverageTier> =
     maxLeverage: z.number(),
     maxSizeBaseLots: z.number(),
     limitOrderRiskFactor: z.number(),
+    limitOrderRiskFactorBps: z.number().optional(),
   });
 
 export interface ExchangeRiskFactors {
+  /** Maintenance margin risk factor as a percentage (e.g. 50 = 50%). */
   maintenance: number;
+  /** Maintenance margin risk factor in basis points (e.g. 5000 = 50%). */
+  maintenanceBps?: number;
+  /** Backstop liquidation risk factor as a percentage. */
   backstop: number;
+  /** Backstop liquidation risk factor in basis points. */
+  backstopBps?: number;
+  /** High-risk threshold as a percentage. */
   highRisk: number;
+  /** High-risk threshold in basis points. */
+  highRiskBps?: number;
+  /** Positive unrealized PnL discount factor as a percentage. */
   upnl: number;
+  /** Positive unrealized PnL discount factor in basis points. */
+  upnlBps?: number;
+  /** Positive unrealized PnL discount factor for withdrawals as a percentage. */
   upnlForWithdrawals: number;
+  /** Positive unrealized PnL discount factor for withdrawals in basis points. */
+  upnlForWithdrawalsBps?: number;
+  /** Cancel-order risk factor as a percentage. */
   cancelOrder: number;
+  /** Cancel-order risk factor in basis points. */
+  cancelOrderBps?: number;
 }
 
 export const ExchangeRiskFactorsSchema: z.ZodType<ExchangeRiskFactors> =
   z.object({
     maintenance: z.number(),
+    maintenanceBps: z.number().optional(),
     backstop: z.number(),
+    backstopBps: z.number().optional(),
     highRisk: z.number(),
+    highRiskBps: z.number().optional(),
     upnl: z.number(),
+    upnlBps: z.number().optional(),
     upnlForWithdrawals: z.number(),
+    upnlForWithdrawalsBps: z.number().optional(),
     cancelOrder: z.number(),
+    cancelOrderBps: z.number().optional(),
   });
 
 export interface MarketCalendar {
@@ -258,6 +286,7 @@ export const ExchangeConfigSchema: z.ZodType<ExchangeConfig> = z.object({
 export interface ExchangeWsLeverageTier {
   maxLeverage: number;
   maxSizeBaseLots: bigint;
+  /** Limit order risk factor in basis points (e.g. 6000 = 60%). */
   limitOrderRiskFactor: number;
 }
 

--- a/ts/src/exchange-cache/_metadataShared.ts
+++ b/ts/src/exchange-cache/_metadataShared.ts
@@ -354,13 +354,21 @@ const toMarketSnapshot = async (
     })),
     riskFactors: {
       maintenance: metadata.riskParams.riskFactors[0] ?? 0,
+      maintenanceBps: metadata.riskParams.riskFactors[0] ?? 0,
       backstop: metadata.riskParams.riskFactors[1] ?? 0,
+      backstopBps: metadata.riskParams.riskFactors[1] ?? 0,
       highRisk: metadata.riskParams.riskFactors[2] ?? 0,
+      highRiskBps: metadata.riskParams.riskFactors[2] ?? 0,
       upnl: Number(metadata.riskParams.upnlRiskFactor),
+      upnlBps: Number(metadata.riskParams.upnlRiskFactor),
       upnlForWithdrawals: Number(
         metadata.riskParams.upnlRiskFactorForWithdrawals
       ),
+      upnlForWithdrawalsBps: Number(
+        metadata.riskParams.upnlRiskFactorForWithdrawals
+      ),
       cancelOrder: metadata.riskParams.cancelOrderRiskFactor,
+      cancelOrderBps: metadata.riskParams.cancelOrderRiskFactor,
     },
     fundingConfig: {
       fundingIntervalSeconds: Number(

--- a/ts/src/exchange-cache/projectedMarket.ts
+++ b/ts/src/exchange-cache/projectedMarket.ts
@@ -82,13 +82,32 @@ const toUnits = (market: ExchangeMarketSnapshot): MarketUnits => ({
   tickSizeInQuoteLotsPerBaseLot: market.tickSize,
 });
 
+const riskFactorPercentToBps = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.round(value * 100);
+};
+
 const toRiskFactors = (market: ExchangeMarketSnapshot): RiskFactors => ({
-  maintenance: market.riskFactors.maintenance,
-  backstop: market.riskFactors.backstop,
-  highRisk: market.riskFactors.highRisk,
-  upnl: market.riskFactors.upnl,
-  upnlForWithdrawals: market.riskFactors.upnlForWithdrawals,
-  cancelOrder: market.riskFactors.cancelOrder,
+  maintenance:
+    market.riskFactors.maintenanceBps ??
+    riskFactorPercentToBps(market.riskFactors.maintenance),
+  backstop:
+    market.riskFactors.backstopBps ??
+    riskFactorPercentToBps(market.riskFactors.backstop),
+  highRisk:
+    market.riskFactors.highRiskBps ??
+    riskFactorPercentToBps(market.riskFactors.highRisk),
+  upnl:
+    market.riskFactors.upnlBps ??
+    riskFactorPercentToBps(market.riskFactors.upnl),
+  upnlForWithdrawals:
+    market.riskFactors.upnlForWithdrawalsBps ??
+    riskFactorPercentToBps(market.riskFactors.upnlForWithdrawals),
+  cancelOrder:
+    market.riskFactors.cancelOrderBps ??
+    riskFactorPercentToBps(market.riskFactors.cancelOrder),
 });
 
 export interface PhoenixProjectedMarket {

--- a/ts/src/exchange-cache/store.ts
+++ b/ts/src/exchange-cache/store.ts
@@ -145,6 +145,13 @@ const cloneExchange = (
   exchangeStatusFeatures: [...exchange.exchangeStatusFeatures],
 });
 
+const riskFactorPercentToBps = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.round(value * 100);
+};
+
 const sortMarkets = (markets: ExchangeMarketSnapshot[]): void => {
   markets.sort(
     (left, right) =>
@@ -804,6 +811,7 @@ class PhoenixExchangeCacheStoreImpl implements PhoenixExchangeCacheStore {
         nextMarket.riskFactors = {
           ...nextMarket.riskFactors,
           cancelOrder: update.new,
+          cancelOrderBps: update.newBps ?? riskFactorPercentToBps(update.new),
         };
         return nextMarket;
       case "isolatedOnlyUpdated":
@@ -822,12 +830,15 @@ class PhoenixExchangeCacheStoreImpl implements PhoenixExchangeCacheStore {
         nextMarket.riskFactors = {
           ...nextMarket.riskFactors,
           upnl: update.new,
+          upnlBps: update.newBps ?? riskFactorPercentToBps(update.new),
         };
         return nextMarket;
       case "upnlRiskFactorForWithdrawalsUpdated":
         nextMarket.riskFactors = {
           ...nextMarket.riskFactors,
           upnlForWithdrawals: update.new,
+          upnlForWithdrawalsBps:
+            update.newBps ?? riskFactorPercentToBps(update.new),
         };
         return nextMarket;
       case "fundingParametersUpdated":

--- a/ts/src/margin/marketParamsStore.ts
+++ b/ts/src/margin/marketParamsStore.ts
@@ -55,6 +55,7 @@ export interface MarginMarketParamsStoreOptions<
 const DEFAULT_TTL_MS = 30_000;
 
 const MICRO_USD = 1_000_000n;
+const RISK_FACTOR_BPS_MAX = 10_000;
 
 const resolveMarketsClient = (client: MarginClient): MarginMarketsClient => {
   if ("markets" in client) {
@@ -151,6 +152,29 @@ export const priceUsdToTicks = (
   return (numerator / denominator).toString();
 };
 
+const riskFactorBpsToMarginBps = (value: number, field: string): string => {
+  if (!Number.isFinite(value)) {
+    throw new Error(`${field} risk factor is not finite`);
+  }
+  if (value < 0) {
+    throw new Error(`${field} risk factor must be non-negative`);
+  }
+
+  const basisPoints = value;
+  if (basisPoints > RISK_FACTOR_BPS_MAX) {
+    throw new Error(
+      `${field} risk factor must be at most ${RISK_FACTOR_BPS_MAX} bps`
+    );
+  }
+
+  const rounded = Math.round(basisPoints);
+  if (Math.abs(rounded - basisPoints) > 1e-9) {
+    throw new Error(`${field} risk factor must resolve to whole bps`);
+  }
+
+  return rounded.toString();
+};
+
 export const buildMarketParamsFromSummary = (
   market: MarketSummary,
   markPriceUsd: number | string | null | undefined,
@@ -178,17 +202,34 @@ export const buildMarketParamsFromSummary = (
     leverageTiers: market.leverageTiers.map((tier) => ({
       upperBoundSize: tier.maxSizeBaseLots.toString(),
       maxLeverage: tier.maxLeverage.toString(),
-      limitOrderRiskFactorBps: tier.limitOrderRiskFactor.toString(),
+      limitOrderRiskFactorBps: riskFactorBpsToMarginBps(
+        tier.limitOrderRiskFactor,
+        "leverage_tier.limit_order_risk_factor"
+      ),
     })),
     riskFactors: {
-      maintenanceMarginFactorBps: market.riskFactors.maintenance.toString(),
-      backstopMarginFactorBps: market.riskFactors.backstop.toString(),
-      highRiskMarginFactorBps: market.riskFactors.highRisk.toString(),
+      maintenanceMarginFactorBps: riskFactorBpsToMarginBps(
+        market.riskFactors.maintenance,
+        "maintenance"
+      ),
+      backstopMarginFactorBps: riskFactorBpsToMarginBps(
+        market.riskFactors.backstop,
+        "backstop"
+      ),
+      highRiskMarginFactorBps: riskFactorBpsToMarginBps(
+        market.riskFactors.highRisk,
+        "high_risk"
+      ),
     },
-    cancelOrderRiskFactorBps: market.riskFactors.cancelOrder.toString(),
-    upnlRiskFactor: market.riskFactors.upnl.toString(),
-    upnlRiskFactorForWithdrawals:
-      market.riskFactors.upnlForWithdrawals.toString(),
+    cancelOrderRiskFactorBps: riskFactorBpsToMarginBps(
+      market.riskFactors.cancelOrder,
+      "cancel_order"
+    ),
+    upnlRiskFactor: riskFactorBpsToMarginBps(market.riskFactors.upnl, "upnl"),
+    upnlRiskFactorForWithdrawals: riskFactorBpsToMarginBps(
+      market.riskFactors.upnlForWithdrawals,
+      "upnl_for_withdrawals"
+    ),
     isolatedOnly: market.isolatedOnly,
   };
 };

--- a/ts/src/types/market.ts
+++ b/ts/src/types/market.ts
@@ -32,6 +32,7 @@ export const MarketFeesSchema: z.ZodType<MarketFees> = z.object({
 export interface MarketLeverageTier {
   maxLeverage: number;
   maxSizeBaseLots: number;
+  /** Limit order risk factor in basis points (e.g. 6000 = 60%). */
   limitOrderRiskFactor: number;
 }
 
@@ -43,11 +44,17 @@ export const LeverageTierSchema: z.ZodType<MarketLeverageTier> = z.object({
 });
 
 export interface RiskFactors {
+  /** Maintenance margin risk factor in basis points (e.g. 5000 = 50%). */
   maintenance: number;
+  /** Backstop liquidation risk factor in basis points. */
   backstop: number;
+  /** High-risk threshold in basis points. */
   highRisk: number;
+  /** Positive unrealized PnL discount factor in basis points. */
   upnl: number;
+  /** Positive unrealized PnL discount factor for withdrawals in basis points. */
   upnlForWithdrawals: number;
+  /** Cancel-order risk factor in basis points. */
   cancelOrder: number;
 }
 

--- a/ts/src/ws/adapters/exchange/wire.ts
+++ b/ts/src/ws/adapters/exchange/wire.ts
@@ -85,6 +85,8 @@ export interface CancelRiskFactorUpdated {
   kind: "cancelRiskFactorUpdated";
   previous: number;
   new: number;
+  previousBps?: number;
+  newBps?: number;
 }
 
 export interface IsolatedOnlyUpdated {
@@ -115,12 +117,16 @@ export interface UpnlRiskFactorUpdated {
   kind: "upnlRiskFactorUpdated";
   previous: number;
   new: number;
+  previousBps?: number;
+  newBps?: number;
 }
 
 export interface UpnlRiskFactorForWithdrawalsUpdated {
   kind: "upnlRiskFactorForWithdrawalsUpdated";
   previous: number;
   new: number;
+  previousBps?: number;
+  newBps?: number;
 }
 
 export interface FundingParametersUpdated {
@@ -274,6 +280,18 @@ const normalizeUnknownMarketParameterUpdate = (
   };
 };
 
+const normalizeRiskFactorUpdateCoordinates = (
+  update: Record<string, unknown>
+): Record<string, unknown> => {
+  if (update.previousBps === undefined) {
+    update.previousBps = update.previous_bps;
+  }
+  if (update.newBps === undefined) {
+    update.newBps = update.new_bps;
+  }
+  return update;
+};
+
 const normalizeExchangeDeltaOp = (value: unknown): unknown => {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return value;
@@ -343,9 +361,18 @@ const normalizeExchangeDeltaOp = (value: unknown): unknown => {
         typeof op.update === "object" &&
         !Array.isArray(op.update)
       ) {
-        op.update = normalizeUnknownMarketParameterUpdate({
+        const update = normalizeUnknownMarketParameterUpdate({
           ...(op.update as Record<string, unknown>),
         });
+        if (
+          update.kind === "cancelRiskFactorUpdated" ||
+          update.kind === "upnlRiskFactorUpdated" ||
+          update.kind === "upnlRiskFactorForWithdrawalsUpdated"
+        ) {
+          op.update = normalizeRiskFactorUpdateCoordinates(update);
+        } else {
+          op.update = update;
+        }
       }
       return op;
     default:
@@ -409,6 +436,8 @@ const exchangeMarketParameterUpdateSchema = z.discriminatedUnion("kind", [
     kind: z.literal("cancelRiskFactorUpdated"),
     previous: z.number(),
     new: z.number(),
+    previousBps: z.number().optional(),
+    newBps: z.number().optional(),
   }),
   z.object({
     kind: z.literal("isolatedOnlyUpdated"),
@@ -434,11 +463,15 @@ const exchangeMarketParameterUpdateSchema = z.discriminatedUnion("kind", [
     kind: z.literal("upnlRiskFactorUpdated"),
     previous: z.number(),
     new: z.number(),
+    previousBps: z.number().optional(),
+    newBps: z.number().optional(),
   }),
   z.object({
     kind: z.literal("upnlRiskFactorForWithdrawalsUpdated"),
     previous: z.number(),
     new: z.number(),
+    previousBps: z.number().optional(),
+    newBps: z.number().optional(),
   }),
   z.object({
     kind: z.literal("fundingParametersUpdated"),

--- a/ts/tests/exchange-selectors.test.ts
+++ b/ts/tests/exchange-selectors.test.ts
@@ -38,11 +38,17 @@ const buildMarket = (
   ],
   riskFactors: {
     maintenance: 5,
+    maintenanceBps: 500,
     backstop: 8,
+    backstopBps: 800,
     highRisk: 12,
+    highRiskBps: 1200,
     upnl: 90,
+    upnlBps: 9000,
     upnlForWithdrawals: 80,
+    upnlForWithdrawalsBps: 8000,
     cancelOrder: 2.5,
+    cancelOrderBps: 250,
   },
   fundingConfig: {
     fundingIntervalSeconds: 3600,
@@ -265,7 +271,22 @@ describe("exchange selectors", () => {
   });
 
   it("projects normalized market display fields from exchange snapshots", () => {
-    const market = buildMarket("SOL");
+    const market = buildMarket("SOL", {
+      riskFactors: {
+        maintenance: 0.5,
+        maintenanceBps: 5_000,
+        backstop: 0.2,
+        backstopBps: 2_000,
+        highRisk: 0.1,
+        highRiskBps: 1_000,
+        upnl: 1,
+        upnlBps: 10_000,
+        upnlForWithdrawals: 0.01,
+        upnlForWithdrawalsBps: 100,
+        cancelOrder: 0.7,
+        cancelOrderBps: 7_000,
+      },
+    });
 
     const projectedA = projectPhoenixMarket(market);
     const projectedB = projectPhoenixMarket(market);
@@ -285,6 +306,14 @@ describe("exchange selectors", () => {
       maxLeverage: 20,
       maxSizeBaseLots: 1000,
       limitOrderRiskFactor: 250,
+    });
+    expect(projectedA.riskFactors).toEqual({
+      maintenance: 5_000,
+      backstop: 2_000,
+      highRisk: 1_000,
+      upnl: 10_000,
+      upnlForWithdrawals: 100,
+      cancelOrder: 7_000,
     });
 
     const projectedBySymbolA = projectPhoenixMarketsBySymbol({

--- a/ts/tests/margin-risk-factor-bps.test.ts
+++ b/ts/tests/margin-risk-factor-bps.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { buildMarketParamsFromSummary, createMarginCalculator } from "@/margin";
+import { symbol } from "@/primitives/Symbol";
+import type { MarketSummary } from "@/types";
+
+const tokenAmount = { value: 0, decimals: 0, ui: "0" };
+
+const marketSummary = (
+  overrides: Partial<MarketSummary> = {}
+): MarketSummary => ({
+  symbol: symbol("SOL-PERP"),
+  assetId: 1,
+  marketStatus: "active",
+  units: {
+    tickSizeInQuoteLotsPerBaseLot: 1,
+    baseLotsDecimals: 0,
+  },
+  fees: {
+    takerFeeMicro: 0,
+    makerFeeMicro: 0,
+  },
+  openInterest: tokenAmount,
+  openInterestCap: tokenAmount,
+  leverageTiers: [
+    {
+      maxLeverage: 20,
+      maxSizeBaseLots: 1_000,
+      limitOrderRiskFactor: 6_000,
+    },
+  ],
+  fundingIntervalInSlots: 0,
+  fundingPeriodInSlots: 0,
+  fundingStartIntervalSlot: 0,
+  cumulativeFundingRate: 0,
+  maxLiquidationSize: tokenAmount,
+  riskFactors: {
+    maintenance: 5_000,
+    backstop: 2_000,
+    highRisk: 1_000,
+    upnl: 10_000,
+    upnlForWithdrawals: 100,
+    cancelOrder: 7_000,
+  },
+  isolatedOnly: false,
+  ...overrides,
+});
+
+describe("margin risk factor bps handling", () => {
+  it("preserves public market-summary bps risk factors for margin math", () => {
+    const params = buildMarketParamsFromSummary(marketSummary(), "0.00242");
+
+    expect(params).not.toBeNull();
+    expect(params?.leverageTiers[0]?.limitOrderRiskFactorBps).toBe("6000");
+    expect(params?.riskFactors.maintenanceMarginFactorBps).toBe("5000");
+    expect(params?.riskFactors.backstopMarginFactorBps).toBe("2000");
+    expect(params?.riskFactors.highRiskMarginFactorBps).toBe("1000");
+    expect(params?.upnlRiskFactor).toBe("10000");
+    expect(params?.upnlRiskFactorForWithdrawals).toBe("100");
+
+    const calculator = createMarginCalculator([params!]);
+    const result = calculator.computeSubaccountMarginFromInputs({
+      subaccountIndex: 0,
+      collateralBalanceQuoteLots: "1",
+      markets: [
+        {
+          symbol: "SOL-PERP",
+          position: {
+            basePositionLots: "1",
+            virtualQuotePositionLots: "-2420",
+            entryPriceTicks: "2420",
+            unsettledFundingQuoteLots: "0",
+            accumulatedFundingQuoteLots: "0",
+          },
+        },
+      ],
+    });
+
+    expect(result.margin.initialMarginQuoteLots).toBe("121");
+    expect(result.margin.maintenanceMarginQuoteLots).toBe("60");
+  });
+
+  it("preserves already-bps risk factors above the percentage range", () => {
+    const params = buildMarketParamsFromSummary(
+      marketSummary({
+        leverageTiers: [
+          {
+            maxLeverage: 20,
+            maxSizeBaseLots: 1_000,
+            limitOrderRiskFactor: 6_000,
+          },
+        ],
+        riskFactors: {
+          maintenance: 5_000,
+          backstop: 2_000,
+          highRisk: 1_000,
+          upnl: 10_000,
+          upnlForWithdrawals: 3_000,
+          cancelOrder: 7_000,
+        },
+      }),
+      "0.00242"
+    );
+
+    expect(params?.leverageTiers[0]?.limitOrderRiskFactorBps).toBe("6000");
+    expect(params?.riskFactors.maintenanceMarginFactorBps).toBe("5000");
+    expect(params?.riskFactors.backstopMarginFactorBps).toBe("2000");
+    expect(params?.riskFactors.highRiskMarginFactorBps).toBe("1000");
+    expect(params?.upnlRiskFactor).toBe("10000");
+    expect(params?.upnlRiskFactorForWithdrawals).toBe("3000");
+    expect(params?.cancelOrderRiskFactorBps).toBe("7000");
+  });
+});


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `7b0e722849fbc44d2d34d481d208db0ea951b78e`
- Mode: automatic
- Synced paths:

- `rise/ts` -> `ts`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/test-fixtures` -> `test-fixtures`

## Versions

- TypeScript `@ellipsis-labs/rise`: Phoenix 0.4.28 -> 0.4.30; Rise target is 0.4.28

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `ts/CHANGELOG.md`

### TypeScript `@ellipsis-labs/rise`

- **Risk factor values in `RiskFactors` are now in basis points.** `PhoenixProjectedMarket.riskFactors` fields (`maintenance`, `backstop`, `highRisk`, `upnl`, `upnlForWithdrawals`, `cancelOrder`) now carry bps values (e.g. `5000` = 50%) instead of the previous percentage scale (e.g. `5` = 5%). The cache store, projected-market selector, and margin params builder all consistently prefer the new bps representation.
- **Optional `*Bps` sibling fields added to `ExchangeRiskFactors` and `ExchangeLeverageTier`.** `maintenanceBps`, `backstopBps`, `highRiskBps`, `upnlBps`, `upnlForWithdrawalsBps`, `cancelOrderBps`, and `limitOrderRiskFactorBps` are now available on the HTTP API types; where present they take precedence over the legacy percentage fields.
- **WebSocket risk-factor update events carry optional bps deltas.** `cancelRiskFactorUpdated`, `upnlRiskFactorUpdated`, and `upnlRiskFactorForWithdrawalsUpdated` now include `previousBps`/`newBps` (normalized from server snake_case `previous_bps`/`new_bps`).
- **`buildMarketParamsFromSummary` now validates risk factor inputs strictly.** Passing a non-finite, negative, non-integer, or >10 000 bps value throws an explicit error instead of silently stringifying it.

### Breaking Changes

- **`buildMarketParamsFromSummary` can now throw.** If a `MarketSummary` contains risk factor values that are non-finite, negative, non-integer bps, or exceed 10 000 bps, the function throws instead of returning a params object. Callers that previously relied on unconditional success should wrap the call or validate inputs first.

### Consumer Notes

- The legacy percentage-scale fields on `ExchangeRiskFactors` (`maintenance`, `backstop`, etc.) remain present for backwards compatibility with older API responses; prefer the new `*Bps` fields when available.
- WS consumers parsing `cancelRiskFactorUpdated`, `upnlRiskFactorUpdated`, or `upnlRiskFactorForWithdrawalsUpdated` events can now read `newBps`/`previousBps` directly; the wire adapter normalizes snake_case `new_bps`/`previous_bps` from the server automatically.