### PR TITLE
sync: Rise TypeScript v0.4.34

### DIFF
--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -125,3 +125,23 @@ Source Phoenix commit: `d1c6f3dea8582f451d616bc42b1a083f9fa04000`
 - `getTraderCollateralHistory(authority, { pdaIndex? })` continues to work for authority-based lookups via `/v1/trader/{authority}/collateral-history` (path now carries the `v1` prefix internally, but the method signature is unchanged).
 - New `getTraderPdaCollateralHistory(traderPubkey, request?)` targets `/v1/traders/{traderPubkey}/collateral-history` — use this when you have the trader PDA pubkey directly rather than the authority.
 - New `getAllTraderPdaCollateralHistory(traderPubkey, pageSize?, request?)` auto-paginates until `hasMore` is false and returns the flat event array; the default page size is 1000.
+
+## v0.4.34 - 2026-06-15
+
+Source Phoenix commit: `c25ccb579ff367b65aedf254320d6a54da56613f`
+
+### Summary
+
+- Added `MaxLiquidationSizeUpdated` exchange market parameter update event: new `interface MaxLiquidationSizeUpdated` with `kind: "maxLiquidationSizeUpdated"`, `previousBaseLots: bigint`, and `newBaseLots: bigint`.
+- `MaxLiquidationSizeUpdated` is now included in the `ExchangeMarketParameterUpdate` discriminated union and recognized by the WebSocket wire adapter's known-kinds set and Zod schema.
+- The exchange cache store now maps `"maxLiquidationSizeUpdated"` events to the `"maxLiquidationSize"` change kind and applies `update.newBaseLots` to `nextMarket.maxLiquidationSizeBaseLots`.
+- `"maxLiquidationSize"` added to the `ExchangeCacheMarketChangeKind` union type.
+
+### Breaking Changes
+
+- None identified in the synced diff.
+
+### Consumer Notes
+
+- Consumers subscribing to exchange market parameter updates will now receive `maxLiquidationSizeUpdated` events. If you have exhaustive switch/discriminated-union handling over `ExchangeMarketParameterUpdate`, TypeScript will require you to handle the new `MaxLiquidationSizeUpdated` variant.
+- If you use `ExchangeCacheMarketChangeKind` exhaustively (e.g., in a switch or mapped type), add a case for `"maxLiquidationSize"` to avoid compilation errors.

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/rise",
-  "version": "0.4.33",
+  "version": "0.4.34",
   "packageManager": "bun@1.3.13",
   "repository": {
     "type": "git",

--- a/ts/src/exchange-cache/store.ts
+++ b/ts/src/exchange-cache/store.ts
@@ -785,6 +785,8 @@ class PhoenixExchangeCacheStoreImpl implements PhoenixExchangeCacheStore {
         return "markPriceParameters";
       case "openInterestCapUpdated":
         return "openInterestCap";
+      case "maxLiquidationSizeUpdated":
+        return "maxLiquidationSize";
       case "upnlRiskFactorUpdated":
         return "upnlRiskFactor";
       case "upnlRiskFactorForWithdrawalsUpdated":
@@ -825,6 +827,9 @@ class PhoenixExchangeCacheStoreImpl implements PhoenixExchangeCacheStore {
         return nextMarket;
       case "openInterestCapUpdated":
         nextMarket.openInterestCapBaseLots = update.newBaseLots;
+        return nextMarket;
+      case "maxLiquidationSizeUpdated":
+        nextMarket.maxLiquidationSizeBaseLots = update.newBaseLots;
         return nextMarket;
       case "upnlRiskFactorUpdated":
         nextMarket.riskFactors = {

--- a/ts/src/exchange-cache/types.ts
+++ b/ts/src/exchange-cache/types.ts
@@ -52,6 +52,7 @@ export type ExchangeCacheMarketChangeKind =
   | "leverageTiers"
   | "markPriceParameters"
   | "openInterestCap"
+  | "maxLiquidationSize"
   | "upnlRiskFactor"
   | "upnlRiskFactorForWithdrawals"
   | "fundingParameters"

--- a/ts/src/ws/adapters/exchange/wire.ts
+++ b/ts/src/ws/adapters/exchange/wire.ts
@@ -113,6 +113,12 @@ export interface OpenInterestCapUpdated {
   newBaseLots: bigint;
 }
 
+export interface MaxLiquidationSizeUpdated {
+  kind: "maxLiquidationSizeUpdated";
+  previousBaseLots: bigint;
+  newBaseLots: bigint;
+}
+
 export interface UpnlRiskFactorUpdated {
   kind: "upnlRiskFactorUpdated";
   previous: number;
@@ -159,6 +165,7 @@ export type ExchangeMarketParameterUpdate =
   | LeverageTiersUpdated
   | MarkPriceParametersUpdated
   | OpenInterestCapUpdated
+  | MaxLiquidationSizeUpdated
   | UpnlRiskFactorUpdated
   | UpnlRiskFactorForWithdrawalsUpdated
   | FundingParametersUpdated
@@ -240,6 +247,7 @@ const KNOWN_MARKET_PARAMETER_UPDATE_KINDS = new Set([
   "leverageTiersUpdated",
   "markPriceParametersUpdated",
   "openInterestCapUpdated",
+  "maxLiquidationSizeUpdated",
   "upnlRiskFactorUpdated",
   "upnlRiskFactorForWithdrawalsUpdated",
   "fundingParametersUpdated",
@@ -456,6 +464,11 @@ const exchangeMarketParameterUpdateSchema = z.discriminatedUnion("kind", [
   }),
   z.object({
     kind: z.literal("openInterestCapUpdated"),
+    previousBaseLots: numericBigint("previousBaseLots"),
+    newBaseLots: numericBigint("newBaseLots"),
+  }),
+  z.object({
+    kind: z.literal("maxLiquidationSizeUpdated"),
     previousBaseLots: numericBigint("previousBaseLots"),
     newBaseLots: numericBigint("newBaseLots"),
   }),


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `c25ccb579ff367b65aedf254320d6a54da56613f`
- Mode: manual
- Synced paths:

- `rise/ts` -> `ts`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `ts/CHANGELOG.md`

### Summary

- Added `MaxLiquidationSizeUpdated` exchange market parameter update event: new `interface MaxLiquidationSizeUpdated` with `kind: "maxLiquidationSizeUpdated"`, `previousBaseLots: bigint`, and `newBaseLots: bigint`.
- `MaxLiquidationSizeUpdated` is now included in the `ExchangeMarketParameterUpdate` discriminated union and recognized by the WebSocket wire adapter's known-kinds set and Zod schema.
- The exchange cache store now maps `"maxLiquidationSizeUpdated"` events to the `"maxLiquidationSize"` change kind and applies `update.newBaseLots` to `nextMarket.maxLiquidationSizeBaseLots`.
- `"maxLiquidationSize"` added to the `ExchangeCacheMarketChangeKind` union type.

### Breaking Changes

- None identified in the synced diff.

### Consumer Notes

- Consumers subscribing to exchange market parameter updates will now receive `maxLiquidationSizeUpdated` events. If you have exhaustive switch/discriminated-union handling over `ExchangeMarketParameterUpdate`, TypeScript will require you to handle the new `MaxLiquidationSizeUpdated` variant.
- If you use `ExchangeCacheMarketChangeKind` exhaustively (e.g., in a switch or mapped type), add a case for `"maxLiquidationSize"` to avoid compilation errors.