### PR TITLE
ci: dispatch Rise sync PR refreshes

### DIFF
--- a/.github/workflows/refresh-rise-sync-prs.yaml
+++ b/.github/workflows/refresh-rise-sync-prs.yaml
@@ -1,0 +1,49 @@
+name: Refresh Rise Sync PRs
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      package:
+        description: "Package queue to refresh."
+        default: "all"
+        required: true
+        type: choice
+        options:
+          - "all"
+          - "ts"
+          - "rust"
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    env:
+      BASE_BRANCH: ${{ vars.RISE_SYNC_BASE_BRANCH || 'master' }}
+      GH_TOKEN: ${{ secrets.RISE_SYNC_DISPATCH_TOKEN }}
+      PACKAGE: ${{ inputs.package || 'all' }}
+      PHOENIX_REPO: ${{ vars.RISE_SYNC_PHOENIX_REPO || 'Ellipsis-Labs/phoenix' }}
+      TARGET_REPO: ${{ vars.RISE_SYNC_TARGET_REPO || github.repository }}
+    steps:
+      - name: Dispatch Phoenix refresh
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::warning::RISE_SYNC_DISPATCH_TOKEN is not configured; skipping Phoenix refresh dispatch."
+            exit 0
+          fi
+
+          gh api "repos/${PHOENIX_REPO}/dispatches" \
+            -f event_type="rise-public-master-updated" \
+            -f "client_payload[operation]=refresh_next_sync_pr" \
+            -f "client_payload[target_repo]=${TARGET_REPO}" \
+            -f "client_payload[base_branch]=${BASE_BRANCH}" \
+            -f "client_payload[package]=${PACKAGE}" \
+            -f "client_payload[source_repo]=${GITHUB_REPOSITORY}" \
+            -f "client_payload[source_sha]=${GITHUB_SHA}" \
+            -f "client_payload[source_event]=${GITHUB_EVENT_NAME}"


### PR DESCRIPTION
## Summary

Adds a rise-public workflow that dispatches Phoenix's Rise sync workflow whenever `master` changes, with a manual package-specific trigger as a fallback.

## Changes

- `ci: dispatch Rise sync PR refreshes`

## User Impact

Operators can refresh the next queued Rise sync PR after a release merge without manually finding and rebuilding the stale branch.

## Root Cause

Queued sync PRs are generated from the target repo base branch, but rise-public did not notify Phoenix when that base changed.

## Fix

Adds `.github/workflows/refresh-rise-sync-prs.yaml`, which sends a `repository_dispatch` event to Phoenix with target repo, base branch, package queue, and source metadata. If `RISE_SYNC_DISPATCH_TOKEN` is not configured, the workflow exits cleanly with a warning.

## Validation

- `actionlint /Users/conner/dev/Ellipsis-Labs/rise-public/.github/workflows/refresh-rise-sync-prs.yaml`
- `git diff --check`
