### PR TITLE
sync: Rise TypeScript v0.4.39

### DIFF
--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -217,3 +217,23 @@ Source Phoenix commit: `978cab228c047f8e511a8075621846c679d331d5`
 ### Consumer Notes
 
 - If you pin `ws` to an exact version below `8.21.0`, you may see peer dependency warnings or conflicts. Update your lockfile or pin to `ws@8.21.0` or later.
+
+## v0.4.39 - 2026-06-15
+
+Source Phoenix commit: `6b96d79ca6d38a289150f382efe441c4116e395c`
+
+### Summary
+
+- **Version bump**: `@ellipsis-labs/rise` is now `0.4.39`.
+- **Source files included in package**: The `src/` directory is now bundled in the published npm package alongside `dist/`. Consumers benefit from source availability for debugging and source maps without needing a separate step.
+- **Changelog included in package**: `CHANGELOG.md` is now shipped with the npm package, making release notes available locally after install.
+- **README documents changelog location**: A new "Changelog" section in the README links to the public Rise TypeScript changelog on GitHub.
+
+### Breaking Changes
+
+- None identified in the synced diff.
+
+### Consumer Notes
+
+- No API, type, or runtime behavior changes in this release — the changes are packaging-only.
+- If your bundler or tooling scans `node_modules` for `.ts` source files, the newly included `src/` directory may be picked up; verify your `exclude` or `ignore` patterns if unexpected files appear in your build.

--- a/ts/README.md
+++ b/ts/README.md
@@ -13,6 +13,11 @@ It gives you:
 - built-in WebSocket adapters plus typed custom subscription registration
 - low-level transport helpers for custom HTTP endpoints
 
+## Changelog
+
+See the [public Rise TypeScript changelog](https://github.com/Ellipsis-Labs/rise-public/blob/master/ts/CHANGELOG.md)
+for release notes.
+
 ## Main Entry Points
 
 ```ts

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/rise",
-  "version": "0.4.38",
+  "version": "0.4.39",
   "packageManager": "bun@1.3.13",
   "repository": {
     "type": "git",
@@ -18,7 +18,9 @@
   "description": "Rise SDK - Phoenix HTTP client",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "src",
+    "CHANGELOG.md"
   ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `6b96d79ca6d38a289150f382efe441c4116e395c`
- Mode: manual
- Synced paths:

- `rise/ts` -> `ts`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `ts/CHANGELOG.md`

### Summary

- **Version bump**: `@ellipsis-labs/rise` is now `0.4.39`.
- **Source files included in package**: The `src/` directory is now bundled in the published npm package alongside `dist/`. Consumers benefit from source availability for debugging and source maps without needing a separate step.
- **Changelog included in package**: `CHANGELOG.md` is now shipped with the npm package, making release notes available locally after install.
- **README documents changelog location**: A new "Changelog" section in the README links to the public Rise TypeScript changelog on GitHub.

### Breaking Changes

- None identified in the synced diff.

### Consumer Notes

- No API, type, or runtime behavior changes in this release — the changes are packaging-only.
- If your bundler or tooling scans `node_modules` for `.ts` source files, the newly included `src/` directory may be picked up; verify your `exclude` or `ignore` patterns if unexpected files appear in your build.