### PR TITLE
sync: Rise TypeScript v0.4.40

### DIFF
--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -237,3 +237,23 @@ Source Phoenix commit: `6b96d79ca6d38a289150f382efe441c4116e395c`
 
 - No API, type, or runtime behavior changes in this release — the changes are packaging-only.
 - If your bundler or tooling scans `node_modules` for `.ts` source files, the newly included `src/` directory may be picked up; verify your `exclude` or `ignore` patterns if unexpected files appear in your build.
+
+## v0.4.40 - 2026-06-16
+
+Source Phoenix commit: `65fc5aad3e13c249bcc606b410059b8adbc61e2d`
+
+### Summary
+
+- **Fixed liquidation price calculation**: The formula for computing a position's liquidation price now correctly incorporates the market's `maintenanceMarginFactorBps` risk parameter. Previously the formula used a simplified approximation; it now derives the denominator and numerator using the actual maintenance margin coefficient, producing more accurate results across leverage tiers.
+- **Fixed unsettled funding sign convention in snapshot helpers**: `buildMarginPositionStateFromSnapshot` no longer negates `unsettledFundingQuoteLots` when converting from a snapshot. The field is now passed through as-is, matching the margin-engine sign convention (positive = increases effective collateral).
+- **Clarified `MarginPositionState.unsettledFundingQuoteLots` documentation**: The JSDoc on this field no longer instructs callers to flip the sign themselves; the snapshot helper now handles the value correctly without manual adjustment.
+
+### Breaking Changes
+
+- **Snapshot-sourced `unsettledFundingQuoteLots` values will differ**: Any code that previously compensated for the sign flip in `buildMarginPositionStateFromSnapshot` (e.g., by negating the field before passing it downstream) must remove that workaround. The value is now passed through with the margin-engine convention intact.
+- **Liquidation price outputs will change**: Computed liquidation prices from `computeLiquidationPriceTicks` will differ from prior versions due to the corrected formula. Consumers who cache, display, or act on liquidation price values should expect updated results after upgrading.
+
+### Consumer Notes
+
+- If you construct `MarginPositionState` manually (not via snapshot helpers) and were previously accounting for the sign flip described in the old JSDoc, no change is needed — the type contract is unchanged; only the snapshot helper behavior is fixed.
+- The liquidation price fix requires `maintenanceMarginFactorBps` to be present and positive in `MarketParams.riskFactors`; positions with a zero or missing value will return `undefined` for liquidation price (was previously a potentially incorrect value).

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/rise",
-  "version": "0.4.39",
+  "version": "0.4.40",
   "packageManager": "bun@1.3.13",
   "repository": {
     "type": "git",

--- a/ts/scripts/lib/marginParityExport.ts
+++ b/ts/scripts/lib/marginParityExport.ts
@@ -194,25 +194,26 @@ const solveLiquidationPrice = (
   positionSize: number,
   entryPrice: number,
   leverage: bigint,
+  maintenanceBps: bigint,
   rawCollateral: number,
   otherAssetUnrealizedPnl: number,
   otherAssetMaintenanceMargin: number
 ): number | undefined => {
-  if (positionSize === 0 || leverage === 0n) {
+  if (positionSize === 0 || leverage === 0n || maintenanceBps <= 0n) {
     return undefined;
   }
   const leverageNumber = Number(leverage);
-  const denom = positionSize * (2 * leverageNumber - 1);
+  const maintenanceCoefficient =
+    (Math.abs(positionSize) * Number(maintenanceBps)) / 10_000 / leverageNumber;
+  const denom = maintenanceCoefficient - positionSize;
   if (!Number.isFinite(denom) || Math.abs(denom) < 1e-10) {
     return undefined;
   }
   const numerator =
-    2 *
-    leverageNumber *
-    (otherAssetMaintenanceMargin +
-      entryPrice * positionSize -
-      rawCollateral -
-      otherAssetUnrealizedPnl);
+    rawCollateral +
+    otherAssetUnrealizedPnl -
+    otherAssetMaintenanceMargin -
+    entryPrice * positionSize;
   const price = numerator / denom;
   if (!Number.isFinite(price) || price <= 0) {
     return undefined;
@@ -259,10 +260,14 @@ const computeLiquidationPriceTicks = (
     parseLeverageTiers(marketParams),
     absBigInt(basePositionLots)
   );
+  const maintenanceBps = toBigInt(
+    marketParams.riskFactors.maintenanceMarginFactorBps
+  );
   const liquidationPrice = solveLiquidationPrice(
     basePosition,
     entryPrice,
     leverage,
+    maintenanceBps,
     rawCollateral,
     otherAssetUnrealizedPnl,
     otherAssetMaintenanceMargin

--- a/ts/src/margin/snapshot.ts
+++ b/ts/src/margin/snapshot.ts
@@ -1,5 +1,4 @@
 import { buildLimitOrderMarginStateFromOrders } from "./inputs";
-import { toBigInt } from "./math";
 import type {
   LimitOrderMarginInput,
   MarginPositionState,
@@ -80,9 +79,7 @@ export const buildMarginPositionStateFromSnapshot = (
   basePositionLots: position.basePositionLots,
   virtualQuotePositionLots: position.virtualQuotePositionLots,
   entryPriceTicks: position.entryPriceTicks,
-  unsettledFundingQuoteLots: (-toBigInt(
-    position.unsettledFundingQuoteLots
-  )).toString(),
+  unsettledFundingQuoteLots: position.unsettledFundingQuoteLots,
   accumulatedFundingQuoteLots: position.accumulatedFundingQuoteLots,
 });
 

--- a/ts/src/margin/types.ts
+++ b/ts/src/margin/types.ts
@@ -42,9 +42,8 @@ export interface MarginPositionState {
   virtualQuotePositionLots: string;
   entryPriceTicks: string;
   /**
-   * Funding with the margin-engine sign convention (positive increases
-   * effective collateral). Use the snapshot helpers to flip the TraderState
-   * sign when needed.
+   * Funding with the margin-engine sign convention: positive increases
+   * effective collateral.
    */
   unsettledFundingQuoteLots: string;
   accumulatedFundingQuoteLots: string;

--- a/ts/tests/margin-funding-sign.test.ts
+++ b/ts/tests/margin-funding-sign.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSubaccountMarginInputsFromSnapshot,
+  createMarginCalculator,
+  type MarketParams,
+} from "@/margin";
+
+const marketParams: MarketParams = {
+  symbol: "SOL-PERP",
+  assetId: 1,
+  markPriceTicks: "100",
+  tickSize: "1",
+  baseLotDecimals: 0,
+  leverageTiers: [
+    {
+      upperBoundSize: "1000",
+      maxLeverage: "10",
+      limitOrderRiskFactorBps: "0",
+    },
+  ],
+  riskFactors: {
+    maintenanceMarginFactorBps: "500",
+    backstopMarginFactorBps: "1000",
+    highRiskMarginFactorBps: "2000",
+  },
+  cancelOrderRiskFactorBps: "500",
+  upnlRiskFactor: "10000",
+  upnlRiskFactorForWithdrawals: "10000",
+  isolatedOnly: false,
+};
+
+describe("margin funding sign handling", () => {
+  it("keeps positive snapshot unsettled funding as effective collateral", () => {
+    const inputs = buildSubaccountMarginInputsFromSnapshot({
+      subaccountIndex: 0,
+      collateral: "1000",
+      positions: [
+        {
+          symbol: "SOL-PERP",
+          basePositionLots: "1",
+          virtualQuotePositionLots: "-100",
+          entryPriceTicks: "100",
+          unsettledFundingQuoteLots: "25",
+          accumulatedFundingQuoteLots: "5",
+        },
+      ],
+    });
+
+    expect(inputs.markets[0]?.position?.unsettledFundingQuoteLots).toBe("25");
+
+    const margin = createMarginCalculator([
+      marketParams,
+    ]).computeSubaccountMarginFromInputs(inputs);
+
+    expect(margin.marketMargins[0]?.unsettledFundingQuoteLots).toBe("25");
+    expect(margin.marketMargins[0]?.accumulatedFundingQuoteLots).toBe("5");
+    expect(margin.margin.unsettledFundingQuoteLots).toBe("25");
+    expect(margin.margin.accumulatedFundingQuoteLots).toBe("5");
+    expect(margin.margin.effectiveCollateralQuoteLots).toBe("1025");
+  });
+});


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `65fc5aad3e13c249bcc606b410059b8adbc61e2d`
- Mode: manual
- Synced paths:

- `rise/ts` -> `ts`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `ts/CHANGELOG.md`

### Summary

- **Fixed liquidation price calculation**: The formula for computing a position's liquidation price now correctly incorporates the market's `maintenanceMarginFactorBps` risk parameter. Previously the formula used a simplified approximation; it now derives the denominator and numerator using the actual maintenance margin coefficient, producing more accurate results across leverage tiers.
- **Fixed unsettled funding sign convention in snapshot helpers**: `buildMarginPositionStateFromSnapshot` no longer negates `unsettledFundingQuoteLots` when converting from a snapshot. The field is now passed through as-is, matching the margin-engine sign convention (positive = increases effective collateral).
- **Clarified `MarginPositionState.unsettledFundingQuoteLots` documentation**: The JSDoc on this field no longer instructs callers to flip the sign themselves; the snapshot helper now handles the value correctly without manual adjustment.

### Breaking Changes

- **Snapshot-sourced `unsettledFundingQuoteLots` values will differ**: Any code that previously compensated for the sign flip in `buildMarginPositionStateFromSnapshot` (e.g., by negating the field before passing it downstream) must remove that workaround. The value is now passed through with the margin-engine convention intact.
- **Liquidation price outputs will change**: Computed liquidation prices from `computeLiquidationPriceTicks` will differ from prior versions due to the corrected formula. Consumers who cache, display, or act on liquidation price values should expect updated results after upgrading.

### Consumer Notes

- If you construct `MarginPositionState` manually (not via snapshot helpers) and were previously accounting for the sign flip described in the old JSDoc, no change is needed — the type contract is unchanged; only the snapshot helper behavior is fixed.
- The liquidation price fix requires `maintenanceMarginFactorBps` to be present and positive in `MarketParams.riskFactors`; positions with a zero or missing value will return `undefined` for liquidation price (was previously a potentially incorrect value).