### PR TITLE
sync: Rise Rust v0.1.7

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -56,3 +56,30 @@ Source Phoenix commit: `443ff8dfd64a9e7d35960b8b1946b3248d6681e5`
 
 - **Prefer `_bps` fields for risk factor arithmetic.** The server now populates them (e.g., `maintenance_bps: Some(5000)` = 50%). When present, these should be considered authoritative; the legacy `f64` fields may carry basis-point-scale values from the API rather than percentages in some contexts — divide by 100 only for human-readable display, as shown in the updated `http_client` example.
 - `ExchangeRiskFactors` struct literals in your own code now require the six new `Option<u16>` fields; either supply `None` or use `..Default::default()` (if you derive `Default`) to stay forward-compatible.
+
+## v0.1.7 - 2026-06-16
+
+Source Phoenix commit: `65fc5aad3e13c249bcc606b410059b8adbc61e2d`
+
+### Summary
+
+- **Delegated market orders**: New `MarketOrderDelegatedParams` / `create_place_market_order_delegated_ix` instruction builder and `PhoenixTxBuilder::place_market_order_delegated` for signing via a wallet that differs from the trader account authority. Delegated market-order instructions are now routable through `PhoenixFlightClient`.
+- **Session manager abstraction**: New `PhoenixSessionManager` trait with two built-in implementations — `PhoenixMemorySessionManager` (any `AuthSession`) and `PhoenixWalletSessionManager` (Solana keypair login, `solana-keypair` feature). Concurrent refreshes are coalesced. Pass via `PhoenixHttpClientBuilder::with_session_manager`.
+- **Authenticated WebSocket handshake**: `PhoenixClient::new_from_env_with_auth` / `from_env_with_auth` / `from_env_with_http_client` propagate the HTTP client's auth lifecycle to WebSocket connections; the handshake now sends `Authorization` and `Sec-WebSocket-Protocol` JWT headers and auto-retries on 401/403/409.
+- **WS connection status observable**: `PhoenixClient::connection_status()` and `subscribe_connection_status()` expose a `watch::Receiver<WsConnectionStatus>` for the full client's reconnection state.
+- **`MaxLiquidationSizeUpdated` WS event**: New `ExchangeMarketParameterUpdate::MaxLiquidationSizeUpdated` variant tracked by `ExchangeCacheMarketChangeKind::MaxLiquidationSize`.
+
+### Breaking Changes
+
+- **`TradersClient` API replaced**: `get_trader(authority)`, `get_trader_internal(authority, pda_index)`, and `get_trader_state(authority, pda_index)` are removed. Use `get_trader_by_pubkey(&trader_pda)` instead, which takes the trader PDA directly. The convenience top-level methods `PhoenixHttpClient::get_traders` and `get_trader_state` are also removed.
+- **`get_permission_address` removed** from the public re-export list in `phoenix_rise`.
+- **New `ExchangeMarketParameterUpdate::MaxLiquidationSizeUpdated` variant**: exhaustive `match` arms over this enum must add a handler for the new variant.
+- **New `PhoenixWsError::Authentication` variant**: exhaustive `match` arms over this error type must add a handler.
+
+### Consumer Notes
+
+- `PhoenixEnv::from_api_url(api_url)` is a new convenience constructor that derives the WebSocket URL automatically, including preserving reverse-proxy path prefixes (e.g. `https://gateway.example.com/phoenix` → `wss://gateway.example.com/phoenix/v1/ws`).
+- `PhoenixHttpClient::from_url_with_wallet_keypair(url, keypair)` (`solana-keypair` feature) creates a fully authenticated client in one step.
+- `PhoenixHttpClient::post_json` is now public.
+- `is_auth_recovery_error` is now a public export for downstream error classification.
+- `async-trait 0.1` is a new direct dependency of `phoenix-rise`.

--- a/rust/CRATES.md
+++ b/rust/CRATES.md
@@ -18,6 +18,11 @@ Optional features:
 - `ed25519-dalek` for service-account signing helpers
 - `rust_decimal` for decimal-backed helpers
 
+## Changelog
+
+Release notes are maintained in the public Rise repository:
+<https://github.com/Ellipsis-Labs/rise-public/blob/master/rust/CHANGELOG.md>.
+
 ## Source Layout
 
 The published `phoenix-rise` crate is assembled from:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2529,8 +2529,9 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
+ "async-trait",
  "axum",
  "base64 0.22.1",
  "borsh 1.6.0",
@@ -2574,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-sdk-cli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "clap",
  "phoenix-rise",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,6 +25,10 @@ version = { workspace = true }
 path = "sdk/src/lib.rs"
 
 [[test]]
+name = "auth_config_tests"
+path = "sdk/tests/auth_config_tests.rs"
+
+[[test]]
 name = "invite_client_tests"
 path = "sdk/tests/invite_client_tests.rs"
 
@@ -159,6 +163,7 @@ ignored = [
 ]
 
 [dependencies]
+async-trait        = { workspace = true }
 base64             = { workspace = true }
 borsh              = { workspace = true }
 bs58               = { workspace = true }
@@ -216,9 +221,10 @@ publish      = true
 readme       = "CRATES.md"
 repository   = "https://github.com/Ellipsis-Labs/rise"
 rust-version = "1.84.0"
-version      = "0.1.6"
+version      = "0.1.7"
 
 [workspace.dependencies]
+async-trait = "0.1"
 base64 = "0.22"
 borsh = { version = "1.5", features = ["derive"] }
 bs58 = "0.5"

--- a/rust/README.md
+++ b/rust/README.md
@@ -44,6 +44,11 @@ rust/
   modules
 - `phoenix-rise-sdk-cli`: smoke-test CLI for HTTP, websocket, and auth flows
 
+## Changelog
+
+The public Rust SDK changelog is published at
+<https://github.com/Ellipsis-Labs/rise-public/blob/master/rust/CHANGELOG.md>.
+
 ## Main SDK Surfaces
 
 ### `PhoenixHttpClient`

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -63,10 +63,6 @@ enum HttpCommand {
         symbol: String,
     },
     Exchange,
-    Traders {
-        #[arg(long)]
-        authority: String,
-    },
     CollateralHistory {
         #[arg(long)]
         authority: String,
@@ -381,11 +377,6 @@ async fn run_http_request(
         }
         HttpCommand::Exchange => {
             let response = client.get_exchange().await?;
-            print_json(&response, pretty)?;
-        }
-        HttpCommand::Traders { authority } => {
-            let authority = parse_pubkey(&authority)?;
-            let response = client.get_traders(&authority).await?;
             print_json(&response, pretty)?;
         }
         HttpCommand::CollateralHistory {

--- a/rust/ix/examples/build_all_ix.rs
+++ b/rust/ix/examples/build_all_ix.rs
@@ -658,6 +658,50 @@ fn main() {
         );
     }
 
+    // 19. PlaceMarketOrderDelegated
+    {
+        let market_order = MarketOrderParams::builder()
+            .trader(pubkeys[0])
+            .trader_account(pubkeys[1])
+            .perp_asset_map(pubkeys[2])
+            .orderbook(pubkeys[3])
+            .spline_collection(pubkeys[4])
+            .global_trader_index(vec2(5, 6))
+            .active_trader_buffer(vec2(7, 8))
+            .side(Side::Ask)
+            .num_base_lots(100)
+            .min_base_lots_to_fill(0)
+            .min_quote_lots_to_fill(0)
+            .self_trade_behavior(phoenix_rise_ix::SelfTradeBehavior::Abort)
+            .client_order_id(0)
+            .order_flags(phoenix_rise_ix::OrderFlags::None)
+            .cancel_existing(false)
+            .build()
+            .unwrap();
+        let params = MarketOrderDelegatedParams::builder()
+            .market_order(market_order)
+            .trader_wallet(pubkeys[9])
+            .permission_account(pubkeys[10])
+            .build()
+            .unwrap();
+
+        let delegated_ix = create_place_market_order_delegated_ix(params).unwrap();
+        results.insert(
+            "PlaceMarketOrderDelegated".to_string(),
+            hex_encode(&delegated_ix.data),
+        );
+
+        // 20. Flight wrapper for PlaceMarketOrderDelegated
+        let flight_client = PhoenixFlightClient::new(pubkeys[9], 0, 0);
+        let ix = flight_client
+            .try_wrap_order_instruction(delegated_ix.into(), pubkeys[0])
+            .unwrap();
+        results.insert(
+            "FlightPlaceMarketOrderDelegated".to_string(),
+            hex_encode(&ix.data),
+        );
+    }
+
     // Output JSON
     let mut json = String::from("{");
     let mut first = true;

--- a/rust/ix/src/constants.rs
+++ b/rust/ix/src/constants.rs
@@ -150,6 +150,11 @@ pub fn place_market_order_discriminant() -> [u8; 8] {
     compute_discriminant("global:place_market_order")
 }
 
+/// Instruction discriminant for place_market_order_delegated.
+pub fn place_market_order_delegated_discriminant() -> [u8; 8] {
+    compute_discriminant("global:place_market_order_delegated")
+}
+
 /// Instruction discriminant for cancel_orders_by_id.
 pub fn cancel_orders_by_id_discriminant() -> [u8; 8] {
     compute_discriminant("global:cancel_orders_by_id")

--- a/rust/ix/src/lib.rs
+++ b/rust/ix/src/lib.rs
@@ -69,7 +69,8 @@ pub use limit_order::{
     create_place_limit_order_ix,
 };
 pub use market_order::{
-    IsolatedMarketOrderParams, MarketOrderParams, create_place_market_order_ix,
+    IsolatedMarketOrderParams, MarketOrderDelegatedParams, MarketOrderParams,
+    create_place_market_order_delegated_ix, create_place_market_order_ix,
 };
 pub use multi_limit_order::{
     MultiLimitOrderParams, MultiLimitOrderParamsBuilder, create_place_multi_limit_order_ix,

--- a/rust/ix/src/market_order.rs
+++ b/rust/ix/src/market_order.rs
@@ -5,7 +5,7 @@ use solana_pubkey::Pubkey;
 
 use crate::ix::constants::{
     PHOENIX_GLOBAL_CONFIGURATION, PHOENIX_LOG_AUTHORITY, PHOENIX_PROGRAM_ID,
-    place_market_order_discriminant,
+    place_market_order_delegated_discriminant, place_market_order_discriminant,
 };
 use crate::ix::error::PhoenixIxError;
 use crate::ix::order_packet::{OrderPacket, client_order_id_to_bytes};
@@ -39,6 +39,82 @@ pub struct MarketOrderParams {
     symbol: String,
     /// Subaccount index (0 = cross-margin, 1+ = isolated). Not serialized.
     subaccount_index: u8,
+}
+
+/// Parameters for placing a market order through the delegated market-order
+/// entrypoint.
+#[derive(Debug, Clone)]
+pub struct MarketOrderDelegatedParams {
+    market_order: MarketOrderParams,
+    trader_wallet: Pubkey,
+    permission_account: Pubkey,
+}
+
+impl MarketOrderDelegatedParams {
+    pub fn builder() -> MarketOrderDelegatedParamsBuilder {
+        MarketOrderDelegatedParamsBuilder::new()
+    }
+
+    pub fn market_order(&self) -> &MarketOrderParams {
+        &self.market_order
+    }
+
+    pub fn trader_wallet(&self) -> Pubkey {
+        self.trader_wallet
+    }
+
+    pub fn permission_account(&self) -> Pubkey {
+        self.permission_account
+    }
+}
+
+#[derive(Default)]
+pub struct MarketOrderDelegatedParamsBuilder {
+    market_order: Option<MarketOrderParams>,
+    trader_wallet: Option<Pubkey>,
+    permission_account: Option<Pubkey>,
+}
+
+impl MarketOrderDelegatedParamsBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn market_order(mut self, market_order: MarketOrderParams) -> Self {
+        self.market_order = Some(market_order);
+        self
+    }
+
+    /// Signing wallet. This may be the trader account authority, the account's
+    /// primary position authority, or a secondary/delegated wallet authorized
+    /// by `permission_account`.
+    pub fn trader_wallet(mut self, trader_wallet: Pubkey) -> Self {
+        self.trader_wallet = Some(trader_wallet);
+        self
+    }
+
+    /// Permission account to validate. When signing as the trader account
+    /// authority or primary position authority, pass the same pubkey used for
+    /// `trader_wallet`. A secondary/delegated wallet must pass an actual
+    /// permission account bridging it to the trader account authority.
+    pub fn permission_account(mut self, permission_account: Pubkey) -> Self {
+        self.permission_account = Some(permission_account);
+        self
+    }
+
+    pub fn build(self) -> Result<MarketOrderDelegatedParams, PhoenixIxError> {
+        Ok(MarketOrderDelegatedParams {
+            market_order: self
+                .market_order
+                .ok_or(PhoenixIxError::MissingField("market_order"))?,
+            trader_wallet: self
+                .trader_wallet
+                .ok_or(PhoenixIxError::MissingField("trader_wallet"))?,
+            permission_account: self
+                .permission_account
+                .ok_or(PhoenixIxError::MissingField("permission_account"))?,
+        })
+    }
 }
 
 impl MarketOrderParams {
@@ -329,8 +405,27 @@ pub fn create_place_market_order_ix(
 ) -> Result<Instruction, PhoenixIxError> {
     validate(&params)?;
 
-    let data = encode_market_order(&params);
+    let data = encode_market_order(&params, place_market_order_discriminant());
     let accounts = build_accounts(&params);
+
+    Ok(Instruction {
+        program_id: *PHOENIX_PROGRAM_ID,
+        accounts,
+        data,
+    })
+}
+
+/// Create a delegated place market order instruction.
+pub fn create_place_market_order_delegated_ix(
+    params: MarketOrderDelegatedParams,
+) -> Result<Instruction, PhoenixIxError> {
+    validate(params.market_order())?;
+
+    let data = encode_market_order(
+        params.market_order(),
+        place_market_order_delegated_discriminant(),
+    );
+    let accounts = build_delegated_accounts(&params);
 
     Ok(Instruction {
         program_id: *PHOENIX_PROGRAM_ID,
@@ -349,11 +444,11 @@ fn validate(params: &MarketOrderParams) -> Result<(), PhoenixIxError> {
     Ok(())
 }
 
-fn encode_market_order(params: &MarketOrderParams) -> Vec<u8> {
+fn encode_market_order(params: &MarketOrderParams, discriminant: [u8; 8]) -> Vec<u8> {
     let mut data = Vec::new();
 
     // Instruction discriminant (8 bytes)
-    data.extend_from_slice(&place_market_order_discriminant());
+    data.extend_from_slice(&discriminant);
 
     // Build the order packet using proper Borsh serialization
     let packet = OrderPacket::immediate_or_cancel(
@@ -374,6 +469,32 @@ fn encode_market_order(params: &MarketOrderParams) -> Vec<u8> {
     data.extend_from_slice(&to_vec(&packet.kind).expect("serialization should not fail"));
 
     data
+}
+
+fn build_delegated_accounts(params: &MarketOrderDelegatedParams) -> Vec<AccountMeta> {
+    let market_order = params.market_order();
+    let mut accounts = Vec::new();
+
+    accounts.push(AccountMeta::readonly(*PHOENIX_PROGRAM_ID));
+    accounts.push(AccountMeta::readonly(*PHOENIX_LOG_AUTHORITY));
+    accounts.push(AccountMeta::writable(*PHOENIX_GLOBAL_CONFIGURATION));
+    accounts.push(AccountMeta::readonly_signer(params.trader_wallet()));
+    accounts.push(AccountMeta::writable(params.permission_account()));
+    accounts.push(AccountMeta::writable(market_order.trader_account()));
+    accounts.push(AccountMeta::writable(market_order.perp_asset_map()));
+
+    for addr in market_order.global_trader_index() {
+        accounts.push(AccountMeta::writable(*addr));
+    }
+
+    for addr in market_order.active_trader_buffer() {
+        accounts.push(AccountMeta::writable(*addr));
+    }
+
+    accounts.push(AccountMeta::writable(market_order.orderbook()));
+    accounts.push(AccountMeta::writable(market_order.spline_collection()));
+
+    accounts
 }
 
 fn build_accounts(params: &MarketOrderParams) -> Vec<AccountMeta> {
@@ -480,6 +601,55 @@ mod tests {
     }
 
     #[test]
+    fn test_create_market_order_delegated_ix_uses_distinct_signer_and_permission() {
+        let trader_authority = Pubkey::new_unique();
+        let trader_wallet = Pubkey::new_unique();
+        let permission_account = Pubkey::new_unique();
+        let trader_account = Pubkey::new_unique();
+        let perp_asset_map = Pubkey::new_unique();
+        let orderbook = Pubkey::new_unique();
+        let spline_collection = Pubkey::new_unique();
+        let global_trader_index = Pubkey::new_unique();
+        let active_trader_buffer = Pubkey::new_unique();
+
+        let market_order = MarketOrderParams::builder()
+            .trader(trader_authority)
+            .trader_account(trader_account)
+            .perp_asset_map(perp_asset_map)
+            .orderbook(orderbook)
+            .spline_collection(spline_collection)
+            .global_trader_index(vec![global_trader_index])
+            .active_trader_buffer(vec![active_trader_buffer])
+            .side(Side::Bid)
+            .price_in_ticks(50000)
+            .num_base_lots(1000)
+            .min_base_lots_to_fill(1000)
+            .min_quote_lots_to_fill(1)
+            .build()
+            .unwrap();
+        let normal_ix = create_place_market_order_ix(market_order.clone()).unwrap();
+        let delegated_params = MarketOrderDelegatedParams::builder()
+            .market_order(market_order)
+            .trader_wallet(trader_wallet)
+            .permission_account(permission_account)
+            .build()
+            .unwrap();
+
+        let ix = create_place_market_order_delegated_ix(delegated_params).unwrap();
+
+        assert_eq!(ix.program_id, *PHOENIX_PROGRAM_ID);
+        assert_eq!(ix.accounts.len(), 11);
+        assert_eq!(&ix.data[..8], &place_market_order_delegated_discriminant());
+        assert_eq!(&ix.data[8..], &normal_ix.data[8..]);
+        assert_eq!(ix.accounts[3].pubkey, trader_wallet);
+        assert!(ix.accounts[3].is_signer);
+        assert_eq!(ix.accounts[4].pubkey, permission_account);
+        assert!(ix.accounts[4].is_writable);
+        assert_eq!(ix.accounts[5].pubkey, trader_account);
+        assert_ne!(ix.accounts[3].pubkey, trader_authority);
+    }
+
+    #[test]
     fn test_builder_missing_required_field() {
         let result = MarketOrderParams::builder()
             .trader(Pubkey::new_unique())
@@ -487,5 +657,31 @@ mod tests {
             .build();
 
         assert!(matches!(result, Err(PhoenixIxError::MissingField(_))));
+    }
+
+    #[test]
+    fn test_delegated_builder_requires_trader_wallet() {
+        let market_order = MarketOrderParams::builder()
+            .trader(Pubkey::new_unique())
+            .trader_account(Pubkey::new_unique())
+            .perp_asset_map(Pubkey::new_unique())
+            .orderbook(Pubkey::new_unique())
+            .spline_collection(Pubkey::new_unique())
+            .global_trader_index(vec![Pubkey::new_unique()])
+            .active_trader_buffer(vec![Pubkey::new_unique()])
+            .side(Side::Bid)
+            .num_base_lots(1000)
+            .build()
+            .unwrap();
+
+        let result = MarketOrderDelegatedParams::builder()
+            .market_order(market_order)
+            .permission_account(Pubkey::new_unique())
+            .build();
+
+        assert!(matches!(
+            result,
+            Err(PhoenixIxError::MissingField("trader_wallet"))
+        ));
     }
 }

--- a/rust/sdk/examples/compute_trader_margin.rs
+++ b/rust/sdk/examples/compute_trader_margin.rs
@@ -163,23 +163,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let trader_key = TraderKey::from_authority(authority);
     let mut trader = Trader::new(trader_key.clone());
 
-    // Optionally fetch initial state via HTTP
-    match http_client.get_traders(&authority).await {
-        Ok(traders) => {
-            if let Some(view) = traders.into_iter().find(|t| t.trader_subaccount_index == 0) {
-                println!("  Found trader (PDA index: {})", view.trader_pda_index);
-                println!("  Positions: {}", view.positions.len());
-                println!("  Current Risk Tier: {:?}\n", view.risk_tier);
-            } else {
-                println!("  No primary subaccount found");
-                println!("  Will populate from WebSocket\n");
-            }
-        }
-        Err(e) => {
-            println!("  Could not fetch trader state: {}", e);
-            println!("  Will populate from WebSocket\n");
-        }
-    };
+    println!("  Trader state will populate from WebSocket\n");
 
     // Portfolio will be built from trader state updates
     let mut portfolio = TraderPortfolio::default();

--- a/rust/sdk/examples/http_client.rs
+++ b/rust/sdk/examples/http_client.rs
@@ -1,23 +1,20 @@
-//! Example: Query exchange keys, SOL market, and trader info via HTTP API.
+//! Example: Query exchange keys, SOL market, and trader history via HTTP API.
 //!
 //! Demonstrates the resource-based sub-client API:
 //!   client.markets().get_markets()
 //!   client.exchange().get_keys()
-//!   client.traders().get_trader(&authority)
 //!   etc.
 //!
 //! Run with:
 //!   export TRADER_PUBKEY=your_trader_pubkey  # optional
+//!   export AUTHORITY_PUBKEY=your_authority_pubkey  # optional
 //!   cargo run -p phoenix-rise --example http_client
-
-use std::str::FromStr;
 
 use phoenix_rise::{
     CandlesQueryParams, CollateralHistoryQueryParams, FundingHistoryQueryParams,
     OrderHistoryQueryParams, PhoenixHttpClient, PnlQueryParams, PnlResolution, Timeframe,
     TradeHistoryQueryParams,
 };
-use solana_pubkey::Pubkey;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -162,57 +159,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     println!();
 
-    // Fetch trader info (if TRADER_PUBKEY env var is set)
+    // Fetch trader history and analytics (if TRADER_PUBKEY env var is set)
     if let Ok(pubkey_str) = std::env::var("TRADER_PUBKEY") {
-        println!("=== Trader Subaccounts ===");
-        let authority = Pubkey::from_str(&pubkey_str)?;
-        let traders = client.traders().get_trader(&authority).await?;
-        println!("  Found {} subaccount(s)\n", traders.len());
-
-        for trader in &traders {
-            println!(
-                "  --- Subaccount {} (PDA index: {}) ---",
-                trader.trader_subaccount_index, trader.trader_pda_index
-            );
-            println!("  Trader Key:        {}", trader.trader_key);
-            println!("  State:             {:?}", trader.state);
-            println!("  Collateral:        {}", trader.collateral_balance.ui);
-            println!("  Portfolio Value:   {}", trader.portfolio_value.ui);
-            println!("  Unrealized PnL:    {}", trader.unrealized_pnl.ui);
-            println!("  Risk State:        {:?}", trader.risk_state);
-            println!("  Risk Tier:         {:?}", trader.risk_tier);
-
-            if !trader.positions.is_empty() {
-                println!("\n  Positions:");
-                for pos in &trader.positions {
-                    println!(
-                        "    {}: {} @ {} (uPnL: {})",
-                        pos.symbol, pos.position_size.ui, pos.entry_price.ui, pos.unrealized_pnl.ui
-                    );
-                }
-            }
-
-            let order_count: usize = trader.limit_orders.values().map(|v| v.len()).sum();
-            if order_count > 0 {
-                println!("\n  Limit Orders ({} total):", order_count);
-                for (symbol, orders) in &trader.limit_orders {
-                    for order in orders {
-                        println!(
-                            "    {}: {:?} {} @ {}",
-                            symbol, order.side, order.trade_size_remaining.ui, order.price.ui
-                        );
-                    }
-                }
-            }
-            println!();
-        }
+        let trader_pubkey = pubkey_str.parse()?;
 
         // Fetch trade history (fills) for this trader
         println!("=== Trade History ===");
         let params = TradeHistoryQueryParams::new().with_limit(10);
         let trades = client
             .trades()
-            .get_trader_trade_history(&authority, params)
+            .get_trader_trade_history(&trader_pubkey, params)
             .await?;
         println!("  Latest {} trades:", trades.data.len());
         for fill in &trades.data {
@@ -232,7 +188,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("  (more trades available via pagination)");
         }
 
-        // Fetch collateral history for this trader
+        // Demonstrate market filter for trades
+        println!("\n  Filtering trades by SOL market:");
+        let sol_params = TradeHistoryQueryParams::new()
+            .with_market_symbol("SOL")
+            .with_limit(5);
+        let sol_trades = client
+            .trades()
+            .get_trader_trade_history(&trader_pubkey, sol_params)
+            .await?;
+        println!("  Found {} SOL trades", sol_trades.data.len());
+        println!();
+    }
+
+    // Fetch authority-scoped history and analytics (if AUTHORITY_PUBKEY env var is
+    // set)
+    if let Ok(pubkey_str) = std::env::var("AUTHORITY_PUBKEY") {
+        let authority = pubkey_str.parse()?;
+
+        // Fetch collateral history for this authority
         println!("=== Collateral History ===");
         let params = CollateralHistoryQueryParams::new(10);
         let history = client
@@ -343,18 +317,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .get_trader_order_history(&authority, sol_params)
             .await?;
         println!("  Found {} SOL orders", sol_orders.data.len());
-        println!();
-
-        // Demonstrate market filter for trades
-        println!("\n  Filtering trades by SOL market:");
-        let sol_params = TradeHistoryQueryParams::new()
-            .with_market_symbol("SOL")
-            .with_limit(5);
-        let sol_trades = client
-            .trades()
-            .get_trader_trade_history(&authority, sol_params)
-            .await?;
-        println!("  Found {} SOL trades", sol_trades.data.len());
         println!();
     }
 

--- a/rust/sdk/src/api/exchange.rs
+++ b/rust/sdk/src/api/exchange.rs
@@ -9,11 +9,11 @@ pub struct ExchangeClient<'a> {
 
 impl ExchangeClient<'_> {
     pub async fn get_exchange(&self) -> Result<ExchangeResponse, PhoenixHttpError> {
-        self.http.get_json("/exchange").await
+        self.http.get_json("/v1/view/exchange").await
     }
 
     pub async fn get_keys(&self) -> Result<ExchangeKeysView, PhoenixHttpError> {
-        self.http.get_json("/exchange/keys").await
+        self.http.get_json("/v1/view/exchange/keys").await
     }
 
     pub async fn get_snapshot(&self) -> Result<ExchangeSnapshotView, PhoenixHttpError> {

--- a/rust/sdk/src/api/markets.rs
+++ b/rust/sdk/src/api/markets.rs
@@ -11,13 +11,13 @@ pub struct MarketsClient<'a> {
 
 impl MarketsClient<'_> {
     pub async fn get_markets(&self) -> Result<Vec<ExchangeMarketConfig>, PhoenixHttpError> {
-        self.http.get_json("/exchange/markets").await
+        self.http.get_json("/v1/view/exchange/markets").await
     }
 
     pub async fn get_market(&self, symbol: &str) -> Result<ExchangeMarketConfig, PhoenixHttpError> {
         let symbol_upper = symbol.to_ascii_uppercase();
         self.http
-            .get_json(&format!("/exchange/market/{}", symbol_upper))
+            .get_json(&format!("/v1/view/exchange/market/{}", symbol_upper))
             .await
     }
 
@@ -34,7 +34,7 @@ impl MarketsClient<'_> {
         let symbol_upper = symbol.to_ascii_uppercase();
         self.http
             .get_json_with_query(
-                &format!("/market/{}/orderbook", symbol_upper),
+                &format!("/v1/view/orderbook/{}", symbol_upper),
                 &Query { include_splines },
             )
             .await

--- a/rust/sdk/src/api/traders.rs
+++ b/rust/sdk/src/api/traders.rs
@@ -1,49 +1,21 @@
-use serde::Serialize;
 use solana_pubkey::Pubkey;
 
 use crate::http_client::HttpClientInner;
 use crate::phoenix_rise_types::{
-    PhoenixHttpError, PnlPoint, PnlQueryParams, TraderKey, TraderStateResponse, TraderView,
+    PhoenixHttpError, PnlPoint, PnlQueryParams, TraderKey, TraderView,
 };
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct TraderStateQuery {
-    pda_index: u8,
-}
 
 pub struct TradersClient<'a> {
     pub(crate) http: &'a HttpClientInner,
 }
 
 impl TradersClient<'_> {
-    pub async fn get_trader(
+    pub async fn get_trader_by_pubkey(
         &self,
-        authority: &Pubkey,
-    ) -> Result<Vec<TraderView>, PhoenixHttpError> {
-        self.get_trader_internal(authority, 0).await
-    }
-
-    pub async fn get_trader_internal(
-        &self,
-        authority: &Pubkey,
-        pda_index: u8,
-    ) -> Result<Vec<TraderView>, PhoenixHttpError> {
-        let resp = self.get_trader_state(authority, pda_index).await?;
-
-        Ok(resp.traders)
-    }
-
-    pub async fn get_trader_state(
-        &self,
-        authority: &Pubkey,
-        pda_index: u8,
-    ) -> Result<TraderStateResponse, PhoenixHttpError> {
+        trader_pubkey: &Pubkey,
+    ) -> Result<TraderView, PhoenixHttpError> {
         self.http
-            .get_json_with_query(
-                &format!("/trader/{authority}/state"),
-                &TraderStateQuery { pda_index },
-            )
+            .get_json(&format!("/v1/view/trader/{trader_pubkey}"))
             .await
     }
 
@@ -53,11 +25,13 @@ impl TradersClient<'_> {
         pda_index: u8,
         subaccount_index: u8,
     ) -> Result<Option<TraderView>, PhoenixHttpError> {
-        Ok(self
-            .get_trader_internal(authority, pda_index)
-            .await?
-            .into_iter()
-            .find(|trader| trader.trader_subaccount_index == subaccount_index))
+        let trader_key =
+            TraderKey::from_authority_with_idx(*authority, pda_index, subaccount_index);
+        match self.get_trader_by_pubkey(&trader_key.pda()).await {
+            Ok(trader) => Ok(Some(trader)),
+            Err(err) if err.status() == Some(404) => Ok(None),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn get_user_pnl(
@@ -94,18 +68,5 @@ impl TradersClient<'_> {
         params: PnlQueryParams,
     ) -> Result<Vec<PnlPoint>, PhoenixHttpError> {
         self.get_trader_pda_pnl(&trader_key.pda(), params).await
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn trader_state_request_uses_public_route_and_pda_index_query() {
-        assert_eq!(
-            serde_urlencoded::to_string(TraderStateQuery { pda_index: 7 }).unwrap(),
-            "pdaIndex=7"
-        );
     }
 }

--- a/rust/sdk/src/api/trades.rs
+++ b/rust/sdk/src/api/trades.rs
@@ -51,7 +51,7 @@ impl TradesClient<'_> {
         trader_pubkey: &Pubkey,
         params: TradeHistoryQueryParams,
     ) -> Result<TradeHistoryResponse, PhoenixHttpError> {
-        self.get_legacy_trader_trade_history(trader_pubkey, params)
+        self.get_trader_trade_history_by_pda(trader_pubkey, params)
             .await
     }
 
@@ -72,19 +72,6 @@ impl TradesClient<'_> {
         let query = trade_history_v2_query(&params, None);
         self.http
             .get_json_with_query(&format!("/v1/traders/{trader_pda}/trades_v2"), &query)
-            .await
-    }
-
-    async fn get_legacy_trader_trade_history(
-        &self,
-        trader_pubkey: &Pubkey,
-        params: TradeHistoryQueryParams,
-    ) -> Result<TradeHistoryResponse, PhoenixHttpError> {
-        self.http
-            .get_json_with_query(
-                &format!("/v1/trader/{trader_pubkey}/trades-history"),
-                &params,
-            )
             .await
     }
 }

--- a/rust/sdk/src/auth.rs
+++ b/rust/sdk/src/auth.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use async_trait::async_trait;
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use parking_lot::{Mutex as ParkingMutex, RwLock};
@@ -17,6 +18,7 @@ use solana_keypair::Keypair;
 #[cfg(feature = "solana-keypair")]
 use solana_signer::Signer as SolanaSigner;
 use thiserror::Error;
+use tokio::sync::Mutex as AsyncMutex;
 use url::Url;
 
 use crate::http_client::map_transport_error;
@@ -189,6 +191,24 @@ pub trait AuthSessionStore: Send + Sync {
     fn clear_session(&self) -> Result<(), AuthError>;
 }
 
+#[async_trait]
+pub trait PhoenixSessionManager: Send + Sync {
+    async fn current_session(&self) -> Result<Option<AuthSession>, PhoenixHttpError>;
+
+    async fn refresh_session(&self) -> Result<(), PhoenixHttpError>;
+
+    fn session_store(&self) -> Option<Arc<dyn AuthSessionStore>> {
+        None
+    }
+
+    async fn reload_session(
+        &self,
+        _current_session: Option<&AuthSession>,
+    ) -> Result<bool, PhoenixHttpError> {
+        Ok(false)
+    }
+}
+
 pub trait PhoenixAuthSigner: Send + Sync {
     fn client_id(&self) -> &str;
 
@@ -209,11 +229,196 @@ pub struct MemoryAuthSessionStore {
     session: Arc<ParkingMutex<Option<AuthSession>>>,
 }
 
+pub struct PhoenixMemorySessionManager {
+    auth_client: PhoenixServiceAuthClient,
+    session_store: Arc<dyn AuthSessionStore>,
+    session: AuthSession,
+    refresh_lock: AsyncMutex<()>,
+}
+
+impl PhoenixMemorySessionManager {
+    pub fn new(api_url: impl AsRef<str>, session: AuthSession) -> Result<Self, PhoenixHttpError> {
+        let session_store: Arc<dyn AuthSessionStore> = Arc::new(MemoryAuthSessionStore::new());
+        Self::with_session_store(api_url, session, session_store)
+    }
+
+    pub fn with_session_store(
+        api_url: impl AsRef<str>,
+        session: AuthSession,
+        session_store: Arc<dyn AuthSessionStore>,
+    ) -> Result<Self, PhoenixHttpError> {
+        let auth_client = PhoenixServiceAuthClient::new(api_url.as_ref(), session_store.clone())?;
+        Self::from_parts(auth_client, session_store, session)
+    }
+
+    fn from_parts(
+        auth_client: PhoenixServiceAuthClient,
+        session_store: Arc<dyn AuthSessionStore>,
+        session: AuthSession,
+    ) -> Result<Self, PhoenixHttpError> {
+        session_store
+            .store_session(&session)
+            .map_err(auth_error_to_http_error)?;
+
+        Ok(Self {
+            auth_client,
+            session_store,
+            session,
+            refresh_lock: AsyncMutex::new(()),
+        })
+    }
+
+    pub fn session(&self) -> AuthSession {
+        self.session.clone()
+    }
+
+    fn update_session(&self, session: &AuthSession) -> Result<(), PhoenixHttpError> {
+        self.session
+            .update_from_snapshot(session.snapshot())
+            .map_err(auth_error_to_http_error)?;
+        self.session_store
+            .store_session(&self.session)
+            .map_err(auth_error_to_http_error)
+    }
+
+    fn missing_refresh_error(&self) -> PhoenixHttpError {
+        let error = if self.session.refresh_token().is_none() {
+            AuthError::MissingRefreshToken
+        } else {
+            AuthError::RefreshExpired
+        };
+        auth_error_to_http_error(error)
+    }
+}
+
+#[async_trait]
+impl PhoenixSessionManager for PhoenixMemorySessionManager {
+    async fn current_session(&self) -> Result<Option<AuthSession>, PhoenixHttpError> {
+        Ok(Some(self.session.clone()))
+    }
+
+    fn session_store(&self) -> Option<Arc<dyn AuthSessionStore>> {
+        Some(self.session_store.clone())
+    }
+
+    async fn refresh_session(&self) -> Result<(), PhoenixHttpError> {
+        let refresh_candidate = self.session.snapshot();
+        let _guard = self.refresh_lock.lock().await;
+
+        if self.session.snapshot() != refresh_candidate {
+            return Ok(());
+        }
+
+        if !self.session.can_refresh() {
+            return Err(self.missing_refresh_error());
+        }
+
+        let session = self.auth_client.refresh_session().await?;
+        self.update_session(&session)
+    }
+
+    async fn reload_session(
+        &self,
+        current_session: Option<&AuthSession>,
+    ) -> Result<bool, PhoenixHttpError> {
+        let Some(loaded) = self
+            .session_store
+            .load_session()
+            .map_err(auth_error_to_http_error)?
+        else {
+            return Ok(false);
+        };
+
+        if current_session
+            .or(Some(&self.session))
+            .is_some_and(|current| sessions_match_for_reload(current, &loaded))
+        {
+            return Ok(false);
+        }
+
+        self.update_session(&loaded)?;
+        Ok(true)
+    }
+}
+
+#[cfg(feature = "solana-keypair")]
+pub struct PhoenixWalletSessionManager {
+    memory: PhoenixMemorySessionManager,
+    keypair: Arc<Keypair>,
+}
+
+#[cfg(feature = "solana-keypair")]
+impl PhoenixWalletSessionManager {
+    pub async fn login(
+        api_url: impl AsRef<str>,
+        keypair: Arc<Keypair>,
+    ) -> Result<Self, PhoenixHttpError> {
+        let session_store: Arc<dyn AuthSessionStore> = Arc::new(MemoryAuthSessionStore::new());
+        let auth_client = PhoenixServiceAuthClient::new(api_url.as_ref(), session_store.clone())?;
+        let session = if let Some(env_session) = AuthSession::from_env().map_err(|error| {
+            map_transport_error(PhoenixApiError::Authentication(error), None, None)
+        })? {
+            session_store.store_session(&env_session).map_err(|error| {
+                map_transport_error(PhoenixApiError::Authentication(error), None, None)
+            })?;
+            env_session
+        } else {
+            auth_client
+                .login_with_wallet_keypair(keypair.as_ref())
+                .await?
+        };
+        let memory = PhoenixMemorySessionManager::from_parts(auth_client, session_store, session)?;
+
+        Ok(Self { memory, keypair })
+    }
+
+    pub fn session(&self) -> AuthSession {
+        self.memory.session()
+    }
+
+    async fn reauthenticate(&self) -> Result<(), PhoenixHttpError> {
+        let session = self
+            .memory
+            .auth_client
+            .login_with_wallet_keypair(self.keypair.as_ref())
+            .await?;
+        self.memory.update_session(&session)
+    }
+}
+
+#[cfg(feature = "solana-keypair")]
+#[async_trait]
+impl PhoenixSessionManager for PhoenixWalletSessionManager {
+    async fn current_session(&self) -> Result<Option<AuthSession>, PhoenixHttpError> {
+        self.memory.current_session().await
+    }
+
+    fn session_store(&self) -> Option<Arc<dyn AuthSessionStore>> {
+        self.memory.session_store()
+    }
+
+    async fn refresh_session(&self) -> Result<(), PhoenixHttpError> {
+        match self.memory.refresh_session().await {
+            Ok(()) => Ok(()),
+            Err(error) if is_auth_recovery_error(&error) => self.reauthenticate().await,
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn reload_session(
+        &self,
+        current_session: Option<&AuthSession>,
+    ) -> Result<bool, PhoenixHttpError> {
+        self.memory.reload_session(current_session).await
+    }
+}
+
 #[derive(Default)]
 pub struct PhoenixHttpAuthConfig {
     pub initial_session: Option<AuthSession>,
     pub session_store: Option<Arc<dyn AuthSessionStore>>,
     pub signer: Option<Arc<dyn PhoenixAuthSigner>>,
+    pub session_manager: Option<Arc<dyn PhoenixSessionManager>>,
 }
 
 impl PhoenixHttpAuthConfig {
@@ -233,6 +438,11 @@ impl PhoenixHttpAuthConfig {
 
     pub fn with_signer(mut self, signer: Arc<dyn PhoenixAuthSigner>) -> Self {
         self.signer = Some(signer);
+        self
+    }
+
+    pub fn with_session_manager(mut self, manager: Arc<dyn PhoenixSessionManager>) -> Self {
+        self.session_manager = Some(manager);
         self
     }
 
@@ -259,12 +469,18 @@ impl PhoenixHttpAuthConfig {
     pub(crate) fn into_parts(self) -> PhoenixHttpAuthParts {
         let session_store = self
             .session_store
+            .or_else(|| {
+                self.session_manager
+                    .as_ref()
+                    .and_then(|manager| manager.session_store())
+            })
             .unwrap_or_else(|| Arc::new(MemoryAuthSessionStore::new()));
 
         PhoenixHttpAuthParts {
             initial_session: self.initial_session,
             session_store,
             signer: self.signer,
+            session_manager: self.session_manager,
         }
     }
 }
@@ -273,6 +489,7 @@ pub(crate) struct PhoenixHttpAuthParts {
     pub initial_session: Option<AuthSession>,
     pub session_store: Arc<dyn AuthSessionStore>,
     pub signer: Option<Arc<dyn PhoenixAuthSigner>>,
+    pub session_manager: Option<Arc<dyn PhoenixSessionManager>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1166,6 +1383,48 @@ fn body_preview(body: &str, max_chars: usize) -> String {
         preview.push_str("...");
     }
     preview
+}
+
+pub fn is_auth_recovery_error(error: &PhoenixHttpError) -> bool {
+    error.is_auth_error()
+        || matches!(error.status(), Some(401 | 403))
+        || matches!(
+            error.error_code(),
+            Some(
+                "missing_access_token"
+                    | "invalid_access_token"
+                    | "access_token_expired"
+                    | "access_jti_mismatch"
+                    | "session_missing"
+                    | "missing_refresh_token"
+                    | "invalid_refresh_token"
+                    | "refresh_expired"
+                    | "missing_pop_nonce"
+                    | "missing_pop_mac"
+                    | "missing_pop_binding"
+                    | "invalid_pop_nonce"
+                    | "invalid_pop_mac"
+                    | "invalid_pop_key"
+                    | "pop_binding_mismatch"
+                    | "pop_replay"
+                    | "pop_too_far_ahead"
+                    | "no_auth_session"
+            )
+        )
+}
+
+fn auth_error_to_http_error(error: AuthError) -> PhoenixHttpError {
+    map_transport_error(PhoenixApiError::Authentication(error), None, None)
+}
+
+fn sessions_match_for_reload(current_session: &AuthSession, loaded_session: &AuthSession) -> bool {
+    let mut current_snapshot = current_session.snapshot();
+    let mut loaded_snapshot = loaded_session.snapshot();
+    current_snapshot.access_expires_at = None;
+    current_snapshot.refresh_expires_at = None;
+    loaded_snapshot.access_expires_at = None;
+    loaded_snapshot.refresh_expires_at = None;
+    current_snapshot == loaded_snapshot
 }
 
 fn write_private_session_file(path: &Path, payload: &[u8]) -> Result<(), AuthError> {

--- a/rust/sdk/src/client.rs
+++ b/rust/sdk/src/client.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use futures_util::stream::{BoxStream, StreamExt};
 use parking_lot::Mutex;
 use solana_pubkey::Pubkey;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 use tokio_stream::StreamMap;
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -28,6 +28,7 @@ use crate::ws_client::{PhoenixWSClient, SubscriptionHandle, WsConnectionStatus};
 struct PhoenixClientInner {
     http_client: PhoenixHttpClient,
     cmd_tx: mpsc::UnboundedSender<ClientCommand>,
+    connection_status_rx: watch::Receiver<WsConnectionStatus>,
     task_handle: Mutex<Option<JoinHandle<()>>>,
 }
 
@@ -54,10 +55,33 @@ impl PhoenixClient {
         Self::from_env(PhoenixEnv::load()).await
     }
 
+    /// Create a new authenticated PhoenixClient from environment variables.
+    pub async fn new_from_env_with_auth() -> Result<Self, PhoenixClientError> {
+        Self::from_env_with_auth(PhoenixEnv::load()).await
+    }
+
     /// Create a new PhoenixClient from a [`PhoenixEnv`].
     pub async fn from_env(env: PhoenixEnv) -> Result<Self, PhoenixClientError> {
         let http_client =
             PhoenixHttpClient::from_env(env.clone()).map_err(PhoenixClientError::Http)?;
+        Self::from_env_with_http_client(env, http_client).await
+    }
+
+    /// Create a new authenticated PhoenixClient from a [`PhoenixEnv`].
+    pub async fn from_env_with_auth(env: PhoenixEnv) -> Result<Self, PhoenixClientError> {
+        let http_client =
+            PhoenixHttpClient::from_env_with_auth(env.clone()).map_err(PhoenixClientError::Http)?;
+        Self::from_env_with_http_client(env, http_client).await
+    }
+
+    /// Create a new PhoenixClient from an environment and HTTP client.
+    ///
+    /// If the HTTP client has auth configured, the WebSocket connection loop
+    /// uses the same auth lifecycle for handshake JWT refreshes.
+    pub async fn from_env_with_http_client(
+        env: PhoenixEnv,
+        http_client: PhoenixHttpClient,
+    ) -> Result<Self, PhoenixClientError> {
         let exchange_response = http_client
             .get_exchange()
             .await
@@ -65,9 +89,14 @@ impl PhoenixClient {
         let metadata = PhoenixMetadata::new(exchange_response.into());
 
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        let (connection_status_tx, connection_status_rx) = watch::channel(
+            WsConnectionStatus::Disconnected("not connected".to_string()),
+        );
+        let ws_http_client = http_client.clone();
         let inner = Arc::new(PhoenixClientInner {
             http_client,
             cmd_tx,
+            connection_status_rx,
             task_handle: Mutex::new(None),
         });
 
@@ -75,7 +104,13 @@ impl PhoenixClient {
             inner: Arc::clone(&inner),
         };
 
-        let task_handle = tokio::spawn(Self::connection_loop(env, cmd_rx, metadata));
+        let task_handle = tokio::spawn(Self::connection_loop(
+            env,
+            ws_http_client,
+            cmd_rx,
+            metadata,
+            connection_status_tx,
+        ));
         *client.inner.task_handle.lock() = Some(task_handle);
 
         Ok(client)
@@ -120,6 +155,16 @@ impl PhoenixClient {
         &self.inner.http_client
     }
 
+    /// Return the latest observed WebSocket connection status.
+    pub fn connection_status(&self) -> WsConnectionStatus {
+        self.inner.connection_status_rx.borrow().clone()
+    }
+
+    /// Subscribe to WebSocket connection status updates for this client.
+    pub fn subscribe_connection_status(&self) -> watch::Receiver<WsConnectionStatus> {
+        self.inner.connection_status_rx.clone()
+    }
+
     /// Signal the background task to shut down.
     pub fn shutdown(&self) {
         let _ = self.inner.cmd_tx.send(ClientCommand::Shutdown);
@@ -135,8 +180,10 @@ impl PhoenixClient {
 
     async fn connection_loop(
         env: PhoenixEnv,
+        http_client: PhoenixHttpClient,
         mut cmd_rx: mpsc::UnboundedReceiver<ClientCommand>,
         metadata: PhoenixMetadata,
+        connection_status_tx: watch::Sender<WsConnectionStatus>,
     ) {
         let mut runtime_state = RuntimeState::new(metadata);
         let mut logical_subscriptions: HashMap<ClientSubscriptionId, LogicalSubscription> =
@@ -150,14 +197,17 @@ impl PhoenixClient {
         const MAX_BACKOFF_MS: u64 = 30_000;
 
         'reconnect: loop {
-            let mut ws_client = match PhoenixWSClient::from_env_with_connection_status(env.clone())
-            {
+            let mut ws_client = match PhoenixWSClient::from_env_with_connection_status_and_auth(
+                env.clone(),
+                http_client.clone(),
+            ) {
                 Ok(client) => {
                     backoff_ms = 1_000;
                     client
                 }
                 Err(e) => {
                     error!("Failed to create WS client: {:?}", e);
+                    let _ = connection_status_tx.send(WsConnectionStatus::ConnectionFailed);
                     if !Self::wait_with_command_processing(
                         Duration::from_millis(backoff_ms),
                         &mut cmd_rx,
@@ -183,6 +233,9 @@ impl PhoenixClient {
                         "PhoenixWSClient missing status receiver; expected \
                          from_env_with_connection_status to enable it"
                     );
+                    let _ = connection_status_tx.send(WsConnectionStatus::Disconnected(
+                        "connection status unavailable".to_string(),
+                    ));
                     return;
                 }
             };
@@ -201,16 +254,29 @@ impl PhoenixClient {
             loop {
                 tokio::select! {
                     status = status_rx.recv() => {
-                        match status {
-                            Some(WsConnectionStatus::Connected) => {
-                                debug!("PhoenixClient WebSocket connected");
-                                backoff_ms = 1_000;
-                            }
-                            Some(WsConnectionStatus::Connecting) => {
-                                debug!("PhoenixClient WebSocket connecting");
-                            }
-                            Some(WsConnectionStatus::Disconnected(reason)) => {
-                                warn!("PhoenixClient WebSocket disconnected: {}", reason);
+                        if let Some(status) = status {
+                            let _ = connection_status_tx.send(status.clone());
+                            let should_reconnect = match status {
+                                WsConnectionStatus::Connected => {
+                                    debug!("PhoenixClient WebSocket connected");
+                                    backoff_ms = 1_000;
+                                    false
+                                }
+                                WsConnectionStatus::Connecting => {
+                                    debug!("PhoenixClient WebSocket connecting");
+                                    false
+                                }
+                                WsConnectionStatus::Disconnected(reason) => {
+                                    warn!("PhoenixClient WebSocket disconnected: {}", reason);
+                                    true
+                                }
+                                WsConnectionStatus::ConnectionFailed => {
+                                    warn!("PhoenixClient WebSocket connection failed");
+                                    true
+                                }
+                            };
+
+                            if should_reconnect {
                                 drop(ws_handles);
                                 if !Self::wait_with_command_processing(
                                     Duration::from_millis(backoff_ms),
@@ -226,28 +292,13 @@ impl PhoenixClient {
                                 backoff_ms = (backoff_ms * 2).min(MAX_BACKOFF_MS);
                                 continue 'reconnect;
                             }
-                            Some(WsConnectionStatus::ConnectionFailed) => {
-                                warn!("PhoenixClient WebSocket connection failed");
-                                drop(ws_handles);
-                                if !Self::wait_with_command_processing(
-                                    Duration::from_millis(backoff_ms),
-                                    &mut cmd_rx,
-                                    &runtime_state,
-                                    &mut logical_subscriptions,
-                                    &mut subscribers_by_key,
-                                    &mut dependency_refcounts,
-                                    &mut next_subscription_id,
-                                ).await {
-                                    return;
-                                }
-                                backoff_ms = (backoff_ms * 2).min(MAX_BACKOFF_MS);
-                                continue 'reconnect;
-                            }
-                            None => {
-                                warn!("PhoenixClient connection status channel closed");
-                                drop(ws_handles);
-                                continue 'reconnect;
-                            }
+                        } else {
+                            warn!("PhoenixClient connection status channel closed");
+                            let _ = connection_status_tx.send(WsConnectionStatus::Disconnected(
+                                "connection status channel closed".to_string(),
+                            ));
+                            drop(ws_handles);
+                            continue 'reconnect;
                         }
                     }
 

--- a/rust/sdk/src/env.rs
+++ b/rust/sdk/src/env.rs
@@ -42,6 +42,14 @@ pub struct PhoenixEnv {
 }
 
 impl PhoenixEnv {
+    /// Build environment configuration from an API URL, deriving the canonical
+    /// Phoenix WebSocket URL at `/v1/ws` under any configured path prefix.
+    pub fn from_api_url(api_url: impl Into<String>) -> Result<Self, PhoenixWsError> {
+        let api_url = api_url.into();
+        let ws_url = ws_url_from_api_url(&api_url)?;
+        Ok(Self { api_url, ws_url })
+    }
+
     /// Load configuration from environment variables.
     ///
     /// # Environment Variables
@@ -80,16 +88,32 @@ impl Default for PhoenixEnv {
 pub(crate) fn ws_url_from_api_url(api_url: &str) -> Result<String, PhoenixWsError> {
     let mut url = Url::parse(api_url)?;
 
-    // Convert http(s) to ws(s) by replacing "http" prefix with "ws"
-    let scheme = url.scheme();
-    if let Some(ws_scheme) = scheme.strip_prefix("http") {
-        let new_scheme = format!("ws{}", ws_scheme);
-        let _ = url.set_scheme(&new_scheme);
-    } else if scheme != "ws" && scheme != "wss" {
-        return Err(PhoenixWsError::UnsupportedUrlScheme(scheme.to_string()));
+    let scheme = url.scheme().to_ascii_lowercase();
+    match scheme.as_str() {
+        "http" => {
+            url.set_scheme("ws")
+                .map_err(|_| PhoenixWsError::UnsupportedUrlScheme(scheme.clone()))?;
+        }
+        "https" => {
+            url.set_scheme("wss")
+                .map_err(|_| PhoenixWsError::UnsupportedUrlScheme(scheme.clone()))?;
+        }
+        "ws" | "wss" => {}
+        _ => return Err(PhoenixWsError::UnsupportedUrlScheme(scheme)),
     }
 
-    url.set_path(DEFAULT_WS_PATH);
+    let path = url.path().trim_end_matches('/');
+    let ws_path = if path.ends_with(DEFAULT_WS_PATH) {
+        path.to_string()
+    } else if path.ends_with("/v1") {
+        format!("{path}/ws")
+    } else if path.is_empty() || path == "/" {
+        DEFAULT_WS_PATH.to_string()
+    } else {
+        format!("{path}{DEFAULT_WS_PATH}")
+    };
+
+    url.set_path(&ws_path);
     url.set_query(None);
     url.set_fragment(None);
 
@@ -117,6 +141,13 @@ mod tests {
     }
 
     #[test]
+    fn test_from_api_url_derives_ws_url() {
+        let env = PhoenixEnv::from_api_url("http://localhost:8080").unwrap();
+        assert_eq!(env.api_url, "http://localhost:8080");
+        assert_eq!(env.ws_url, "ws://localhost:8080/v1/ws");
+    }
+
+    #[test]
     fn test_ws_url_from_https_api_url_appends_ws() {
         let ws_url = ws_url_from_api_url("https://perp-api.phoenix.trade").unwrap();
         assert_eq!(ws_url, "wss://perp-api.phoenix.trade/v1/ws");
@@ -135,6 +166,12 @@ mod tests {
     }
 
     #[test]
+    fn test_ws_url_preserves_path_prefix() {
+        let ws_url = ws_url_from_api_url("https://gateway.example.com/phoenix").unwrap();
+        assert_eq!(ws_url, "wss://gateway.example.com/phoenix/v1/ws");
+    }
+
+    #[test]
     fn test_ws_url_handles_trailing_slash() {
         let ws_url = ws_url_from_api_url("https://perp-api.phoenix.trade/").unwrap();
         assert_eq!(ws_url, "wss://perp-api.phoenix.trade/v1/ws");
@@ -142,7 +179,7 @@ mod tests {
 
     #[test]
     fn test_ws_url_does_not_double_append_ws() {
-        let ws_url = ws_url_from_api_url("https://perp-api.phoenix.trade/ws").unwrap();
+        let ws_url = ws_url_from_api_url("https://perp-api.phoenix.trade/v1/ws").unwrap();
         assert_eq!(ws_url, "wss://perp-api.phoenix.trade/v1/ws");
     }
 }

--- a/rust/sdk/src/exchange_cache.rs
+++ b/rust/sdk/src/exchange_cache.rs
@@ -30,6 +30,7 @@ pub enum ExchangeCacheMarketChangeKind {
     LeverageTiers,
     MarkPriceParameters,
     OpenInterestCap,
+    MaxLiquidationSize,
     UpnlRiskFactor,
     UpnlRiskFactorForWithdrawals,
     FundingParameters,
@@ -366,6 +367,9 @@ fn apply_market_parameter_update(
         ExchangeMarketParameterUpdate::OpenInterestCapUpdated { new_base_lots, .. } => {
             market.open_interest_cap_base_lots = *new_base_lots;
         }
+        ExchangeMarketParameterUpdate::MaxLiquidationSizeUpdated { new_base_lots, .. } => {
+            market.max_liquidation_size_base_lots = *new_base_lots;
+        }
         ExchangeMarketParameterUpdate::UpnlRiskFactorUpdated { new, new_bps, .. } => {
             market.risk_factors.upnl = *new;
             market.risk_factors.upnl_bps = (*new_bps).or_else(|| percent_to_basis_points(*new));
@@ -420,6 +424,9 @@ fn market_change_kind(
         }
         ExchangeMarketParameterUpdate::OpenInterestCapUpdated { .. } => {
             Some(ExchangeCacheMarketChangeKind::OpenInterestCap)
+        }
+        ExchangeMarketParameterUpdate::MaxLiquidationSizeUpdated { .. } => {
+            Some(ExchangeCacheMarketChangeKind::MaxLiquidationSize)
         }
         ExchangeMarketParameterUpdate::UpnlRiskFactorUpdated { .. } => {
             Some(ExchangeCacheMarketChangeKind::UpnlRiskFactor)

--- a/rust/sdk/src/flight_client.rs
+++ b/rust/sdk/src/flight_client.rs
@@ -10,8 +10,9 @@ use solana_pubkey::Pubkey;
 use crate::phoenix_rise_ix::flight::{ProxyInstructionParams, create_proxy_instruction_ix};
 use crate::phoenix_rise_ix::{
     PhoenixIxError, place_attached_conditional_order_discriminant, place_limit_order_discriminant,
-    place_limit_order_with_conditionals_discriminant, place_market_order_discriminant,
-    place_position_conditional_order_discriminant, place_stop_loss_discriminant,
+    place_limit_order_with_conditionals_discriminant, place_market_order_delegated_discriminant,
+    place_market_order_discriminant, place_position_conditional_order_discriminant,
+    place_stop_loss_discriminant,
 };
 use crate::phoenix_rise_types::TraderKey;
 
@@ -78,6 +79,7 @@ impl PhoenixFlightClient {
 pub fn is_flight_routable_instruction(ix: &Instruction) -> bool {
     has_discriminant(&ix.data, &place_limit_order_discriminant())
         || has_discriminant(&ix.data, &place_market_order_discriminant())
+        || has_discriminant(&ix.data, &place_market_order_delegated_discriminant())
         || has_discriminant(&ix.data, &place_stop_loss_discriminant())
         || has_discriminant(&ix.data, &place_position_conditional_order_discriminant())
         || has_discriminant(&ix.data, &place_attached_conditional_order_discriminant())
@@ -193,6 +195,9 @@ mod tests {
         assert!(is_flight_routable_instruction(&build_sample_limit_ix()));
         assert!(is_flight_routable_instruction(&build_sample_phoenix_ix(
             place_market_order_discriminant()
+        )));
+        assert!(is_flight_routable_instruction(&build_sample_phoenix_ix(
+            place_market_order_delegated_discriminant()
         )));
         assert!(is_flight_routable_instruction(&build_sample_phoenix_ix(
             place_stop_loss_discriminant()

--- a/rust/sdk/src/http_client.rs
+++ b/rust/sdk/src/http_client.rs
@@ -10,6 +10,8 @@ use std::time::Duration;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use solana_instruction::Instruction;
+#[cfg(feature = "solana-keypair")]
+use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use tracing::debug;
 
@@ -18,9 +20,11 @@ use crate::api::{
     CandlesClient, CollateralClient, ExchangeClient, FundingClient, InviteClient, MarketsClient,
     OrdersClient, TradersClient, TradesClient,
 };
+#[cfg(feature = "solana-keypair")]
+use crate::auth::PhoenixWalletSessionManager;
 use crate::auth::{
     AuthError, AuthSession, AuthSessionStore, PhoenixAuthSigner, PhoenixHttpAuthConfig,
-    PhoenixServiceAuthClient,
+    PhoenixServiceAuthClient, PhoenixSessionManager,
 };
 use crate::auth_lifecycle::{AuthLifecycleError, AuthLifecycleState};
 use crate::env::PhoenixEnv;
@@ -36,8 +40,8 @@ use crate::phoenix_rise_types::{
     PlaceIsolatedLimitOrderRequest, PlaceIsolatedLimitOrderWithConditionalsRequest,
     PlaceIsolatedMarketOrderRequest, PlacePositionConditionalOrderRequest,
     PlaceStopLossOrderRequest, PnlPoint, PnlQueryParams, TradeHistoryQueryParams,
-    TradeHistoryResponse, TraderKey, TraderStateResponse, TraderView,
-    UserLiquidationHistoryQueryParams, UserLiquidationHistoryResponse,
+    TradeHistoryResponse, TraderKey, UserLiquidationHistoryQueryParams,
+    UserLiquidationHistoryResponse,
 };
 use crate::transport::{PhoenixApiClient, PhoenixApiError};
 
@@ -121,6 +125,34 @@ impl HttpClientInner {
 
     pub fn auth_lifecycle_last_error(&self) -> Option<AuthLifecycleError> {
         self.transport.auth_lifecycle_last_error()
+    }
+
+    pub(crate) async fn auth_session_for_request(
+        &self,
+    ) -> Result<Option<AuthSession>, PhoenixHttpError> {
+        self.transport
+            .auth_session_for_request()
+            .await
+            .map_err(|error| {
+                map_transport_error(
+                    error,
+                    Some(self.auth_lifecycle_state()),
+                    self.auth_lifecycle_last_error(),
+                )
+            })
+    }
+
+    pub(crate) async fn refresh_auth_session(&self) -> Result<(), PhoenixHttpError> {
+        self.transport
+            .refresh_auth_session()
+            .await
+            .map_err(|error| {
+                map_transport_error(
+                    error,
+                    Some(self.auth_lifecycle_state()),
+                    self.auth_lifecycle_last_error(),
+                )
+            })
     }
 
     async fn execute_with_rate_limit_retry<T, F, Fut>(
@@ -240,6 +272,16 @@ impl PhoenixHttpClientBuilder {
         self
     }
 
+    pub fn with_session_manager(mut self, manager: Arc<dyn PhoenixSessionManager>) -> Self {
+        let auth = self
+            .auth
+            .take()
+            .unwrap_or_default()
+            .with_session_manager(manager);
+        self.auth = Some(auth);
+        self
+    }
+
     pub fn with_rate_limit_retry_config(mut self, config: RateLimitRetryConfig) -> Self {
         self.rate_limit_retry = config;
         self
@@ -279,6 +321,9 @@ impl PhoenixHttpClientBuilder {
                 transport_builder.with_auth_session_store(parts.session_store.clone());
             if let Some(signer) = parts.signer.clone() {
                 transport_builder = transport_builder.with_auth_signer(signer);
+            }
+            if let Some(manager) = parts.session_manager.clone() {
+                transport_builder = transport_builder.with_session_manager(manager);
             }
         }
         let transport = transport_builder
@@ -370,6 +415,19 @@ impl PhoenixHttpClient {
         Self::builder(api_url).build()
     }
 
+    /// Creates an HTTP client backed by a wallet session manager.
+    #[cfg(feature = "solana-keypair")]
+    pub async fn from_url_with_wallet_keypair(
+        api_url: impl AsRef<str>,
+        keypair: Arc<Keypair>,
+    ) -> Result<Self, PhoenixHttpError> {
+        let api_url = api_url.as_ref();
+        let session_manager = PhoenixWalletSessionManager::login(api_url, keypair).await?;
+        Self::builder(api_url)
+            .with_session_manager(Arc::new(session_manager))
+            .build()
+    }
+
     /// Creates a new unauthenticated HTTP client.
     pub fn new_public(api_url: impl Into<String>) -> Result<Self, PhoenixHttpError> {
         Self::builder(api_url).build()
@@ -418,6 +476,16 @@ impl PhoenixHttpClient {
         self.inner.get_json_with_query(path, query).await
     }
 
+    /// POST a typed JSON request and response using the client's configured
+    /// auth behavior.
+    pub async fn post_json<T: DeserializeOwned, B: Serialize>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<T, PhoenixHttpError> {
+        self.inner.post_json(path, body).await
+    }
+
     /// Returns the optional shared auth client when auth was enabled for this
     /// HTTP client.
     pub fn auth(&self) -> Option<&PhoenixServiceAuthClient> {
@@ -430,6 +498,16 @@ impl PhoenixHttpClient {
 
     pub fn auth_lifecycle_last_error(&self) -> Option<AuthLifecycleError> {
         self.inner.auth_lifecycle_last_error()
+    }
+
+    pub(crate) async fn auth_session_for_request(
+        &self,
+    ) -> Result<Option<AuthSession>, PhoenixHttpError> {
+        self.inner.auth_session_for_request().await
+    }
+
+    pub(crate) async fn refresh_auth_session(&self) -> Result<(), PhoenixHttpError> {
+        self.inner.refresh_auth_session().await
     }
 
     // --- Resource sub-client accessors ---
@@ -518,21 +596,6 @@ impl PhoenixHttpClient {
 
     pub async fn get_exchange_snapshot(&self) -> Result<ExchangeSnapshotView, PhoenixHttpError> {
         self.exchange().get_snapshot().await
-    }
-
-    pub async fn get_traders(
-        &self,
-        authority: &Pubkey,
-    ) -> Result<Vec<TraderView>, PhoenixHttpError> {
-        self.traders().get_trader(authority).await
-    }
-
-    pub async fn get_trader_state(
-        &self,
-        authority: &Pubkey,
-        pda_index: u8,
-    ) -> Result<TraderStateResponse, PhoenixHttpError> {
-        self.traders().get_trader_state(authority, pda_index).await
     }
 
     pub async fn get_collateral_history(
@@ -928,6 +991,7 @@ pub(crate) fn map_transport_error(
             message: error.to_string(),
             error_code: auth_error_code(&error),
         },
+        PhoenixApiError::SessionManager(error) => error,
         other => PhoenixHttpError::ParseFailed(other.to_string()),
     }
 }

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -85,11 +85,14 @@ pub use api::{
     CandlesClient, CollateralClient, ExchangeClient, FundingClient, InviteClient, MarketsClient,
     OrdersClient, TradersClient, TradesClient,
 };
+#[cfg(feature = "solana-keypair")]
+pub use auth::PhoenixWalletSessionManager;
 pub use auth::{
     AuthError, AuthSession, AuthSessionSnapshot, AuthSessionStore, FileAuthSessionStore,
-    MemoryAuthSessionStore, PhoenixAuthSigner, PhoenixHttpAuthConfig, PhoenixServiceAuthClient,
-    PhoenixServiceChallenge, PhoenixServiceLoginRequest, PhoenixWalletNonce,
-    PhoenixWalletNonceRequest, PhoenixWalletTransactionChallenge, default_auth_session_store_path,
+    MemoryAuthSessionStore, PhoenixAuthSigner, PhoenixHttpAuthConfig, PhoenixMemorySessionManager,
+    PhoenixServiceAuthClient, PhoenixServiceChallenge, PhoenixServiceLoginRequest,
+    PhoenixSessionManager, PhoenixWalletNonce, PhoenixWalletNonceRequest,
+    PhoenixWalletTransactionChallenge, default_auth_session_store_path, is_auth_recovery_error,
 };
 pub use auth_lifecycle::{AuthLifecycleError, AuthLifecycleErrorReason, AuthLifecycleState};
 #[cfg(feature = "ed25519-dalek")]
@@ -121,13 +124,13 @@ pub use ws_client::{PhoenixWSClient, SubscriptionHandle, WsConnectionStatus};
 pub use crate::phoenix_rise_ix::{
     CancelConditionalOrderParams, CancelId, CancelStopLossParams, CondensedOrder,
     CreateConditionalOrdersAccountParams, Direction, FifoOrderId, IsolatedCollateralFlow,
-    IsolatedLimitOrderParams, IsolatedMarketOrderParams, MultiLimitOrderParams,
-    OnboardTraderDelegatedParams, OrderFlags, PlaceAttachedConditionalOrderParams,
-    PlaceLimitOrderWithConditionalsParams, PlacePositionConditionalOrderParams,
-    RegisterTraderParams, SelfTradeBehavior, Side, StopLossOrderKind, TransferCollateralParams,
-    TriggerOrderParams, get_conditional_orders_address, get_permission_address,
-    phoenix_global_configuration, phoenix_instruction_addresses, phoenix_log_authority,
-    phoenix_program_id, resolve_phoenix_instruction_addresses_for_env,
+    IsolatedLimitOrderParams, IsolatedMarketOrderParams, MarketOrderDelegatedParams,
+    MultiLimitOrderParams, OnboardTraderDelegatedParams, OrderFlags,
+    PlaceAttachedConditionalOrderParams, PlaceLimitOrderWithConditionalsParams,
+    PlacePositionConditionalOrderParams, RegisterTraderParams, SelfTradeBehavior, Side,
+    StopLossOrderKind, TransferCollateralParams, TriggerOrderParams,
+    get_conditional_orders_address, phoenix_global_configuration, phoenix_instruction_addresses,
+    phoenix_log_authority, phoenix_program_id, resolve_phoenix_instruction_addresses_for_env,
 };
 // Re-export useful types from the types crate
 pub use crate::phoenix_rise_types::{

--- a/rust/sdk/src/transport.rs
+++ b/rust/sdk/src/transport.rs
@@ -11,11 +11,12 @@ use url::Url;
 
 use crate::auth::{
     AuthError, AuthResponseBody, AuthSession, AuthSessionStore, PhoenixAuthSigner,
-    RefreshRequestBody, login_with_auth_signer,
+    PhoenixSessionManager, RefreshRequestBody, login_with_auth_signer,
 };
 use crate::auth_lifecycle::{
     AuthLifecycleController, AuthLifecycleError, AuthLifecycleErrorReason, AuthLifecycleState,
 };
+use crate::phoenix_rise_types::PhoenixHttpError;
 
 const ACCESS_REFRESH_WINDOW: Duration = Duration::from_secs(60);
 pub(crate) const PHOENIX_CLIENT_HEADER_VALUE: &str = concat!(
@@ -105,6 +106,9 @@ pub(crate) enum PhoenixApiError {
 
     #[error("authentication error: {0}")]
     Authentication(#[from] AuthError),
+
+    #[error("session manager error: {0}")]
+    SessionManager(#[from] PhoenixHttpError),
 }
 
 impl PhoenixApiError {
@@ -140,6 +144,7 @@ pub(crate) struct PhoenixApiClient {
     auth_session: Option<AuthSession>,
     auth_session_store: Option<Arc<dyn AuthSessionStore>>,
     auth_signer: Option<Arc<dyn PhoenixAuthSigner>>,
+    session_manager: Option<Arc<dyn PhoenixSessionManager>>,
     auth_lifecycle: Arc<Mutex<AuthLifecycleController>>,
 }
 
@@ -149,6 +154,7 @@ pub(crate) struct PhoenixApiClientBuilder {
     auth_session: Option<AuthSession>,
     auth_session_store: Option<Arc<dyn AuthSessionStore>>,
     auth_signer: Option<Arc<dyn PhoenixAuthSigner>>,
+    session_manager: Option<Arc<dyn PhoenixSessionManager>>,
 }
 
 impl PhoenixApiClient {
@@ -162,6 +168,40 @@ impl PhoenixApiClient {
 
     pub(crate) fn auth_lifecycle_last_error(&self) -> Option<AuthLifecycleError> {
         self.auth_lifecycle.lock().last_error().cloned()
+    }
+
+    pub(crate) async fn auth_session_for_request(
+        &self,
+    ) -> Result<Option<AuthSession>, PhoenixApiError> {
+        self.maybe_refresh_before_request().await?;
+
+        match self.current_auth_session().await? {
+            Some(session) if !access_expires_at_is_expired(&session) => Ok(Some(session)),
+            Some(session) => {
+                if session.can_refresh()
+                    || self.auth_signer.is_some()
+                    || self.session_manager.is_some()
+                {
+                    self.refresh_session().await?;
+                    return self.current_auth_session().await.map(|session| {
+                        session.filter(|session| !access_expires_at_is_expired(session))
+                    });
+                }
+
+                Ok(None)
+            }
+            None if self.auth_signer.is_some() || self.session_manager.is_some() => {
+                self.refresh_session().await?;
+                self.current_auth_session()
+                    .await
+                    .map(|session| session.filter(|session| !access_expires_at_is_expired(session)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    pub(crate) async fn refresh_auth_session(&self) -> Result<(), PhoenixApiError> {
+        self.refresh_session().await
     }
 
     pub(crate) async fn get_json_typed<T: DeserializeOwned>(
@@ -247,7 +287,7 @@ impl PhoenixApiClient {
         let mut allow_store_reload = allow_auth_retry;
 
         loop {
-            let session = self.current_auth_session()?;
+            let session = self.current_auth_session().await?;
             let valid_session = session
                 .as_ref()
                 .filter(|session| !access_expires_at_is_expired(session));
@@ -269,7 +309,8 @@ impl PhoenixApiClient {
 
             let can_retry_auth = valid_session.is_some()
                 || self.auth_session_store.is_some()
-                || self.auth_signer.is_some();
+                || self.auth_signer.is_some()
+                || self.session_manager.is_some();
 
             if allow_auth_retry && status == StatusCode::UNAUTHORIZED && can_retry_auth {
                 if allow_store_reload
@@ -295,14 +336,15 @@ impl PhoenixApiClient {
     }
 
     async fn maybe_refresh_before_request(&self) -> Result<(), PhoenixApiError> {
-        let Some(session) = self.current_auth_session()? else {
+        let Some(session) = self.current_auth_session().await? else {
             return Ok(());
         };
         let should_rotate_access_token = session
             .access_expires_at()
             .map(|expires_at| expires_at <= Instant::now() + ACCESS_REFRESH_WINDOW)
             .unwrap_or(false);
-        let can_renew_session = session.can_refresh() || self.auth_signer.is_some();
+        let can_renew_session =
+            session.can_refresh() || self.auth_signer.is_some() || self.session_manager.is_some();
 
         if !should_rotate_access_token || !can_renew_session {
             return Ok(());
@@ -344,7 +386,11 @@ impl PhoenixApiClient {
             .map_err(|error| map_reqwest_error(error, Some(url_string)))
     }
 
-    fn current_auth_session(&self) -> Result<Option<AuthSession>, PhoenixApiError> {
+    async fn current_auth_session(&self) -> Result<Option<AuthSession>, PhoenixApiError> {
+        if let Some(manager) = &self.session_manager {
+            return manager.current_session().await.map_err(Into::into);
+        }
+
         if let Some(session) = &self.auth_session {
             return Ok(Some(session.clone()));
         }
@@ -362,9 +408,26 @@ impl PhoenixApiClient {
     }
 
     async fn refresh_session(&self) -> Result<(), PhoenixApiError> {
+        if let Some(manager) = &self.session_manager {
+            self.auth_lifecycle.lock().on_refresh_started();
+            return match manager.refresh_session().await {
+                Ok(()) => {
+                    self.auth_lifecycle.lock().on_refresh_succeeded(true);
+                    Ok(())
+                }
+                Err(error) => {
+                    self.auth_lifecycle.lock().on_refresh_failed(
+                        AuthLifecycleErrorReason::RefreshFailed,
+                        Some(error.to_string()),
+                    );
+                    Err(error.into())
+                }
+            };
+        }
+
         self.auth_lifecycle.lock().on_refresh_started();
 
-        let Some(session) = self.current_auth_session()? else {
+        let Some(session) = self.current_auth_session().await? else {
             return self
                 .reauthenticate_or_fail(
                     AuthLifecycleErrorReason::NoSession,
@@ -543,6 +606,13 @@ impl PhoenixApiClient {
         &self,
         current_session: Option<&AuthSession>,
     ) -> Result<bool, PhoenixApiError> {
+        if let Some(manager) = &self.session_manager {
+            return manager
+                .reload_session(current_session)
+                .await
+                .map_err(Into::into);
+        }
+
         let Some(store) = &self.auth_session_store else {
             return Ok(false);
         };
@@ -600,6 +670,7 @@ impl PhoenixApiClientBuilder {
             auth_session: None,
             auth_session_store: None,
             auth_signer: None,
+            session_manager: None,
         }
     }
 
@@ -618,6 +689,11 @@ impl PhoenixApiClientBuilder {
         self
     }
 
+    pub(crate) fn with_session_manager(mut self, manager: Arc<dyn PhoenixSessionManager>) -> Self {
+        self.session_manager = Some(manager);
+        self
+    }
+
     pub(crate) fn build(self) -> Result<PhoenixApiClient, PhoenixApiError> {
         let client = match self.client {
             Some(client) => client,
@@ -626,6 +702,7 @@ impl PhoenixApiClientBuilder {
         };
         let base_url = normalize_base_url(Url::parse(&self.api_url)?);
         let has_session = self.auth_session.is_some();
+        let has_session_manager = self.session_manager.is_some();
 
         Ok(PhoenixApiClient {
             client,
@@ -633,7 +710,10 @@ impl PhoenixApiClientBuilder {
             auth_session: self.auth_session,
             auth_session_store: self.auth_session_store,
             auth_signer: self.auth_signer,
-            auth_lifecycle: Arc::new(Mutex::new(AuthLifecycleController::new(has_session))),
+            session_manager: self.session_manager,
+            auth_lifecycle: Arc::new(Mutex::new(AuthLifecycleController::new(
+                has_session || has_session_manager,
+            ))),
         })
     }
 }

--- a/rust/sdk/src/tx_builder.rs
+++ b/rust/sdk/src/tx_builder.rs
@@ -19,8 +19,8 @@ use crate::phoenix_rise_ix::{
     CancelId, CancelOrdersByIdParams, CancelStopLossParams, CondensedOrder,
     CreateConditionalOrdersAccountParams, DepositFundsParams, Direction, EmberDepositParams,
     EmberWithdrawParams, IsolatedCollateralFlow, IsolatedLimitOrderParams,
-    IsolatedMarketOrderParams, LimitOrderParams, MarketOrderParams, MultiLimitOrderParams,
-    OrderPacket, PHOENIX_PROGRAM_ID, PlaceLimitOrderWithConditionalsParams,
+    IsolatedMarketOrderParams, LimitOrderParams, MarketOrderDelegatedParams, MarketOrderParams,
+    MultiLimitOrderParams, OrderPacket, PHOENIX_PROGRAM_ID, PlaceLimitOrderWithConditionalsParams,
     PlacePositionConditionalOrderParams, PlaceStopLossParams, RegisterTraderParams, Side,
     SplApproveParams, StopLossOrderKind, SyncParentToChildParams,
     TransferCollateralChildToParentParams, TransferCollateralParams, TriggerOrderParams, USDC_MINT,
@@ -28,12 +28,13 @@ use crate::phoenix_rise_ix::{
     create_cancel_orders_by_id_ix, create_cancel_stop_loss_ix,
     create_create_conditional_orders_account_ix, create_deposit_funds_ix, create_ember_deposit_ix,
     create_ember_withdraw_ix, create_place_limit_order_ix,
-    create_place_limit_order_with_conditionals_ix, create_place_market_order_ix,
-    create_place_multi_limit_order_ix, create_place_position_conditional_order_ix,
-    create_place_stop_loss_ix, create_register_trader_ix, create_spl_approve_ix,
-    create_sync_parent_to_child_ix, create_transfer_collateral_child_to_parent_ix,
-    create_transfer_collateral_ix, create_withdraw_funds_ix, get_associated_token_address,
-    get_conditional_orders_address, get_ember_state_address, get_stop_loss_address,
+    create_place_limit_order_with_conditionals_ix, create_place_market_order_delegated_ix,
+    create_place_market_order_ix, create_place_multi_limit_order_ix,
+    create_place_position_conditional_order_ix, create_place_stop_loss_ix,
+    create_register_trader_ix, create_spl_approve_ix, create_sync_parent_to_child_ix,
+    create_transfer_collateral_child_to_parent_ix, create_transfer_collateral_ix,
+    create_withdraw_funds_ix, get_associated_token_address, get_conditional_orders_address,
+    get_ember_state_address, get_stop_loss_address,
 };
 use crate::phoenix_rise_math::{MathError, WrapperNum};
 use crate::phoenix_rise_types::accounts::StopLosses;
@@ -96,6 +97,11 @@ pub enum PhoenixTxBuilderError {
          leg sizes or use position conditionals after fill"
     )]
     UnsupportedLimitBracketLegSizing,
+
+    /// Delegated market-order builder only constructs the delegated market
+    /// order instruction, not follow-on conditional-order legs.
+    #[error("Delegated market orders do not support bracket legs in the local tx builder")]
+    UnsupportedDelegatedMarketOrderBrackets,
 }
 
 pub(crate) struct ParsedAddresses {
@@ -226,6 +232,50 @@ impl<'a> PhoenixTxBuilder<'a> {
             return self.create_bracket_market_order_ixs(params, &bracket).await;
         }
         self.create_market_order_ixs(params)
+    }
+
+    /// Build a delegated market order from a trader-facing ticket.
+    ///
+    /// `ticket.authority()` identifies the trader account authority for
+    /// PDA/metadata resolution. `trader_wallet` is the signing wallet. Pass
+    /// `None` for `permission_account` only when `trader_wallet` is the trader
+    /// account authority or primary position authority; this puts
+    /// `trader_wallet` itself in the permission-account slot. A
+    /// secondary/delegated wallet needs an actual
+    /// permission account bridging it to the trader account authority.
+    pub fn place_market_order_delegated(
+        &self,
+        ticket: MarketOrderTicket,
+        trader_wallet: Pubkey,
+        permission_account: Option<Pubkey>,
+    ) -> Result<Vec<Instruction>, PhoenixTxBuilderError> {
+        if ticket
+            .bracket_leg_ticket()
+            .is_some_and(|bracket| !bracket.is_empty())
+        {
+            return Err(PhoenixTxBuilderError::UnsupportedDelegatedMarketOrderBrackets);
+        }
+
+        let market_order = ticket.to_params(self.order_ticket_metadata(ticket.symbol())?)?;
+        let params = MarketOrderDelegatedParams::builder()
+            .market_order(market_order)
+            .trader_wallet(trader_wallet)
+            .permission_account(permission_account.unwrap_or(trader_wallet))
+            .build()?;
+        self.build_market_order_delegated_with_params(params)
+    }
+
+    /// Build a delegated market-order instruction with pre-built params.
+    pub fn build_market_order_delegated_with_params(
+        &self,
+        params: MarketOrderDelegatedParams,
+    ) -> Result<Vec<Instruction>, PhoenixTxBuilderError> {
+        if params.market_order().subaccount_index() == CROSS_MARGIN_SUBACCOUNT_IDX {
+            self.reject_isolated_only(params.market_order().symbol())?;
+        }
+
+        let ix = create_place_market_order_delegated_ix(params)?;
+        Ok(vec![ix.into()])
     }
 
     /// Build a limit order from a trader-facing ticket, optionally attaching
@@ -1673,6 +1723,7 @@ mod tests {
     use crate::order_tickets::BracketLeg;
     use crate::phoenix_rise_ix::{
         OrderFlags, PHOENIX_GLOBAL_CONFIGURATION, PHOENIX_LOG_AUTHORITY, get_ember_vault_address,
+        place_market_order_delegated_discriminant,
     };
     use crate::phoenix_rise_math::{MarketCalculator, QuoteLotsPerBaseLotPerTick};
     use crate::phoenix_rise_types::{
@@ -1768,6 +1819,37 @@ mod tests {
         assert_eq!(params.price_in_ticks(), None);
         assert_eq!(params.order_flags(), OrderFlags::None);
         assert_eq!(params.subaccount_index(), CROSS_MARGIN_SUBACCOUNT_IDX);
+    }
+
+    #[test]
+    fn test_place_market_order_delegated_builds_distinct_ix() {
+        let metadata = mock_metadata("SOL");
+        let builder = PhoenixTxBuilder::new(&metadata);
+        let authority = Pubkey::new_unique();
+        let trader_wallet = Pubkey::new_unique();
+        let trader_account = Pubkey::new_unique();
+        let ticket = MarketOrderTicket::builder()
+            .authority(authority)
+            .trader_account(trader_account)
+            .symbol("SOL")
+            .side(Side::Bid)
+            .num_base_lots(25)
+            .build()
+            .unwrap();
+
+        let ix = builder
+            .place_market_order_delegated(ticket, trader_wallet, None)
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        assert_eq!(&ix.data[..8], &place_market_order_delegated_discriminant());
+        assert_eq!(ix.accounts.len(), 11);
+        assert_eq!(ix.accounts[3].pubkey, trader_wallet);
+        assert!(ix.accounts[3].is_signer);
+        assert_eq!(ix.accounts[4].pubkey, trader_wallet);
+        assert_eq!(ix.accounts[5].pubkey, trader_account);
+        assert_ne!(ix.accounts[3].pubkey, authority);
     }
 
     #[test]

--- a/rust/sdk/src/ws_client.rs
+++ b/rust/sdk/src/ws_client.rs
@@ -6,13 +6,17 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use futures_util::{SinkExt, StreamExt};
 use solana_pubkey::Pubkey;
 use tokio::sync::mpsc;
-use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::header::{AUTHORIZATION, SEC_WEBSOCKET_PROTOCOL};
+use tokio_tungstenite::tungstenite::http::{HeaderValue, StatusCode};
+use tokio_tungstenite::tungstenite::{Error as TungsteniteError, Message};
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
 use tracing::{debug, error, info, warn};
 use url::Url;
 
+use crate::auth::AuthSession;
 use crate::env::PhoenixEnv;
+use crate::http_client::PhoenixHttpClient;
 use crate::phoenix_rise_types::{
     AllMidsData, CandleData, CandlesSubscriptionRequest, ClientMessage, FundingRateMessage,
     FundingRateSubscriptionRequest, L2BookUpdate, MarketStatsUpdate, MarketSubscriptionRequest,
@@ -123,7 +127,7 @@ impl PhoenixWSClient {
 
     /// Create a new WebSocket client from a `PhoenixEnv`.
     pub fn from_env(env: PhoenixEnv) -> Result<Self, PhoenixWsError> {
-        Self::new_internal(&env.ws_url, false)
+        Self::new_internal(&env.ws_url, false, None)
     }
 
     /// Create a new WebSocket client from a `PhoenixEnv` with connection status
@@ -132,7 +136,14 @@ impl PhoenixWSClient {
     /// Use `connection_status_receiver()` to get the receiver for status
     /// updates.
     pub fn from_env_with_connection_status(env: PhoenixEnv) -> Result<Self, PhoenixWsError> {
-        Self::new_internal(&env.ws_url, true)
+        Self::new_internal(&env.ws_url, true, None)
+    }
+
+    pub(crate) fn from_env_with_connection_status_and_auth(
+        env: PhoenixEnv,
+        auth_client: PhoenixHttpClient,
+    ) -> Result<Self, PhoenixWsError> {
+        Self::new_internal(&env.ws_url, true, Some(auth_client))
     }
 
     /// Create a new WebSocket client and connect to the server.
@@ -140,7 +151,7 @@ impl PhoenixWSClient {
     /// # Arguments
     /// * `ws_url` - The WebSocket URL (e.g., "wss://api.phoenix.trade/ws")
     pub fn new(ws_url: &str) -> Result<Self, PhoenixWsError> {
-        Self::new_internal(ws_url, false)
+        Self::new_internal(ws_url, false, None)
     }
 
     /// Create a new WebSocket client with connection status updates enabled.
@@ -151,13 +162,14 @@ impl PhoenixWSClient {
     /// # Arguments
     /// * `ws_url` - The WebSocket URL (e.g., "wss://api.phoenix.trade/ws")
     pub fn new_with_connection_status(ws_url: &str) -> Result<Self, PhoenixWsError> {
-        Self::new_internal(ws_url, true)
+        Self::new_internal(ws_url, true, None)
     }
 
     /// Internal constructor.
     fn new_internal(
         ws_url: &str,
         receiver_connection_status: bool,
+        auth_client: Option<PhoenixHttpClient>,
     ) -> Result<Self, PhoenixWsError> {
         let url = Url::parse(ws_url)?;
         let (control_tx, control_rx) = mpsc::unbounded_channel();
@@ -179,6 +191,7 @@ impl PhoenixWSClient {
         // Spawn the connection manager task
         tokio::spawn(Self::connection_manager(
             url,
+            auth_client,
             control_rx,
             ws_connection_status_tx,
         ));
@@ -505,6 +518,7 @@ impl PhoenixWSClient {
     /// routing.
     async fn connection_manager(
         url: Url,
+        auth_client: Option<PhoenixHttpClient>,
         mut control_rx: mpsc::UnboundedReceiver<ControlMessage>,
         ws_connection_status_tx: Option<mpsc::UnboundedSender<WsConnectionStatus>>,
     ) {
@@ -518,7 +532,7 @@ impl PhoenixWSClient {
         }
 
         // Connect to WebSocket
-        let ws_stream = match Self::connect(&url).await {
+        let ws_stream = match Self::connect(&url, auth_client.as_ref()).await {
             Ok(stream) => {
                 info!("Connected to WebSocket: {}", url);
                 if let Some(ref tx) = ws_connection_status_tx {
@@ -650,10 +664,67 @@ impl PhoenixWSClient {
     /// Connect to the WebSocket server.
     async fn connect(
         url: &Url,
+        auth_client: Option<&PhoenixHttpClient>,
     ) -> Result<WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>, PhoenixWsError> {
-        let request = url.as_str().into_client_request()?;
-        let (ws_stream, _response) = connect_async(request).await?;
+        let auth_session = Self::auth_session_for_connect(auth_client).await?;
+        let request = Self::connect_request(url, auth_session.as_ref())?;
+        let ws_stream = match connect_async(request).await {
+            Ok((ws_stream, _response)) => ws_stream,
+            Err(error) if is_ws_auth_error(&error) => {
+                let Some(auth_client) = auth_client else {
+                    return Err(error.into());
+                };
+                auth_client
+                    .refresh_auth_session()
+                    .await
+                    .map_err(ws_auth_error)?;
+                let auth_session = Self::auth_session_for_connect(Some(auth_client)).await?;
+                let request = Self::connect_request(url, auth_session.as_ref())?;
+                let (ws_stream, _response) = connect_async(request).await?;
+                ws_stream
+            }
+            Err(error) => return Err(error.into()),
+        };
         Ok(ws_stream)
+    }
+
+    async fn auth_session_for_connect(
+        auth_client: Option<&PhoenixHttpClient>,
+    ) -> Result<Option<AuthSession>, PhoenixWsError> {
+        let Some(auth_client) = auth_client else {
+            return Ok(None);
+        };
+
+        auth_client
+            .auth_session_for_request()
+            .await
+            .map_err(ws_auth_error)
+    }
+
+    fn connect_request(
+        url: &Url,
+        auth_session: Option<&AuthSession>,
+    ) -> Result<tokio_tungstenite::tungstenite::handshake::client::Request, PhoenixWsError> {
+        let mut request = url.as_str().into_client_request()?;
+        let Some(auth_session) = auth_session else {
+            return Ok(request);
+        };
+
+        let bearer = format!("Bearer {}", auth_session.access_token());
+        let protocols = format!("phoenix-jwt, {}", auth_session.access_token());
+        request.headers_mut().insert(
+            AUTHORIZATION,
+            bearer
+                .parse::<HeaderValue>()
+                .map_err(|error| PhoenixWsError::InvalidHeaderValue(error.to_string()))?,
+        );
+        request.headers_mut().insert(
+            SEC_WEBSOCKET_PROTOCOL,
+            protocols
+                .parse::<HeaderValue>()
+                .map_err(|error| PhoenixWsError::InvalidHeaderValue(error.to_string()))?,
+        );
+        Ok(request)
     }
 
     /// Broadcast a message to all subscribers for a given key.
@@ -803,5 +874,70 @@ impl PhoenixWSClient {
 impl Drop for PhoenixWSClient {
     fn drop(&mut self) {
         self.shutdown();
+    }
+}
+
+fn is_ws_auth_error(error: &TungsteniteError) -> bool {
+    matches!(
+        error,
+        TungsteniteError::Http(response)
+            if matches!(
+                response.status(),
+                StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN | StatusCode::CONFLICT
+            )
+    )
+}
+
+fn ws_auth_error(error: impl std::fmt::Display) -> PhoenixWsError {
+    PhoenixWsError::Authentication(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    use super::*;
+
+    #[test]
+    fn connect_request_includes_auth_headers_when_session_is_available() {
+        let access_token = test_jwt("ws-jti");
+        let session = AuthSession::from_tokens(
+            access_token.clone(),
+            Some("refresh-token".to_string()),
+            URL_SAFE_NO_PAD.encode(b"pop-key"),
+            Some(300),
+            Some(600),
+        )
+        .expect("session should parse");
+        let url = Url::parse("wss://api.example.test/ws").expect("url should parse");
+
+        let request =
+            PhoenixWSClient::connect_request(&url, Some(&session)).expect("request should build");
+
+        assert_eq!(
+            request.headers().get(AUTHORIZATION).unwrap(),
+            &format!("Bearer {access_token}")
+        );
+        assert_eq!(
+            request.headers().get(SEC_WEBSOCKET_PROTOCOL).unwrap(),
+            &format!("phoenix-jwt, {access_token}")
+        );
+    }
+
+    #[test]
+    fn connect_request_omits_auth_headers_without_session() {
+        let url = Url::parse("wss://api.example.test/ws").expect("url should parse");
+
+        let request = PhoenixWSClient::connect_request(&url, None).expect("request should build");
+
+        assert!(request.headers().get(AUTHORIZATION).is_none());
+        assert!(request.headers().get(SEC_WEBSOCKET_PROTOCOL).is_none());
+    }
+
+    fn test_jwt(jti: &str) -> String {
+        let header = URL_SAFE_NO_PAD.encode(r#"{"alg":"none"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"jti":"{jti}"}}"#));
+        format!("{header}.{payload}.sig")
     }
 }

--- a/rust/sdk/tests/auth_config_tests.rs
+++ b/rust/sdk/tests/auth_config_tests.rs
@@ -11,7 +11,8 @@ use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use phoenix_rise::{
     AuthError, AuthSession, AuthSessionStore, MemoryAuthSessionStore, PhoenixAuthSigner,
-    PhoenixHttpClient, PhoenixServiceChallenge, PhoenixServiceLoginRequest,
+    PhoenixHttpClient, PhoenixMemorySessionManager, PhoenixServiceChallenge,
+    PhoenixServiceLoginRequest,
 };
 use serde_json::{Value, json};
 #[cfg(feature = "solana-keypair")]
@@ -67,7 +68,7 @@ async fn service_account_login_shares_session_with_http_client() {
         )
         .route("/v1/auth/login/service", post(service_login_handler))
         .route("/v1/auth/refresh", post(refresh_handler))
-        .route("/exchange/keys", get(exchange_keys_handler))
+        .route("/v1/view/exchange/keys", get(exchange_keys_handler))
         .with_state(state.clone());
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -128,7 +129,7 @@ async fn wallet_login_shares_session_with_http_client() {
     let app = Router::new()
         .route("/v1/auth/nonce", get(wallet_nonce_handler))
         .route("/v1/auth/login/wallet", post(wallet_login_handler))
-        .route("/exchange/keys", get(exchange_keys_handler))
+        .route("/v1/view/exchange/keys", get(exchange_keys_handler))
         .with_state(state.clone());
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -182,7 +183,7 @@ async fn signer_reauthenticates_when_refresh_token_is_missing() {
         )
         .route("/v1/auth/login/service", post(service_login_handler))
         .route("/v1/auth/refresh", post(refresh_handler))
-        .route("/exchange/keys", get(exchange_keys_handler))
+        .route("/v1/view/exchange/keys", get(exchange_keys_handler))
         .with_state(state.clone());
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -246,7 +247,7 @@ async fn signer_reauthenticates_after_invalid_refresh_token() {
         )
         .route("/v1/auth/login/service", post(service_login_handler))
         .route("/v1/auth/refresh", post(refresh_handler))
-        .route("/exchange/keys", get(exchange_keys_handler))
+        .route("/v1/view/exchange/keys", get(exchange_keys_handler))
         .with_state(state.clone());
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -304,7 +305,7 @@ async fn store_only_auth_refreshes_after_unauthorized() {
 
     let app = Router::new()
         .route("/v1/auth/refresh", post(refresh_success_handler))
-        .route("/exchange/keys", get(exchange_keys_handler))
+        .route("/v1/view/exchange/keys", get(exchange_keys_handler))
         .with_state(state.clone());
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -337,6 +338,122 @@ async fn store_only_auth_refreshes_after_unauthorized() {
         store.load_session().unwrap().unwrap().access_jti(),
         "jti-fresh"
     );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn memory_session_manager_refreshes_before_request() {
+    let state = TestState {
+        login_access_token: make_jwt("jti-memory-fresh"),
+        pop_key: URL_SAFE_NO_PAD.encode(b"pop-key-memory"),
+        saw_auth_header: Arc::new(AtomicBool::new(false)),
+        service_login_calls: Arc::new(AtomicUsize::new(0)),
+        wallet_login_calls: Arc::new(AtomicUsize::new(0)),
+        refresh_calls: Arc::new(AtomicUsize::new(0)),
+    };
+
+    let app = Router::new()
+        .route("/v1/auth/refresh", post(refresh_success_handler))
+        .route("/v1/view/exchange/keys", get(exchange_keys_handler))
+        .with_state(state.clone());
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let initial_session = AuthSession::from_tokens(
+        make_jwt_with_exp("jti-memory-expired", 1),
+        Some("refresh-token-memory".to_string()),
+        URL_SAFE_NO_PAD.encode(b"pop-key-stale"),
+        None,
+        Some(3600),
+    )
+    .unwrap();
+    let manager = Arc::new(
+        PhoenixMemorySessionManager::new(format!("http://{}", addr), initial_session).unwrap(),
+    );
+
+    let client = PhoenixHttpClient::builder(format!("http://{}", addr))
+        .with_session_manager(manager.clone())
+        .build()
+        .unwrap();
+
+    let keys = client.exchange().get_keys().await.unwrap();
+    assert_eq!(keys.global_config, "11111111111111111111111111111111");
+    assert!(state.saw_auth_header.load(Ordering::SeqCst));
+    assert_eq!(state.refresh_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(manager.session().access_jti(), "jti-memory-fresh");
+    assert_eq!(
+        client
+            .auth()
+            .expect("manager-backed client should expose shared auth client")
+            .session()
+            .unwrap()
+            .expect("refreshed session should be stored")
+            .access_jti(),
+        "jti-memory-fresh"
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn memory_session_manager_coalesces_concurrent_refreshes() {
+    let state = TestState {
+        login_access_token: make_jwt("jti-memory-fresh"),
+        pop_key: URL_SAFE_NO_PAD.encode(b"pop-key-memory"),
+        saw_auth_header: Arc::new(AtomicBool::new(false)),
+        service_login_calls: Arc::new(AtomicUsize::new(0)),
+        wallet_login_calls: Arc::new(AtomicUsize::new(0)),
+        refresh_calls: Arc::new(AtomicUsize::new(0)),
+    };
+
+    let app = Router::new()
+        .route("/v1/auth/refresh", post(refresh_success_slow_handler))
+        .route("/v1/view/exchange/keys", get(exchange_keys_handler))
+        .with_state(state.clone());
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let initial_session = AuthSession::from_tokens(
+        make_jwt_with_exp("jti-memory-expired", 1),
+        Some("refresh-token-memory".to_string()),
+        URL_SAFE_NO_PAD.encode(b"pop-key-stale"),
+        None,
+        Some(3600),
+    )
+    .unwrap();
+    let manager = Arc::new(
+        PhoenixMemorySessionManager::new(format!("http://{}", addr), initial_session).unwrap(),
+    );
+
+    let client = PhoenixHttpClient::builder(format!("http://{}", addr))
+        .with_session_manager(manager.clone())
+        .build()
+        .unwrap();
+
+    let first = async { client.exchange().get_keys().await };
+    let second = async { client.exchange().get_keys().await };
+    let (first, second) = tokio::join!(first, second);
+
+    assert_eq!(
+        first.unwrap().global_config,
+        "11111111111111111111111111111111"
+    );
+    assert_eq!(
+        second.unwrap().global_config,
+        "11111111111111111111111111111111"
+    );
+    assert!(state.saw_auth_header.load(Ordering::SeqCst));
+    assert_eq!(state.refresh_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(manager.session().access_jti(), "jti-memory-fresh");
 
     server.abort();
 }
@@ -389,7 +506,7 @@ async fn store_reload_does_not_consume_refresh_retry() {
 
     let app = Router::new()
         .route("/v1/auth/refresh", post(refresh_success_handler))
-        .route("/exchange/keys", get(exchange_keys_handler))
+        .route("/v1/view/exchange/keys", get(exchange_keys_handler))
         .with_state(state.clone());
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -530,6 +647,13 @@ async fn refresh_success_handler(
     })))
 }
 
+async fn refresh_success_slow_handler(
+    State(state): State<TestState>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    refresh_success_handler(State(state)).await
+}
+
 async fn exchange_keys_handler(
     State(state): State<TestState>,
     headers: HeaderMap,
@@ -577,8 +701,11 @@ async fn exchange_keys_handler(
 }
 
 fn make_jwt(jti: &str) -> String {
+    make_jwt_with_exp(jti, 4_102_444_800)
+}
+
+fn make_jwt_with_exp(jti: &str, exp: u64) -> String {
     let header = URL_SAFE_NO_PAD.encode(r#"{"alg":"none","typ":"JWT"}"#);
-    let payload =
-        URL_SAFE_NO_PAD.encode(format!(r#"{{"jti":"{jti}","exp":4102444800}}"#).as_bytes());
+    let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"jti":"{jti}","exp":{exp}}}"#).as_bytes());
     format!("{header}.{payload}.sig")
 }

--- a/rust/sdk/tests/client_identity_tests.rs
+++ b/rust/sdk/tests/client_identity_tests.rs
@@ -61,7 +61,7 @@ async fn auth_client_sends_rise_client_identity_header() {
 
 async fn spawn_test_server(state: TestState) -> (String, tokio::task::JoinHandle<()>) {
     let app = Router::new()
-        .route("/exchange/keys", get(exchange_keys_handler))
+        .route("/v1/view/exchange/keys", get(exchange_keys_handler))
         .route(
             "/v1/auth/login/service/challenge",
             post(service_challenge_handler),

--- a/rust/sdk/tests/http_retry_tests.rs
+++ b/rust/sdk/tests/http_retry_tests.rs
@@ -64,7 +64,7 @@ async fn get_requests_can_disable_rate_limit_retry_at_creation() {
 
 async fn spawn_test_server(state: TestState) -> (String, tokio::task::JoinHandle<()>) {
     let app = Router::new()
-        .route("/exchange/keys", get(exchange_keys_handler))
+        .route("/v1/view/exchange/keys", get(exchange_keys_handler))
         .with_state(state);
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/rust/types/src/exchange_ws.rs
+++ b/rust/types/src/exchange_ws.rs
@@ -259,6 +259,10 @@ pub enum ExchangeMarketParameterUpdate {
         previous_base_lots: JsSafeU64,
         new_base_lots: JsSafeU64,
     },
+    MaxLiquidationSizeUpdated {
+        previous_base_lots: JsSafeU64,
+        new_base_lots: JsSafeU64,
+    },
     UpnlRiskFactorUpdated {
         previous: f64,
         new: f64,

--- a/rust/types/src/ws_error.rs
+++ b/rust/types/src/ws_error.rs
@@ -21,6 +21,10 @@ pub enum PhoenixWsError {
     #[error("Invalid header value: {0}")]
     InvalidHeaderValue(String),
 
+    /// Failed to prepare WebSocket authentication.
+    #[error("WebSocket authentication failed: {0}")]
+    Authentication(String),
+
     /// Failed to serialize a message.
     #[error("Failed to serialize message: {0}")]
     SerializationFailed(#[from] serde_json::Error),


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `65fc5aad3e13c249bcc606b410059b8adbc61e2d`
- Mode: automatic
- Synced paths:

- `rise/rust` -> `rust`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `rust/CHANGELOG.md`

### Summary

- **Delegated market orders**: New `MarketOrderDelegatedParams` / `create_place_market_order_delegated_ix` instruction builder and `PhoenixTxBuilder::place_market_order_delegated` for signing via a wallet that differs from the trader account authority. Delegated market-order instructions are now routable through `PhoenixFlightClient`.
- **Session manager abstraction**: New `PhoenixSessionManager` trait with two built-in implementations — `PhoenixMemorySessionManager` (any `AuthSession`) and `PhoenixWalletSessionManager` (Solana keypair login, `solana-keypair` feature). Concurrent refreshes are coalesced. Pass via `PhoenixHttpClientBuilder::with_session_manager`.
- **Authenticated WebSocket handshake**: `PhoenixClient::new_from_env_with_auth` / `from_env_with_auth` / `from_env_with_http_client` propagate the HTTP client's auth lifecycle to WebSocket connections; the handshake now sends `Authorization` and `Sec-WebSocket-Protocol` JWT headers and auto-retries on 401/403/409.
- **WS connection status observable**: `PhoenixClient::connection_status()` and `subscribe_connection_status()` expose a `watch::Receiver<WsConnectionStatus>` for the full client's reconnection state.
- **`MaxLiquidationSizeUpdated` WS event**: New `ExchangeMarketParameterUpdate::MaxLiquidationSizeUpdated` variant tracked by `ExchangeCacheMarketChangeKind::MaxLiquidationSize`.

### Breaking Changes

- **`TradersClient` API replaced**: `get_trader(authority)`, `get_trader_internal(authority, pda_index)`, and `get_trader_state(authority, pda_index)` are removed. Use `get_trader_by_pubkey(&trader_pda)` instead, which takes the trader PDA directly. The convenience top-level methods `PhoenixHttpClient::get_traders` and `get_trader_state` are also removed.
- **`get_permission_address` removed** from the public re-export list in `phoenix_rise`.
- **New `ExchangeMarketParameterUpdate::MaxLiquidationSizeUpdated` variant**: exhaustive `match` arms over this enum must add a handler for the new variant.
- **New `PhoenixWsError::Authentication` variant**: exhaustive `match` arms over this error type must add a handler.

### Consumer Notes

- `PhoenixEnv::from_api_url(api_url)` is a new convenience constructor that derives the WebSocket URL automatically, including preserving reverse-proxy path prefixes (e.g. `https://gateway.example.com/phoenix` → `wss://gateway.example.com/phoenix/v1/ws`).
- `PhoenixHttpClient::from_url_with_wallet_keypair(url, keypair)` (`solana-keypair` feature) creates a fully authenticated client in one step.
- `PhoenixHttpClient::post_json` is now public.
- `is_auth_recovery_error` is now a public export for downstream error classification.
- `async-trait 0.1` is a new direct dependency of `phoenix-rise`.