### PR TITLE
sync: Rise TypeScript v0.4.41

### DIFF
--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -257,3 +257,24 @@ Source Phoenix commit: `65fc5aad3e13c249bcc606b410059b8adbc61e2d`
 
 - If you construct `MarginPositionState` manually (not via snapshot helpers) and were previously accounting for the sign flip described in the old JSDoc, no change is needed — the type contract is unchanged; only the snapshot helper behavior is fixed.
 - The liquidation price fix requires `maintenanceMarginFactorBps` to be present and positive in `MarketParams.riskFactors`; positions with a zero or missing value will return `undefined` for liquidation price (was previously a potentially incorrect value).
+
+## v0.4.41 - 2026-06-16
+
+Source Phoenix commit: `6487be852f3a382717f345a43fd956af3fba1766`
+
+### Summary
+
+- `PhoenixHttpClient` now automatically retries `GET` and `HEAD` requests that receive a `429 Too Many Requests` response. By default, up to 2 retries are attempted with a cumulative wait cap of 15 seconds, honoring the server's `Retry-After` header (both numeric seconds and HTTP-date formats). Pass `rateLimitRetry: false` to opt out.
+- A new `rateLimitRetry` config field on `PhoenixHttpClientConfig` accepts a `RateLimitRetryConfig` object (`maxRetries`, `maxTotalWaitMs`, `fallbackDelayMs`) or `false` to disable retries entirely.
+- `PhoenixHttpError` gains an `attempts` field (number of total attempts including the initial request) so callers can distinguish a first-shot 429 from one that exhausted retries.
+- `RateLimitRetryConfig` is now exported from the package root (`@ellipsis-labs/rise`).
+- `Retry-After` parsing is now unified and more accurate: supports both numeric seconds (including fractional) and HTTP-date strings; previously, `transport.ts` parsed only integers and clamped to a minimum of 1 second.
+
+### Breaking Changes
+
+- None identified in the synced diff.
+
+### Consumer Notes
+
+- **Default retry behavior is now active.** Existing code that calls `GET`/`HEAD` endpoints may now wait and retry on 429s (up to ~15 s total) instead of failing immediately. If your application handles 429s manually or has strict latency budgets, pass `rateLimitRetry: false` to restore the prior behavior.
+- **`PhoenixHttpError.attempts` is additive** — no code changes required, but error-inspection code that checks for a fixed set of fields may now observe this new property on 429 errors.

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/rise",
-  "version": "0.4.40",
+  "version": "0.4.41",
   "packageManager": "bun@1.3.13",
   "repository": {
     "type": "git",

--- a/ts/src/auth/client.ts
+++ b/ts/src/auth/client.ts
@@ -1,5 +1,6 @@
 import { getPhoenixClientHeader } from "@/clientIdentity";
 import { PhoenixAuthError } from "@/errors";
+import { parseRetryAfterSeconds } from "@/http/rateLimitRetry";
 import type { AuthSessionManager } from "./manager";
 import { shouldClearSessionOnRefreshFailure } from "./refreshErrors";
 import {
@@ -38,21 +39,6 @@ export interface PhoenixAuthClientConfig extends PhoenixApiUrlConfig {
 const DEFAULT_TIMEOUT = 30_000;
 const DEFAULT_RATE_LIMIT_RETRY_SECONDS = 1;
 const MAX_RATE_LIMIT_RETRY_SECONDS = 30;
-
-const parseRetryAfterSeconds = (value: string | null): number | undefined => {
-  if (!value) return undefined;
-  const trimmed = value.trim();
-  const parsedSeconds = Number(trimmed);
-  if (Number.isFinite(parsedSeconds) && parsedSeconds >= 0) {
-    return Math.ceil(parsedSeconds);
-  }
-
-  const retryDate = Date.parse(trimmed);
-  if (Number.isNaN(retryDate)) return undefined;
-  const deltaMs = retryDate - Date.now();
-  if (deltaMs <= 0) return 0;
-  return Math.ceil(deltaMs / 1000);
-};
 
 const effectiveRetryAfterSeconds = (retryAfterSeconds?: number): number => {
   const value = retryAfterSeconds ?? DEFAULT_RATE_LIMIT_RETRY_SECONDS;

--- a/ts/src/client.ts
+++ b/ts/src/client.ts
@@ -1,5 +1,13 @@
 import type { HttpTransport, RequestOptions } from "./http/transport";
 import { appendQueryParams } from "./http/transport";
+import {
+  isRateLimitRetryableMethod,
+  rateLimitRetryDecision,
+  resolveRateLimitRetryConfig,
+  setRateLimitRetryAttempts,
+  type RateLimitRetryConfig,
+  type ResolvedRateLimitRetryConfig,
+} from "./http/rateLimitRetry";
 import { V1CandlesClient } from "./api/candles/client";
 import { V1CollateralClient } from "./api/collateral/client";
 import { V1ExchangeClient } from "./api/exchange/client";
@@ -68,20 +76,6 @@ const AUTH_RETRYABLE_CODES = new Set([
   "access_jti_mismatch",
   "session_missing",
 ]);
-
-const parseRetryAfterSeconds = (value: string | null): number | undefined => {
-  if (!value) return undefined;
-  const trimmed = value.trim();
-  const parsedSeconds = Number(trimmed);
-  if (Number.isFinite(parsedSeconds) && parsedSeconds >= 0) {
-    return Math.ceil(parsedSeconds);
-  }
-  const retryDate = Date.parse(trimmed);
-  if (Number.isNaN(retryDate)) return undefined;
-  const deltaMs = retryDate - Date.now();
-  if (deltaMs <= 0) return 0;
-  return Math.ceil(deltaMs / 1000);
-};
 
 const summarizeRequestBody = (
   body: unknown
@@ -158,6 +152,8 @@ export interface PhoenixHttpClientConfig extends PhoenixApiUrlConfig {
   auth?: boolean;
   /** Optional auth/session overrides used when `auth: true`. */
   authConfig?: RiseAuthConfig;
+  /** Automatic rate-limit retry behavior for idempotent HTTP requests. */
+  rateLimitRetry?: RateLimitRetryConfig | false;
   /** Optional flight routing defaults applied to supported order-building paths. */
   flight?: PhoenixFlightClientConfig;
 }
@@ -177,6 +173,7 @@ export class PhoenixHttpClient implements HttpTransport {
   private readonly apiUrl: string;
   private readonly timeout: number;
   private readonly extraHeaders?: PhoenixHttpClientConfig["extraHeaders"];
+  private readonly rateLimitRetry: ResolvedRateLimitRetryConfig | null;
   private readonly authRuntime?: RiseAuthRuntime;
   readonly pda: PhoenixPdaClient;
   private readonly candlesClient: V1CandlesClient;
@@ -195,6 +192,7 @@ export class PhoenixHttpClient implements HttpTransport {
     this.apiUrl = resolvePhoenixApiUrl(config);
     this.timeout = config.timeout ?? DEFAULT_TIMEOUT;
     this.extraHeaders = config.extraHeaders;
+    this.rateLimitRetry = resolveRateLimitRetryConfig(config.rateLimitRetry);
     const pdaConfig: PhoenixPdaClientConfig = {
       phoenixEnv: config.phoenixEnv,
       addresses: config.addresses,
@@ -326,7 +324,7 @@ export class PhoenixHttpClient implements HttpTransport {
         return this.performFetch(url, method, headers, requestBody, controller);
       };
 
-      const authorizedResponse = await execute(
+      let authorizedResponse = await execute(
         session ? `Bearer ${session.accessToken}` : undefined
       );
 
@@ -337,34 +335,58 @@ export class PhoenixHttpClient implements HttpTransport {
         durationMs: Date.now() - startedAt,
       });
 
-      if (
+      let rateLimitRetries = 0;
+      let totalRateLimitWaitMs = 0;
+      while (
         authorizedResponse.status === 429 &&
-        (method === "GET" || method === "HEAD")
+        this.rateLimitRetry !== null &&
+        isRateLimitRetryableMethod(method) &&
+        rateLimitRetries < this.rateLimitRetry.maxRetries
       ) {
-        const retryAfterSeconds = parseRetryAfterSeconds(
-          authorizedResponse.headers.get("retry-after")
+        const retry = rateLimitRetryDecision(
+          authorizedResponse,
+          this.rateLimitRetry,
+          totalRateLimitWaitMs
         );
-        const waitMs = Math.max(
-          1_000,
-          Math.min(30_000, (retryAfterSeconds ?? 1) * 1000)
-        );
+        if (retry.kind === "exhausted") {
+          debugRise("http", "request:retry-after-exhausted", {
+            method: method.toUpperCase(),
+            url: url.toString(),
+            status: authorizedResponse.status,
+            waitMs: retry.waitMs,
+            nextTotalWaitMs: retry.nextTotalWaitMs,
+            totalWaitMs: totalRateLimitWaitMs,
+            maxTotalWaitMs: this.rateLimitRetry.maxTotalWaitMs,
+            retryAfterSeconds: retry.retryAfterSeconds,
+          });
+          break;
+        }
+
         debugRise("http", "request:retry-after", {
           method: method.toUpperCase(),
           url: url.toString(),
           status: authorizedResponse.status,
-          waitMs,
+          waitMs: retry.waitMs,
+          attempt: rateLimitRetries + 2,
+          retryAfterSeconds: retry.retryAfterSeconds,
         });
-        await new Promise((resolve) => setTimeout(resolve, waitMs));
-        const retriedResponse = await execute(
+        await new Promise((resolve) => setTimeout(resolve, retry.waitMs));
+        totalRateLimitWaitMs = retry.nextTotalWaitMs;
+        rateLimitRetries += 1;
+        authorizedResponse = await execute(
           session ? `Bearer ${session.accessToken}` : undefined
         );
         debugRise("http", "request:retry-response", {
           method: method.toUpperCase(),
           url: url.toString(),
-          status: retriedResponse.status,
+          status: authorizedResponse.status,
           durationMs: Date.now() - startedAt,
+          attempt: rateLimitRetries + 1,
         });
-        return retriedResponse;
+      }
+
+      if (authorizedResponse.status === 429) {
+        setRateLimitRetryAttempts(authorizedResponse, rateLimitRetries + 1);
       }
 
       if (

--- a/ts/src/errors.ts
+++ b/ts/src/errors.ts
@@ -6,7 +6,8 @@ export class PhoenixHttpError extends Error {
     message: string,
     public readonly code?: string,
     public readonly retryAfterSeconds?: number,
-    body?: Record<string, unknown>
+    body?: Record<string, unknown>,
+    public readonly attempts?: number
   ) {
     super(message);
     this.name = "PhoenixHttpError";

--- a/ts/src/http/index.ts
+++ b/ts/src/http/index.ts
@@ -4,6 +4,7 @@ export type {
   QueryParams,
   ParamValue,
 } from "./transport";
+export type { RateLimitRetryConfig } from "./rateLimitRetry";
 export {
   send,
   get,

--- a/ts/src/http/rateLimitRetry.ts
+++ b/ts/src/http/rateLimitRetry.ts
@@ -1,0 +1,160 @@
+export interface RateLimitRetryConfig {
+  /** Maximum number of retries after the initial request. */
+  maxRetries?: number;
+  /** Maximum total time spent waiting between retries. */
+  maxTotalWaitMs?: number;
+  /** Fallback delay used when Retry-After is missing or invalid. */
+  fallbackDelayMs?: number;
+}
+
+export interface ResolvedRateLimitRetryConfig {
+  readonly maxRetries: number;
+  readonly maxTotalWaitMs: number;
+  readonly fallbackDelayMs: number;
+}
+
+export type RateLimitRetryDecision =
+  | RateLimitRetryAttempt
+  | RateLimitRetryExhausted;
+
+export interface RateLimitRetryAttempt {
+  readonly kind: "retry";
+  readonly waitMs: number;
+  readonly nextTotalWaitMs: number;
+  readonly retryAfterSeconds?: number;
+}
+
+export interface RateLimitRetryExhausted {
+  readonly kind: "exhausted";
+  readonly waitMs: number;
+  readonly nextTotalWaitMs: number;
+  readonly retryAfterSeconds?: number;
+}
+
+export interface ParsedRetryAfter {
+  readonly raw: string;
+  readonly retryAfterMs: number;
+  readonly retryAfterSeconds: number;
+}
+
+export const DEFAULT_RATE_LIMIT_RETRY_CONFIG: Required<RateLimitRetryConfig> = {
+  maxRetries: 2,
+  maxTotalWaitMs: 15_000,
+  fallbackDelayMs: 1_000,
+};
+
+const DEFAULT_FALLBACK_JITTER_RATIO = 0.15;
+
+const finiteNonNegative = (value: number | undefined): value is number =>
+  value !== undefined && Number.isFinite(value) && value >= 0;
+
+export const resolveRateLimitRetryConfig = (
+  config: RateLimitRetryConfig | false | undefined
+): ResolvedRateLimitRetryConfig | null => {
+  if (config === false) {
+    return null;
+  }
+
+  return {
+    maxRetries: finiteNonNegative(config?.maxRetries)
+      ? Math.floor(config.maxRetries)
+      : DEFAULT_RATE_LIMIT_RETRY_CONFIG.maxRetries,
+    maxTotalWaitMs: finiteNonNegative(config?.maxTotalWaitMs)
+      ? Math.ceil(config.maxTotalWaitMs)
+      : DEFAULT_RATE_LIMIT_RETRY_CONFIG.maxTotalWaitMs,
+    fallbackDelayMs: finiteNonNegative(config?.fallbackDelayMs)
+      ? Math.ceil(config.fallbackDelayMs)
+      : DEFAULT_RATE_LIMIT_RETRY_CONFIG.fallbackDelayMs,
+  };
+};
+
+export const parseRetryAfter = (
+  value: string | null,
+  nowMs: number = Date.now()
+): ParsedRetryAfter | undefined => {
+  if (!value) return undefined;
+  const raw = value.trim();
+  if (!raw) return undefined;
+
+  const parsedSeconds = Number(raw);
+  if (Number.isFinite(parsedSeconds) && parsedSeconds >= 0) {
+    const retryAfterMs = Math.ceil(parsedSeconds * 1000);
+    return {
+      raw,
+      retryAfterMs,
+      retryAfterSeconds: Math.ceil(retryAfterMs / 1000),
+    };
+  }
+
+  const retryAtMs = Date.parse(raw);
+  if (Number.isNaN(retryAtMs)) return undefined;
+  const retryAfterMs = Math.max(0, retryAtMs - nowMs);
+  return {
+    raw,
+    retryAfterMs,
+    retryAfterSeconds: Math.ceil(retryAfterMs / 1000),
+  };
+};
+
+export const parseRetryAfterSeconds = (
+  value: string | null,
+  nowMs?: number
+): number | undefined => parseRetryAfter(value, nowMs)?.retryAfterSeconds;
+
+export const isRateLimitRetryableMethod = (method: string): boolean => {
+  const normalized = method.toUpperCase();
+  return normalized === "GET" || normalized === "HEAD";
+};
+
+const rateLimitRetryAttempts = new WeakMap<Response, number>();
+
+export const setRateLimitRetryAttempts = (
+  response: Response,
+  attempts: number
+): void => {
+  if (Number.isFinite(attempts) && attempts > 0) {
+    rateLimitRetryAttempts.set(response, Math.floor(attempts));
+  }
+};
+
+export const getRateLimitRetryAttempts = (
+  response: Response
+): number | undefined => rateLimitRetryAttempts.get(response);
+
+export const fallbackRateLimitDelayMs = (
+  config: ResolvedRateLimitRetryConfig
+): number => {
+  const jitter =
+    1 -
+    DEFAULT_FALLBACK_JITTER_RATIO +
+    Math.random() * DEFAULT_FALLBACK_JITTER_RATIO * 2;
+  return Math.max(0, Math.round(config.fallbackDelayMs * jitter));
+};
+
+export const rateLimitRetryDecision = (
+  response: Response,
+  config: ResolvedRateLimitRetryConfig,
+  totalWaitMs: number
+): RateLimitRetryDecision => {
+  const retryAfter = parseRetryAfter(response.headers.get("retry-after"));
+  const waitMs = retryAfter?.retryAfterMs ?? fallbackRateLimitDelayMs(config);
+  const nextTotalWaitMs = totalWaitMs + waitMs;
+  const retryAfterSeconds = retryAfter?.retryAfterSeconds;
+  const baseDecision = {
+    waitMs,
+    nextTotalWaitMs,
+    ...(retryAfterSeconds !== undefined ? { retryAfterSeconds } : {}),
+  };
+
+  if (nextTotalWaitMs > config.maxTotalWaitMs) {
+    return {
+      kind: "exhausted",
+      ...baseDecision,
+    };
+  }
+
+  return {
+    kind: "retry",
+    ...baseDecision,
+  };
+};

--- a/ts/src/http/transport.ts
+++ b/ts/src/http/transport.ts
@@ -1,5 +1,9 @@
 import type z from "zod";
 import { PhoenixHttpError } from "@/errors";
+import {
+  getRateLimitRetryAttempts,
+  parseRetryAfterSeconds,
+} from "./rateLimitRetry";
 
 // ---------------------------------------------------------------------------
 // Shared param types
@@ -60,14 +64,6 @@ export function appendQueryParams(url: URL, params: QueryParams): void {
   }
 }
 
-function parseRetryAfterSeconds(headers: Headers): number | undefined {
-  const value = headers.get("retry-after");
-  if (!value) return undefined;
-  const seconds = parseInt(value.trim(), 10);
-  if (Number.isNaN(seconds)) return undefined;
-  return Math.max(seconds, 1);
-}
-
 type ErrorPayload = {
   code?: string;
   message?: string;
@@ -120,7 +116,10 @@ export async function send<T>(
 ): Promise<T> {
   const response = await transport.fetch(method, endpoint, options, body);
   if (!response.ok) {
-    const retryAfter = parseRetryAfterSeconds(response.headers);
+    const retryAfter = parseRetryAfterSeconds(
+      response.headers.get("retry-after")
+    );
+    const attempts = getRateLimitRetryAttempts(response);
     const responseBody = await response.text().catch(() => "");
     const payload = parseErrorPayload(responseBody);
     throw new PhoenixHttpError(
@@ -128,7 +127,8 @@ export async function send<T>(
       formatHttpErrorMessage(method, endpoint, response, responseBody),
       payload.code,
       retryAfter,
-      payload.body
+      payload.body,
+      attempts
     );
   }
   const data: unknown = await response.json();

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -96,7 +96,7 @@ export * from "./margin";
 
 export type { HttpTransport, RequestOptions, QueryParams } from "./http";
 export { send, get, post, put, patch, del } from "./http";
-export type { ParamValue } from "./http";
+export type { ParamValue, RateLimitRetryConfig } from "./http";
 
 export * as api from "./api";
 export { toWebSocketUrl } from "./ws";

--- a/ts/tests/rate-limit-retry.test.ts
+++ b/ts/tests/rate-limit-retry.test.ts
@@ -1,0 +1,239 @@
+import { PhoenixHttpClient } from "@/client";
+import { PhoenixHttpError } from "@/errors";
+import { send } from "@/http";
+import { parseRetryAfter } from "@/http/rateLimitRetry";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import z from "zod";
+
+const OkSchema = z.object({ ok: z.boolean() });
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("rate-limit retry handling", () => {
+  it("parses numeric and HTTP-date Retry-After values", () => {
+    const now = Date.UTC(2026, 0, 1, 0, 0, 0);
+    const retryAt = new Date(now + 2_500).toUTCString();
+
+    expect(parseRetryAfter("2", now)).toEqual({
+      raw: "2",
+      retryAfterMs: 2_000,
+      retryAfterSeconds: 2,
+    });
+    expect(parseRetryAfter(retryAt, now)).toEqual({
+      raw: retryAt,
+      retryAfterMs: 2_000,
+      retryAfterSeconds: 2,
+    });
+    expect(parseRetryAfter(new Date(now - 1_000).toUTCString(), now)).toEqual(
+      expect.objectContaining({
+        retryAfterMs: 0,
+        retryAfterSeconds: 0,
+      })
+    );
+    expect(parseRetryAfter("not a date", now)).toBeUndefined();
+    expect(parseRetryAfter("Infinity", now)).toBeUndefined();
+  });
+
+  it("retries GET rate limits up to the configured retry count", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "rate_limited" }), {
+          status: 429,
+          headers: { "content-type": "application/json", "retry-after": "2" },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "rate_limited" }), {
+          status: 429,
+          headers: { "content-type": "application/json", "retry-after": "0" },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new PhoenixHttpClient({ apiUrl: "https://example.com" });
+    const request = send(client, "GET", "/limited", OkSchema);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.runOnlyPendingTimersAsync();
+
+    await expect(request).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("uses HTTP-date Retry-After values for retry delay", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const retryAt = new Date(Date.now() + 2_000).toUTCString();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "rate_limited" }), {
+          status: 429,
+          headers: {
+            "content-type": "application/json",
+            "retry-after": retryAt,
+          },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new PhoenixHttpClient({ apiUrl: "https://example.com" });
+    const request = send(client, "HEAD", "/limited", OkSchema);
+
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(request).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back on invalid Retry-After values", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "rate_limited" }), {
+          status: 429,
+          headers: {
+            "content-type": "application/json",
+            "retry-after": "invalid",
+          },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new PhoenixHttpClient({ apiUrl: "https://example.com" });
+    const request = send(client, "GET", "/limited", OkSchema);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(request).resolves.toEqual({ ok: true });
+  });
+
+  it("surfaces retry metadata when retries are disabled", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ error: "rate_limited" }), {
+        status: 429,
+        headers: { "content-type": "application/json", "retry-after": "3" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new PhoenixHttpClient({
+      apiUrl: "https://example.com",
+      rateLimitRetry: false,
+    });
+
+    await expect(send(client, "GET", "/limited", OkSchema)).rejects.toEqual(
+      expect.objectContaining<PhoenixHttpError>({
+        status: 429,
+        code: "rate_limited",
+        retryAfterSeconds: 3,
+        attempts: 1,
+      })
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces attempts when retryable GET rate limits exhaust max retries", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ error: "rate_limited" }), {
+        status: 429,
+        headers: { "content-type": "application/json", "retry-after": "0" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new PhoenixHttpClient({
+      apiUrl: "https://example.com",
+      rateLimitRetry: { maxRetries: 1 },
+    });
+
+    await expect(send(client, "GET", "/limited", OkSchema)).rejects.toEqual(
+      expect.objectContaining<PhoenixHttpError>({
+        status: 429,
+        code: "rate_limited",
+        retryAfterSeconds: 0,
+        attempts: 2,
+      })
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry non-idempotent requests", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ error: "rate_limited" }), {
+        status: 429,
+        headers: { "content-type": "application/json", "retry-after": "1" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new PhoenixHttpClient({ apiUrl: "https://example.com" });
+
+    await expect(
+      send(client, "POST", "/limited", OkSchema, undefined, {})
+    ).rejects.toEqual(
+      expect.objectContaining<PhoenixHttpError>({
+        status: 429,
+        code: "rate_limited",
+        retryAfterSeconds: 1,
+        attempts: 1,
+      })
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not sleep past maxTotalWaitMs", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ error: "rate_limited" }), {
+        status: 429,
+        headers: { "content-type": "application/json", "retry-after": "2" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new PhoenixHttpClient({
+      apiUrl: "https://example.com",
+      rateLimitRetry: { maxTotalWaitMs: 1_000 },
+    });
+
+    await expect(send(client, "GET", "/limited", OkSchema)).rejects.toEqual(
+      expect.objectContaining<PhoenixHttpError>({
+        status: 429,
+        code: "rate_limited",
+        retryAfterSeconds: 2,
+        attempts: 1,
+      })
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `6487be852f3a382717f345a43fd956af3fba1766`
- Mode: manual
- Synced paths:

- `rise/ts` -> `ts`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `ts/CHANGELOG.md`

### Summary

- `PhoenixHttpClient` now automatically retries `GET` and `HEAD` requests that receive a `429 Too Many Requests` response. By default, up to 2 retries are attempted with a cumulative wait cap of 15 seconds, honoring the server's `Retry-After` header (both numeric seconds and HTTP-date formats). Pass `rateLimitRetry: false` to opt out.
- A new `rateLimitRetry` config field on `PhoenixHttpClientConfig` accepts a `RateLimitRetryConfig` object (`maxRetries`, `maxTotalWaitMs`, `fallbackDelayMs`) or `false` to disable retries entirely.
- `PhoenixHttpError` gains an `attempts` field (number of total attempts including the initial request) so callers can distinguish a first-shot 429 from one that exhausted retries.
- `RateLimitRetryConfig` is now exported from the package root (`@ellipsis-labs/rise`).
- `Retry-After` parsing is now unified and more accurate: supports both numeric seconds (including fractional) and HTTP-date strings; previously, `transport.ts` parsed only integers and clamped to a minimum of 1 second.

### Breaking Changes

- None identified in the synced diff.

### Consumer Notes

- **Default retry behavior is now active.** Existing code that calls `GET`/`HEAD` endpoints may now wait and retry on 429s (up to ~15 s total) instead of failing immediately. If your application handles 429s manually or has strict latency budgets, pass `rateLimitRetry: false` to restore the prior behavior.
- **`PhoenixHttpError.attempts` is additive** — no code changes required, but error-inspection code that checks for a fixed set of fields may now observe this new property on 429 errors.