### PR TITLE
sync: Rise Rust v0.1.8

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -83,3 +83,25 @@ Source Phoenix commit: `65fc5aad3e13c249bcc606b410059b8adbc61e2d`
 - `PhoenixHttpClient::post_json` is now public.
 - `is_auth_recovery_error` is now a public export for downstream error classification.
 - `async-trait 0.1` is a new direct dependency of `phoenix-rise`.
+
+## v0.1.8 - 2026-06-16
+
+Source Phoenix commit: `6487be852f3a382717f345a43fd956af3fba1766`
+
+### Summary
+
+- Upgraded `rand` from 0.9 to 0.10 (now a workspace dependency); the `rand::Rng` trait import in math tests is replaced by `rand::RngExt`.
+- Rate-limit retry logic now applies ±15% jitter to the fallback delay when no `Retry-After` header is present, reducing thundering-herd retries.
+- `Retry-After` header parsing now accepts both integer seconds and HTTP-date (`RFC 2822`) values; previously only integer seconds were recognized.
+- The `max_delay` field on `RateLimitRetryConfig` now bounds only the jittered fallback delay; explicit `Retry-After` values are bounded by `max_total_wait` instead (doc clarification, behavior change for large `Retry-After` values).
+
+### Breaking Changes
+
+- **`rand` 0.10 workspace dependency**: if your crate depends on `phoenix-rise` and also uses `rand`, you may need to align to `rand = "0.10"`. The `rand::Rng` trait is replaced by `rand::RngExt` in 0.10 — any code importing `rand::Rng` via a shared dependency tree will need updating.
+- **`RateLimitRetryConfig::max_delay` semantics changed**: previously capped all retry delays including explicit `Retry-After` header values; now only caps the jittered fallback delay. If you set a small `max_delay` to bound `Retry-After`-driven waits, use `max_total_wait` instead.
+
+### Consumer Notes
+
+- No changes to public API surface beyond the `RateLimitRetryConfig` doc/semantic fix above.
+- The jitter on fallback delays (±15%) is applied automatically; no configuration required or available.
+- If your server sends `Retry-After` as an HTTP-date string, the client will now correctly parse and honor it.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -561,7 +561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -745,6 +745,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -1359,6 +1370,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,9 +1547,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1571,6 +1602,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash 0.8.12",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -1859,6 +1899,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2044,6 +2090,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -2529,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-trait",
  "axum",
@@ -2545,7 +2597,7 @@ dependencies = [
  "parking_lot",
  "pastey",
  "proptest",
- "rand 0.9.4",
+ "rand 0.10.1",
  "reqwest",
  "rust_decimal",
  "serde",
@@ -2575,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-sdk-cli"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "clap",
  "phoenix-rise",
@@ -2655,6 +2707,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2820,6 +2882,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,6 +2925,17 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2915,6 +2994,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -5909,6 +5994,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6070,6 +6161,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6126,6 +6226,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
 ]
 
 [[package]]
@@ -6435,6 +6569,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.114",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,6 +32,10 @@ path = "sdk/tests/auth_config_tests.rs"
 name = "invite_client_tests"
 path = "sdk/tests/invite_client_tests.rs"
 
+[[test]]
+name = "http_retry_tests"
+path = "sdk/tests/http_retry_tests.rs"
+
 [[example]]
 name              = "cancel_all_conditional_orders"
 path              = "sdk/examples/cancel_all_conditional_orders.rs"
@@ -174,6 +178,7 @@ fixed              = { workspace = true }
 futures-util       = { workspace = true }
 parking_lot        = { workspace = true }
 pastey             = { workspace = true }
+rand               = { workspace = true }
 reqwest            = { workspace = true }
 rust_decimal       = { workspace = true }
 serde              = { workspace = true }
@@ -199,7 +204,6 @@ utoipa             = { workspace = true, optional = true }
 axum                            = "0.8"
 litesvm                         = "0.7"
 proptest                        = "1.6"
-rand                            = "0.9"
 solana-commitment-config        = { workspace = true }
 solana-compute-budget-interface = "~2.2"
 solana-keypair                  = { workspace = true }
@@ -221,7 +225,7 @@ publish      = true
 readme       = "CRATES.md"
 repository   = "https://github.com/Ellipsis-Labs/rise"
 rust-version = "1.84.0"
-version      = "0.1.7"
+version      = "0.1.8"
 
 [workspace.dependencies]
 async-trait = "0.1"
@@ -236,6 +240,7 @@ fixed = "=1.29.0"
 futures-util = "0.3"
 parking_lot = "0.12"
 pastey = "0.1"
+rand = "0.10"
 reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "rustls-tls-webpki-roots",

--- a/rust/math/src/fixed.rs
+++ b/rust/math/src/fixed.rs
@@ -131,7 +131,7 @@ impl Debug for I80F48 {
 #[cfg(test)]
 mod tests {
     use rand::rngs::StdRng;
-    use rand::{Rng, SeedableRng};
+    use rand::{RngExt, SeedableRng};
 
     #[test]
     fn seeded_fixed_fuzz_test() {

--- a/rust/sdk/src/auth.rs
+++ b/rust/sdk/src/auth.rs
@@ -30,7 +30,7 @@ use crate::phoenix_rise_types::{
 };
 use crate::transport::{
     PhoenixApiError, build_default_http_client, map_api_error_response, map_reqwest_error,
-    normalize_base_url,
+    normalize_base_url, parse_retry_after_seconds,
 };
 
 const DEFAULT_AUTH_SESSION_RELATIVE_PATH: &str = ".config/phoenix/access_token.json";
@@ -1368,13 +1368,6 @@ fn parse_error_code(body: &str) -> Option<String> {
                 .and_then(|entry| entry.as_str())
                 .map(str::to_string)
         })
-}
-
-fn parse_retry_after_seconds(headers: &reqwest::header::HeaderMap) -> Option<u64> {
-    headers
-        .get(reqwest::header::RETRY_AFTER)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.parse::<u64>().ok())
 }
 
 fn body_preview(body: &str, max_chars: usize) -> String {

--- a/rust/sdk/src/http_client.rs
+++ b/rust/sdk/src/http_client.rs
@@ -56,7 +56,8 @@ pub struct RateLimitRetryConfig {
     pub max_total_wait: Duration,
     /// Fallback delay if `Retry-After` is missing or invalid.
     pub fallback_delay: Duration,
-    /// Maximum delay per retry attempt.
+    /// Maximum fallback delay per retry attempt. Explicit `Retry-After` values
+    /// are bounded by `max_total_wait` instead.
     pub max_delay: Duration,
 }
 
@@ -81,6 +82,40 @@ impl RateLimitRetryConfig {
             ..Self::default()
         }
     }
+
+    fn retry_plan(
+        &self,
+        retries: u32,
+        total_wait: Duration,
+        retry_after_seconds: Option<u64>,
+    ) -> Option<RateLimitRetryPlan> {
+        if !self.enabled || retries >= self.max_retries {
+            return None;
+        }
+
+        let wait = self.retry_delay(retry_after_seconds);
+        let next_total_wait = total_wait.saturating_add(wait);
+        if next_total_wait > self.max_total_wait {
+            return None;
+        }
+
+        Some(RateLimitRetryPlan {
+            wait,
+            next_total_wait,
+        })
+    }
+
+    fn retry_delay(&self, retry_after_seconds: Option<u64>) -> Duration {
+        retry_after_seconds
+            .map(Duration::from_secs)
+            .unwrap_or_else(|| fallback_delay_with_jitter(self.fallback_delay, self.max_delay))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RateLimitRetryPlan {
+    wait: Duration,
+    next_total_wait: Duration,
 }
 
 /// Shared HTTP transport used by all resource sub-clients.
@@ -173,40 +208,26 @@ impl HttpClientInner {
                 Err(error) if retryable && error.is_rate_limited() => {
                     let retry_after_seconds = error.retry_after_seconds();
                     let attempts = retries.saturating_add(1);
-                    let can_retry = self.rate_limit_retry.enabled
-                        && retries < self.rate_limit_retry.max_retries;
-
-                    if !can_retry {
+                    let Some(plan) =
+                        self.rate_limit_retry
+                            .retry_plan(retries, total_wait, retry_after_seconds)
+                    else {
                         return Err(map_rate_limited_error(
                             error,
                             attempts,
                             Some(self.auth_lifecycle_state()),
                         ));
-                    }
-
-                    let wait = retry_after_seconds
-                        .map(Duration::from_secs)
-                        .unwrap_or(self.rate_limit_retry.fallback_delay)
-                        .min(self.rate_limit_retry.max_delay);
-                    let next_total_wait = total_wait.saturating_add(wait);
-
-                    if next_total_wait > self.rate_limit_retry.max_total_wait {
-                        return Err(map_rate_limited_error(
-                            error,
-                            attempts,
-                            Some(self.auth_lifecycle_state()),
-                        ));
-                    }
+                    };
 
                     debug!(
                         "Rise HTTP rate limited, retrying attempt {} in {:?} (retry_after={:?})",
                         attempts + 1,
-                        wait,
+                        plan.wait,
                         retry_after_seconds
                     );
 
-                    tokio::time::sleep(wait).await;
-                    total_wait = next_total_wait;
+                    tokio::time::sleep(plan.wait).await;
+                    total_wait = plan.next_total_wait;
                     retries = retries.saturating_add(1);
                 }
                 Err(error) => {
@@ -1027,6 +1048,21 @@ fn map_rate_limited_error(
         }
         other => map_transport_error(other, auth_lifecycle_state, None),
     }
+}
+
+fn fallback_delay_with_jitter(fallback_delay: Duration, max_delay: Duration) -> Duration {
+    if fallback_delay.is_zero() {
+        return Duration::ZERO;
+    }
+
+    let jitter_percent = u128::from(fallback_jitter_percent());
+    let jittered_millis = fallback_delay.as_millis().saturating_mul(jitter_percent) / 100;
+    let millis = u64::try_from(jittered_millis).unwrap_or(u64::MAX);
+    Duration::from_millis(millis).min(max_delay)
+}
+
+fn fallback_jitter_percent() -> u32 {
+    rand::random_range(85..=115)
 }
 
 fn auth_error_code(error: &AuthError) -> Option<String> {

--- a/rust/sdk/src/transport.rs
+++ b/rust/sdk/src/transport.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use chrono::Utc;
 use parking_lot::Mutex;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::{Client, Method, StatusCode};
@@ -794,11 +795,33 @@ fn parse_error_code(body: &str) -> Option<String> {
         })
 }
 
-fn parse_retry_after_seconds(headers: &reqwest::header::HeaderMap) -> Option<u64> {
+pub(crate) fn parse_retry_after_seconds(headers: &reqwest::header::HeaderMap) -> Option<u64> {
     headers
         .get(reqwest::header::RETRY_AFTER)
         .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.parse::<u64>().ok())
+        .and_then(|value| parse_retry_after_value_seconds(value, Utc::now()))
+}
+
+fn parse_retry_after_value_seconds(value: &str, now: chrono::DateTime<Utc>) -> Option<u64> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Ok(seconds) = trimmed.parse::<u64>() {
+        return Some(seconds);
+    }
+
+    let retry_at = chrono::DateTime::parse_from_rfc2822(trimmed).ok()?;
+    let delta_ms = retry_at
+        .with_timezone(&Utc)
+        .signed_duration_since(now)
+        .num_milliseconds();
+    if delta_ms <= 0 {
+        return Some(0);
+    }
+    let rounded_seconds = (delta_ms + 999) / 1_000;
+    u64::try_from(rounded_seconds).ok()
 }
 
 fn body_preview(body: &str, max_chars: usize) -> String {
@@ -994,5 +1017,23 @@ mod tests {
         let requests = requests.lock();
         assert_eq!(requests[0].path, "/v1/auth/refresh");
         assert_eq!(requests[0].authorization, None);
+    }
+
+    #[test]
+    fn retry_after_parses_seconds_and_http_dates() {
+        let now = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .expect("valid test timestamp")
+            .with_timezone(&Utc);
+
+        assert_eq!(parse_retry_after_value_seconds("2", now), Some(2));
+        assert_eq!(
+            parse_retry_after_value_seconds("Thu, 01 Jan 2026 00:00:02 GMT", now),
+            Some(2)
+        );
+        assert_eq!(
+            parse_retry_after_value_seconds("Wed, 31 Dec 2025 23:59:59 GMT", now),
+            Some(0)
+        );
+        assert_eq!(parse_retry_after_value_seconds("invalid", now), None);
     }
 }

--- a/rust/sdk/tests/http_retry_tests.rs
+++ b/rust/sdk/tests/http_retry_tests.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
 use axum::Router;
 use axum::extract::State;
@@ -7,35 +8,50 @@ use axum::http::header::{CONTENT_TYPE, RETRY_AFTER};
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
-use phoenix_rise::{PhoenixHttpClient, PhoenixHttpError};
+use phoenix_rise::{PhoenixHttpClient, PhoenixHttpError, RateLimitRetryConfig};
+use serde_json::json;
 use tokio::net::TcpListener;
+
+const EXCHANGE_KEYS_PATH: &str = "/v1/view/exchange/keys";
 
 #[derive(Clone)]
 struct TestState {
     exchange_keys_calls: Arc<AtomicUsize>,
+    rate_limited_responses: usize,
+    retry_after: String,
+}
+
+impl TestState {
+    fn new(rate_limited_responses: usize, retry_after: impl Into<String>) -> Self {
+        Self {
+            exchange_keys_calls: Arc::new(AtomicUsize::new(0)),
+            rate_limited_responses,
+            retry_after: retry_after.into(),
+        }
+    }
+
+    fn exchange_keys_calls(&self) -> usize {
+        self.exchange_keys_calls.load(Ordering::SeqCst)
+    }
 }
 
 #[tokio::test]
 async fn get_requests_retry_rate_limited_responses_by_default() {
-    let state = TestState {
-        exchange_keys_calls: Arc::new(AtomicUsize::new(0)),
-    };
+    let state = TestState::new(1, "0");
     let (base_url, server) = spawn_test_server(state.clone()).await;
 
     let client = PhoenixHttpClient::builder(base_url).build().unwrap();
     let keys = client.exchange().get_keys().await.unwrap();
 
     assert_eq!(keys.global_config, "11111111111111111111111111111111");
-    assert_eq!(state.exchange_keys_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(state.exchange_keys_calls(), 2);
 
     server.abort();
 }
 
 #[tokio::test]
 async fn get_requests_can_disable_rate_limit_retry_at_creation() {
-    let state = TestState {
-        exchange_keys_calls: Arc::new(AtomicUsize::new(0)),
-    };
+    let state = TestState::new(1, "0");
     let (base_url, server) = spawn_test_server(state.clone()).await;
 
     let client = PhoenixHttpClient::builder(base_url)
@@ -44,27 +60,69 @@ async fn get_requests_can_disable_rate_limit_retry_at_creation() {
         .unwrap();
 
     let error = client.exchange().get_keys().await.unwrap_err();
-    match error {
-        PhoenixHttpError::RateLimited {
-            retry_after_seconds,
-            error_code,
-            attempts,
-            ..
-        } => {
-            assert_eq!(retry_after_seconds, Some(0));
-            assert_eq!(error_code.as_deref(), Some("rate_limited"));
-            assert_eq!(attempts, 1);
-        }
-        other => panic!("expected rate-limited error, got {other:?}"),
-    }
+    assert_rate_limited(error, Some(0), 1);
 
-    assert_eq!(state.exchange_keys_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(state.exchange_keys_calls(), 1);
+    server.abort();
+}
+
+#[tokio::test]
+async fn get_requests_respect_configured_max_retries() {
+    let state = TestState::new(2, "0");
+    let (base_url, server) = spawn_test_server(state.clone()).await;
+
+    let client = PhoenixHttpClient::builder(base_url).build().unwrap();
+    let keys = client.exchange().get_keys().await.unwrap();
+
+    assert_eq!(keys.global_config, "11111111111111111111111111111111");
+    assert_eq!(state.exchange_keys_calls(), 3);
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn post_requests_do_not_retry_rate_limits() {
+    let state = TestState::new(1, "0");
+    let (base_url, server) = spawn_test_server(state.clone()).await;
+
+    let client = PhoenixHttpClient::builder(base_url).build().unwrap();
+    let error = client
+        .post_json::<serde_json::Value, _>(EXCHANGE_KEYS_PATH, &json!({}))
+        .await
+        .unwrap_err();
+
+    assert_rate_limited(error, Some(0), 1);
+    assert_eq!(state.exchange_keys_calls(), 1);
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn retry_after_beyond_max_total_wait_returns_rate_limited_without_sleeping() {
+    let state = TestState::new(1, "2");
+    let (base_url, server) = spawn_test_server(state.clone()).await;
+
+    let client = PhoenixHttpClient::builder(base_url)
+        .with_rate_limit_retry_config(RateLimitRetryConfig {
+            max_total_wait: Duration::from_secs(1),
+            ..RateLimitRetryConfig::default()
+        })
+        .build()
+        .unwrap();
+    let error = client.exchange().get_keys().await.unwrap_err();
+
+    assert_rate_limited(error, Some(2), 1);
+    assert_eq!(state.exchange_keys_calls(), 1);
+
     server.abort();
 }
 
 async fn spawn_test_server(state: TestState) -> (String, tokio::task::JoinHandle<()>) {
     let app = Router::new()
-        .route("/v1/view/exchange/keys", get(exchange_keys_handler))
+        .route(
+            EXCHANGE_KEYS_PATH,
+            get(exchange_keys_handler).post(exchange_keys_handler),
+        )
         .with_state(state);
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -76,13 +134,32 @@ async fn spawn_test_server(state: TestState) -> (String, tokio::task::JoinHandle
     (format!("http://{}", addr), server)
 }
 
+fn assert_rate_limited(error: PhoenixHttpError, retry_after_seconds: Option<u64>, attempts: u32) {
+    match error {
+        PhoenixHttpError::RateLimited {
+            retry_after_seconds: actual_retry_after_seconds,
+            error_code,
+            attempts: actual_attempts,
+            ..
+        } => {
+            assert_eq!(actual_retry_after_seconds, retry_after_seconds);
+            assert_eq!(error_code.as_deref(), Some("rate_limited"));
+            assert_eq!(actual_attempts, attempts);
+        }
+        other => panic!("expected rate-limited error, got {other:?}"),
+    }
+}
+
 async fn exchange_keys_handler(State(state): State<TestState>) -> Response {
     let attempt = state.exchange_keys_calls.fetch_add(1, Ordering::SeqCst);
     let mut headers = HeaderMap::new();
     headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
 
-    if attempt == 0 {
-        headers.insert(RETRY_AFTER, HeaderValue::from_static("0"));
+    if attempt < state.rate_limited_responses {
+        headers.insert(
+            RETRY_AFTER,
+            HeaderValue::from_str(&state.retry_after).expect("valid retry-after header"),
+        );
         return (
             StatusCode::TOO_MANY_REQUESTS,
             headers,


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `6487be852f3a382717f345a43fd956af3fba1766`
- Mode: automatic
- Synced paths:

- `rise/rust` -> `rust`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `rust/CHANGELOG.md`

### Summary

- Upgraded `rand` from 0.9 to 0.10 (now a workspace dependency); the `rand::Rng` trait import in math tests is replaced by `rand::RngExt`.
- Rate-limit retry logic now applies ±15% jitter to the fallback delay when no `Retry-After` header is present, reducing thundering-herd retries.
- `Retry-After` header parsing now accepts both integer seconds and HTTP-date (`RFC 2822`) values; previously only integer seconds were recognized.
- The `max_delay` field on `RateLimitRetryConfig` now bounds only the jittered fallback delay; explicit `Retry-After` values are bounded by `max_total_wait` instead (doc clarification, behavior change for large `Retry-After` values).

### Breaking Changes

- **`rand` 0.10 workspace dependency**: if your crate depends on `phoenix-rise` and also uses `rand`, you may need to align to `rand = "0.10"`. The `rand::Rng` trait is replaced by `rand::RngExt` in 0.10 — any code importing `rand::Rng` via a shared dependency tree will need updating.
- **`RateLimitRetryConfig::max_delay` semantics changed**: previously capped all retry delays including explicit `Retry-After` header values; now only caps the jittered fallback delay. If you set a small `max_delay` to bound `Retry-After`-driven waits, use `max_total_wait` instead.

### Consumer Notes

- No changes to public API surface beyond the `RateLimitRetryConfig` doc/semantic fix above.
- The jitter on fallback delays (±15%) is applied automatically; no configuration required or available.
- If your server sends `Retry-After` as an HTTP-date string, the client will now correctly parse and honor it.