### PR TITLE
sync: Rise TypeScript v0.4.43

### DIFF
--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -298,3 +298,23 @@ Source Phoenix commit: `ee8192d915d1d282849dc7e70d84db2e51cbba42`
 
 - The new `permissionAddress` field on `ClientTransferCollateralInput` and `ResolvedTransferCollateralIxInput` is optional and backward compatible; no changes required if you are not using position authority delegation for collateral transfers.
 - If you pass a `permissionAddress`, it is included as the last account (writable) on the resulting `TransferCollateral` instruction — account index assumptions in any manual account-position logic should account for this trailing account.
+
+## v0.4.43 - 2026-06-17
+
+Source Phoenix commit: `e01d6bf79f112b8f9c7c6e7e3ad84fb83050eb43`
+
+### Summary
+
+- **Hawkeye program client**: Added a full read-only simulation client for the Hawkeye program (`RiSeVw3ZjNfsaXPRb4mgaqYaEEt41pNNJoDvVh7pgQj`). Call `client.rpc.hawkeye.viewMargin(...)`, `.viewMarginForAsset(...)`, `.viewLiquidationPrice(...)`, `.viewBbo(...)`, and `.viewFunding(...)` to query on-chain margin, risk state, liquidation price, BBO, and funding data via transaction simulation — no signature required.
+- **New root-level exports**: Five instruction builders (`buildHawkeyeViewMarginIx`, `buildHawkeyeViewMarginForAssetIx`, `buildHawkeyeViewLiquidationPriceIx`, `buildHawkeyeViewBboIx`, `buildHawkeyeViewFundingIx`), `decodeHawkeyeReturnData`, `encodeHawkeyeSimulationTransaction`, `HAWKEYE_PROGRAM_ADDRESS`, `HAWKEYE_SIMULATION_COMPUTE_UNIT_LIMIT`, and all associated TypeScript types (`HawkeyeReturnData`, `HawkeyeMarginReturn`, `HawkeyeAssetReturn`, `HawkeyeLiquidationPriceReturn`, `HawkeyeBboReturn`, `HawkeyeFundingReturn`, etc.) are now exported from the package root.
+- **`PhoenixIxClient` additions**: Five new `buildHawkeyeView*` methods on the ix client automatically resolve trader accounts and asset IDs from authority/symbol, mirroring the existing client pattern.
+- **`zod` pinned to `4.4.3`** (previously `^4.3.6`).
+
+### Breaking Changes
+
+- None identified in the synced diff.
+
+### Consumer Notes
+
+- `PhoenixRpcAccountFetcherClient.request` was widened from `private` to `public`; this is additive and does not break existing code, but the method is now formally part of the class surface.
+- The `zod` dependency is now pinned to the exact version `4.4.3`. If your project declares `zod` as a direct dependency and previously resolved `^4.3.6` to a different patch, verify your lockfile resolves cleanly after upgrading to this version of `@ellipsis-labs/rise`.

--- a/ts/bun.lock
+++ b/ts/bun.lock
@@ -10,7 +10,7 @@
         "@solana/kit": "^4.0.0",
         "fzstd": "^0.1.1",
         "xstate": "^5.28.0",
-        "zod": "^4.3.6",
+        "zod": "4.4.3",
         "zustand": "^5.0.12",
       },
       "devDependencies": {
@@ -733,7 +733,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
 

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/rise",
-  "version": "0.4.42",
+  "version": "0.4.43",
   "packageManager": "bun@1.3.13",
   "repository": {
     "type": "git",
@@ -61,7 +61,7 @@
     "@solana/kit": "^4.0.0",
     "fzstd": "^0.1.1",
     "xstate": "^5.28.0",
-    "zod": "^4.3.6",
+    "zod": "4.4.3",
     "zustand": "^5.0.12"
   },
   "overrides": {

--- a/ts/src/hawkeye.ts
+++ b/ts/src/hawkeye.ts
@@ -1,0 +1,528 @@
+import { sha2_const } from "@/core/discriminants";
+import { generateReadonlyAccount } from "@/core/utils/accountMeta";
+import type {
+  ActiveTraderBufferAddressArray,
+  GlobalConfigurationAddress,
+  GlobalTraderIndexAddressArray,
+  MarketAddress,
+  PerpAssetMapAddress,
+  PhoenixProgramAddress,
+  SplineCollectionAddress,
+  TraderAddress,
+} from "@/primitives";
+import type { InstructionsWithAccountsAndData } from "@/primitives/_utilityTypes";
+import {
+  address,
+  appendTransactionMessageInstructions,
+  compileTransaction,
+  createTransactionMessage,
+  getBase64EncodedWireTransaction,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+  type Address,
+  type Blockhash,
+  type Instruction,
+} from "@solana/kit";
+
+export const HAWKEYE_PROGRAM_ADDRESS: Address = address(
+  "RiSeVw3ZjNfsaXPRb4mgaqYaEEt41pNNJoDvVh7pgQj"
+);
+
+export const HAWKEYE_SIMULATION_FEE_PAYER: Address = address(
+  "Hik5qWJvfgZR9HAGfNqYXfhxbYNGRoZbABEkP91zgC5h"
+);
+
+export const HAWKEYE_SIMULATION_COMPUTE_UNIT_LIMIT: number = 1_400_000;
+export const HAWKEYE_RETURN_VERSION: number = 1;
+
+export type HawkeyeViewInstructionDiscriminators = {
+  readonly margin: "global:view_margin";
+  readonly asset: "global:view_margin_for_asset";
+  readonly liquidation: "global:view_liquidation_price";
+  readonly bbo: "global:view_bbo";
+  readonly funding: "global:view_funding";
+};
+
+export const HAWKEYE_VIEW_INSTRUCTIONS: HawkeyeViewInstructionDiscriminators = {
+  margin: "global:view_margin",
+  asset: "global:view_margin_for_asset",
+  liquidation: "global:view_liquidation_price",
+  bbo: "global:view_bbo",
+  funding: "global:view_funding",
+};
+
+export type HawkeyeReturnLabels = {
+  readonly margin: "view_margin";
+  readonly asset: "view_margin_for_asset";
+  readonly liquidation: "view_liquidation_price";
+  readonly bbo: "view_bbo";
+  readonly funding: "view_funding";
+};
+
+export const HAWKEYE_RETURN_LABELS: HawkeyeReturnLabels = {
+  margin: "view_margin",
+  asset: "view_margin_for_asset",
+  liquidation: "view_liquidation_price",
+  bbo: "view_bbo",
+  funding: "view_funding",
+};
+
+export type HawkeyeViewKind = keyof typeof HAWKEYE_VIEW_INSTRUCTIONS;
+
+const HAWKEYE_RETURN_MAGICS = {
+  margin: sha2_const("return:phoenix_hawkeye_margin"),
+  asset: sha2_const("return:phoenix_hawkeye_asset"),
+  liquidation: sha2_const("return:phoenix_hawkeye_liquidation_price"),
+  bbo: sha2_const("return:phoenix_hawkeye_bbo"),
+  funding: sha2_const("return:phoenix_hawkeye_funding"),
+} as const;
+
+export const HAWKEYE_BBO_HAS_BID: number = 1 << 0;
+export const HAWKEYE_BBO_HAS_ASK: number = 1 << 1;
+export const HAWKEYE_FUNDING_HAS_ACCUMULATED: number = 1 << 0;
+export const HAWKEYE_FUNDING_HAS_UNSETTLED: number = 1 << 1;
+
+const RISK_STATES = [
+  "healthy",
+  "unhealthy",
+  "underwater",
+  "zero_collateral_no_positions",
+] as const;
+
+const RISK_TIERS = [
+  "safe",
+  "at_risk",
+  "cancellable",
+  "liquidatable",
+  "backstop_liquidatable",
+  "high_risk",
+] as const;
+
+const LIQUIDATION_STATUSES = [
+  "no_position",
+  "found",
+  "already_liquidatable",
+  "no_price_in_bounds",
+] as const;
+
+const SIDES = ["flat", "long", "short"] as const;
+
+export type HawkeyeCodeLabel<TLabel extends string = string> = {
+  code: number;
+  label: TLabel | "unknown";
+};
+
+export type HawkeyeMagic = {
+  decimal: string;
+  hex: string;
+};
+
+export type HawkeyeMarginReturn = {
+  kind: typeof HAWKEYE_RETURN_LABELS.margin;
+  magic: HawkeyeMagic;
+  version: number;
+  positionCount: number;
+  riskState: HawkeyeCodeLabel<(typeof RISK_STATES)[number]>;
+  riskTier: HawkeyeCodeLabel<(typeof RISK_TIERS)[number]>;
+  isLiquidatable: boolean;
+  collateralQuoteLots: bigint;
+  effectiveCollateralQuoteLots: bigint;
+  freeCollateralQuoteLots: bigint;
+  withdrawableCollateralQuoteLots: bigint;
+  initialMarginQuoteLots: bigint;
+  maintenanceMarginQuoteLots: bigint;
+  cancelMarginQuoteLots: bigint;
+  backstopMarginQuoteLots: bigint;
+  highRiskMarginQuoteLots: bigint;
+  unrealizedPnlQuoteLots: bigint;
+  discountedUnrealizedPnlQuoteLots: bigint;
+  unsettledFundingQuoteLots: bigint;
+};
+
+export type HawkeyeAssetReturn = {
+  kind: typeof HAWKEYE_RETURN_LABELS.asset;
+  magic: HawkeyeMagic;
+  assetId: number;
+  version: number;
+  hasPositionOrOrders: boolean;
+  riskState: HawkeyeCodeLabel<(typeof RISK_STATES)[number]>;
+  riskTier: HawkeyeCodeLabel<(typeof RISK_TIERS)[number]>;
+  baseLots: bigint;
+  virtualQuoteLots: bigint;
+  markPriceTicks: bigint;
+  entryPriceQuoteLotsPerBaseLot: bigint;
+  positionValueQuoteLots: bigint;
+  unrealizedPnlQuoteLots: bigint;
+  discountedUnrealizedPnlQuoteLots: bigint;
+  unsettledFundingQuoteLots: bigint;
+  initialMarginQuoteLots: bigint;
+  maintenanceMarginQuoteLots: bigint;
+  cancelMarginQuoteLots: bigint;
+  backstopMarginQuoteLots: bigint;
+  highRiskMarginQuoteLots: bigint;
+};
+
+export type HawkeyeLiquidationPriceReturn = {
+  kind: typeof HAWKEYE_RETURN_LABELS.liquidation;
+  magic: HawkeyeMagic;
+  assetId: number;
+  version: number;
+  status: HawkeyeCodeLabel<(typeof LIQUIDATION_STATUSES)[number]>;
+  side: HawkeyeCodeLabel<(typeof SIDES)[number]>;
+  liquidationPriceTicks: bigint;
+  markPriceTicks: bigint;
+  entryPriceQuoteLotsPerBaseLot: bigint;
+  effectiveCollateralQuoteLots: bigint;
+  maintenanceMarginQuoteLots: bigint;
+};
+
+export type HawkeyeBboReturn = {
+  kind: typeof HAWKEYE_RETURN_LABELS.bbo;
+  magic: HawkeyeMagic;
+  version: number;
+  flags: number;
+  bestBidTicks: bigint | null;
+  bestAskTicks: bigint | null;
+  markPriceTicks: bigint;
+  indexPriceTicks: bigint;
+  markPriceLastUpdatedSlot: bigint;
+  indexPriceLastUpdatedSlot: bigint;
+};
+
+export type HawkeyeFundingReturn = {
+  kind: typeof HAWKEYE_RETURN_LABELS.funding;
+  magic: HawkeyeMagic;
+  assetId: number;
+  version: number;
+  flags: number;
+  totalAccumulatedFundingQuoteLots: bigint | null;
+  totalUnsettledFundingQuoteLots: bigint | null;
+  currentFundingRateMicroBps: bigint;
+  projected1hFundingRateMicroBps: bigint;
+};
+
+export type HawkeyeReturnData =
+  | HawkeyeMarginReturn
+  | HawkeyeAssetReturn
+  | HawkeyeLiquidationPriceReturn
+  | HawkeyeBboReturn
+  | HawkeyeFundingReturn;
+
+export type HawkeyeBaseAccounts = {
+  phoenixProgramAddress: PhoenixProgramAddress;
+  globalConfigurationAddress: GlobalConfigurationAddress;
+  globalTraderIndex: GlobalTraderIndexAddressArray;
+  activeTraderBuffer: ActiveTraderBufferAddressArray;
+  perpAssetMap: PerpAssetMapAddress;
+};
+
+export type HawkeyeTraderViewAccounts = HawkeyeBaseAccounts & {
+  traderAccount: TraderAddress;
+};
+
+export type HawkeyeBboViewAccounts = HawkeyeBaseAccounts & {
+  orderbook: MarketAddress;
+  splineCollection: SplineCollectionAddress;
+};
+
+export type HawkeyeIx = InstructionsWithAccountsAndData;
+
+export const buildHawkeyeViewMarginIx = (
+  params: HawkeyeTraderViewAccounts
+): HawkeyeIx => buildTraderViewIx(params, "margin");
+
+export const buildHawkeyeViewMarginForAssetIx = (
+  params: HawkeyeTraderViewAccounts & { assetId: number }
+): HawkeyeIx => buildTraderViewIx(params, "asset", params.assetId);
+
+export const buildHawkeyeViewLiquidationPriceIx = (
+  params: HawkeyeTraderViewAccounts & { assetId: number }
+): HawkeyeIx => buildTraderViewIx(params, "liquidation", params.assetId);
+
+export const buildHawkeyeViewFundingIx = (
+  params: HawkeyeTraderViewAccounts & { assetId: number }
+): HawkeyeIx => buildTraderViewIx(params, "funding", params.assetId);
+
+export const buildHawkeyeViewBboIx = (
+  params: HawkeyeBboViewAccounts
+): HawkeyeIx => ({
+  programAddress: HAWKEYE_PROGRAM_ADDRESS,
+  accounts: [
+    ...buildBaseAccounts(params),
+    generateReadonlyAccount(params.orderbook),
+    generateReadonlyAccount(params.splineCollection),
+  ],
+  data: buildHawkeyeInstructionData("bbo"),
+});
+
+export const buildSetComputeUnitLimitIx = (
+  units: number = HAWKEYE_SIMULATION_COMPUTE_UNIT_LIMIT
+): Instruction => {
+  const data = new Uint8Array(5);
+  const view = new DataView(data.buffer);
+  view.setUint8(0, 2);
+  view.setUint32(1, units, true);
+  return {
+    programAddress: address("ComputeBudget111111111111111111111111111111"),
+    accounts: [],
+    data,
+  };
+};
+
+export const encodeHawkeyeSimulationTransaction = (params: {
+  instruction: Instruction;
+  blockhash: Blockhash;
+  lastValidBlockHeight: bigint;
+  feePayer?: Address;
+  computeUnitLimit?: number;
+}): string => {
+  const message = appendTransactionMessageInstructions(
+    [buildSetComputeUnitLimitIx(params.computeUnitLimit), params.instruction],
+    setTransactionMessageLifetimeUsingBlockhash(
+      {
+        blockhash: params.blockhash,
+        lastValidBlockHeight: params.lastValidBlockHeight,
+      },
+      setTransactionMessageFeePayer(
+        params.feePayer ?? HAWKEYE_SIMULATION_FEE_PAYER,
+        createTransactionMessage({ version: 0 })
+      )
+    )
+  );
+
+  return getBase64EncodedWireTransaction(compileTransaction(message));
+};
+
+export const decodeHawkeyeReturnData = (
+  bytes: Uint8Array
+): HawkeyeReturnData => {
+  const kind = identifyHawkeyeReturnKind(bytes);
+  switch (kind) {
+    case "margin":
+      return decodeMargin(bytes);
+    case "asset":
+      return decodeAsset(bytes);
+    case "liquidation":
+      return decodeLiquidation(bytes);
+    case "bbo":
+      return decodeBbo(bytes);
+    case "funding":
+      return decodeFunding(bytes);
+  }
+};
+
+const buildTraderViewIx = (
+  params: HawkeyeTraderViewAccounts,
+  kind: "margin" | "asset" | "liquidation" | "funding",
+  assetId?: number
+): HawkeyeIx => ({
+  programAddress: HAWKEYE_PROGRAM_ADDRESS,
+  accounts: [
+    ...buildBaseAccounts(params),
+    generateReadonlyAccount(params.traderAccount),
+  ],
+  data: buildHawkeyeInstructionData(kind, assetId),
+});
+
+const buildBaseAccounts = (params: HawkeyeBaseAccounts) => [
+  generateReadonlyAccount(params.phoenixProgramAddress),
+  generateReadonlyAccount(params.globalConfigurationAddress),
+  ...params.globalTraderIndex.map(generateReadonlyAccount),
+  ...params.activeTraderBuffer.map(generateReadonlyAccount),
+  generateReadonlyAccount(params.perpAssetMap),
+];
+
+const buildHawkeyeInstructionData = (
+  kind: HawkeyeViewKind,
+  assetId?: number
+): Uint8Array => {
+  const needsAsset =
+    kind === "asset" || kind === "liquidation" || kind === "funding";
+  if (needsAsset && assetId === undefined) {
+    throw new Error("assetId is required for this Hawkeye view");
+  }
+  const data = new Uint8Array(needsAsset ? 16 : 8);
+  data.set(sha2_const(HAWKEYE_VIEW_INSTRUCTIONS[kind]), 0);
+  if (needsAsset) {
+    new DataView(data.buffer).setUint32(8, assetId!, true);
+  }
+  return data;
+};
+
+const identifyHawkeyeReturnKind = (bytes: Uint8Array): HawkeyeViewKind => {
+  expectLengthAtLeast(bytes, 8, "Hawkeye return data");
+  for (const [kind, magic] of Object.entries(HAWKEYE_RETURN_MAGICS)) {
+    if (bytesEqual(bytes.subarray(0, 8), magic)) {
+      return kind as HawkeyeViewKind;
+    }
+  }
+  throw new Error(`Unknown Hawkeye return data magic ${readMagic(bytes).hex}`);
+};
+
+const decodeMargin = (bytes: Uint8Array): HawkeyeMarginReturn => {
+  const view = viewFor(bytes, 112, "view_margin");
+  return {
+    kind: HAWKEYE_RETURN_LABELS.margin,
+    magic: readMagic(bytes),
+    version: view.getUint16(8, true),
+    positionCount: view.getUint16(10, true),
+    riskState: codeLabel(RISK_STATES, view.getUint8(12)),
+    riskTier: codeLabel(RISK_TIERS, view.getUint8(13)),
+    isLiquidatable: view.getUint8(14) !== 0,
+    collateralQuoteLots: view.getBigInt64(16, true),
+    effectiveCollateralQuoteLots: view.getBigInt64(24, true),
+    freeCollateralQuoteLots: view.getBigInt64(32, true),
+    withdrawableCollateralQuoteLots: view.getBigUint64(40, true),
+    initialMarginQuoteLots: view.getBigUint64(48, true),
+    maintenanceMarginQuoteLots: view.getBigUint64(56, true),
+    cancelMarginQuoteLots: view.getBigUint64(64, true),
+    backstopMarginQuoteLots: view.getBigUint64(72, true),
+    highRiskMarginQuoteLots: view.getBigUint64(80, true),
+    unrealizedPnlQuoteLots: view.getBigInt64(88, true),
+    discountedUnrealizedPnlQuoteLots: view.getBigInt64(96, true),
+    unsettledFundingQuoteLots: view.getBigInt64(104, true),
+  };
+};
+
+const decodeAsset = (bytes: Uint8Array): HawkeyeAssetReturn => {
+  const view = viewFor(bytes, 128, "view_margin_for_asset");
+  return {
+    kind: HAWKEYE_RETURN_LABELS.asset,
+    magic: readMagic(bytes),
+    assetId: view.getUint32(8, true),
+    version: view.getUint16(12, true),
+    hasPositionOrOrders: view.getUint8(14) !== 0,
+    riskState: codeLabel(RISK_STATES, view.getUint8(16)),
+    riskTier: codeLabel(RISK_TIERS, view.getUint8(17)),
+    baseLots: view.getBigInt64(24, true),
+    virtualQuoteLots: view.getBigInt64(32, true),
+    markPriceTicks: view.getBigUint64(40, true),
+    entryPriceQuoteLotsPerBaseLot: view.getBigUint64(48, true),
+    positionValueQuoteLots: view.getBigInt64(56, true),
+    unrealizedPnlQuoteLots: view.getBigInt64(64, true),
+    discountedUnrealizedPnlQuoteLots: view.getBigInt64(72, true),
+    unsettledFundingQuoteLots: view.getBigInt64(80, true),
+    initialMarginQuoteLots: view.getBigUint64(88, true),
+    maintenanceMarginQuoteLots: view.getBigUint64(96, true),
+    cancelMarginQuoteLots: view.getBigUint64(104, true),
+    backstopMarginQuoteLots: view.getBigUint64(112, true),
+    highRiskMarginQuoteLots: view.getBigUint64(120, true),
+  };
+};
+
+const decodeLiquidation = (
+  bytes: Uint8Array
+): HawkeyeLiquidationPriceReturn => {
+  const view = viewFor(bytes, 56, "view_liquidation_price");
+  return {
+    kind: HAWKEYE_RETURN_LABELS.liquidation,
+    magic: readMagic(bytes),
+    assetId: view.getUint32(8, true),
+    version: view.getUint16(12, true),
+    status: codeLabel(LIQUIDATION_STATUSES, view.getUint8(14)),
+    side: codeLabel(SIDES, view.getUint8(15)),
+    liquidationPriceTicks: view.getBigUint64(16, true),
+    markPriceTicks: view.getBigUint64(24, true),
+    entryPriceQuoteLotsPerBaseLot: view.getBigUint64(32, true),
+    effectiveCollateralQuoteLots: view.getBigInt64(40, true),
+    maintenanceMarginQuoteLots: view.getBigUint64(48, true),
+  };
+};
+
+const decodeBbo = (bytes: Uint8Array): HawkeyeBboReturn => {
+  const view = viewFor(bytes, 64, "view_bbo");
+  const flags = view.getUint8(10);
+  return {
+    kind: HAWKEYE_RETURN_LABELS.bbo,
+    magic: readMagic(bytes),
+    version: view.getUint16(8, true),
+    flags,
+    bestBidTicks:
+      (flags & HAWKEYE_BBO_HAS_BID) !== 0 ? view.getBigUint64(16, true) : null,
+    bestAskTicks:
+      (flags & HAWKEYE_BBO_HAS_ASK) !== 0 ? view.getBigUint64(24, true) : null,
+    markPriceTicks: view.getBigUint64(32, true),
+    indexPriceTicks: view.getBigUint64(40, true),
+    markPriceLastUpdatedSlot: view.getBigUint64(48, true),
+    indexPriceLastUpdatedSlot: view.getBigUint64(56, true),
+  };
+};
+
+const decodeFunding = (bytes: Uint8Array): HawkeyeFundingReturn => {
+  const view = viewFor(bytes, 48, "view_funding");
+  const flags = view.getUint8(14);
+  return {
+    kind: HAWKEYE_RETURN_LABELS.funding,
+    magic: readMagic(bytes),
+    assetId: view.getUint32(8, true),
+    version: view.getUint16(12, true),
+    flags,
+    totalAccumulatedFundingQuoteLots:
+      (flags & HAWKEYE_FUNDING_HAS_ACCUMULATED) !== 0
+        ? view.getBigInt64(16, true)
+        : null,
+    totalUnsettledFundingQuoteLots:
+      (flags & HAWKEYE_FUNDING_HAS_UNSETTLED) !== 0
+        ? view.getBigInt64(24, true)
+        : null,
+    currentFundingRateMicroBps: view.getBigInt64(32, true),
+    projected1hFundingRateMicroBps: view.getBigInt64(40, true),
+  };
+};
+
+const viewFor = (
+  bytes: Uint8Array,
+  expectedLength: number,
+  label: string
+): DataView => {
+  if (bytes.byteLength !== expectedLength) {
+    throw new Error(
+      `${label} return data expected ${expectedLength} bytes, got ${bytes.byteLength}`
+    );
+  }
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+};
+
+const expectLengthAtLeast = (
+  bytes: Uint8Array,
+  expectedLength: number,
+  label: string
+) => {
+  if (bytes.byteLength < expectedLength) {
+    throw new Error(
+      `${label} expected at least ${expectedLength} bytes, got ${bytes.byteLength}`
+    );
+  }
+};
+
+const readMagic = (bytes: Uint8Array): HawkeyeMagic => {
+  const value = new DataView(
+    bytes.buffer,
+    bytes.byteOffset,
+    bytes.byteLength
+  ).getBigUint64(0, true);
+  return {
+    decimal: value.toString(),
+    hex: `0x${value.toString(16).padStart(16, "0")}`,
+  };
+};
+
+const codeLabel = <T extends readonly string[]>(
+  labels: T,
+  code: number
+): HawkeyeCodeLabel<T[number]> => ({
+  code,
+  label: labels[code] ?? "unknown",
+});
+
+const bytesEqual = (left: Uint8Array, right: Uint8Array): boolean => {
+  if (left.byteLength !== right.byteLength) {
+    return false;
+  }
+  for (let index = 0; index < left.byteLength; index += 1) {
+    if (left[index] !== right[index]) {
+      return false;
+    }
+  }
+  return true;
+};

--- a/ts/src/hawkeye.ts
+++ b/ts/src/hawkeye.ts
@@ -25,11 +25,11 @@ import {
 } from "@solana/kit";
 
 export const HAWKEYE_PROGRAM_ADDRESS: Address = address(
-  "RiSeVw3ZjNfsaXPRb4mgaqYaEEt41pNNJoDvVh7pgQj"
+  "RiSeVw3ZjNfsaXPRb4mgaqYaEEt41pNNJoDvVh7pgQj",
 );
 
 export const HAWKEYE_SIMULATION_FEE_PAYER: Address = address(
-  "Hik5qWJvfgZR9HAGfNqYXfhxbYNGRoZbABEkP91zgC5h"
+  "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
 );
 
 export const HAWKEYE_SIMULATION_COMPUTE_UNIT_LIMIT: number = 1_400_000;
@@ -228,23 +228,23 @@ export type HawkeyeBboViewAccounts = HawkeyeBaseAccounts & {
 export type HawkeyeIx = InstructionsWithAccountsAndData;
 
 export const buildHawkeyeViewMarginIx = (
-  params: HawkeyeTraderViewAccounts
+  params: HawkeyeTraderViewAccounts,
 ): HawkeyeIx => buildTraderViewIx(params, "margin");
 
 export const buildHawkeyeViewMarginForAssetIx = (
-  params: HawkeyeTraderViewAccounts & { assetId: number }
+  params: HawkeyeTraderViewAccounts & { assetId: number },
 ): HawkeyeIx => buildTraderViewIx(params, "asset", params.assetId);
 
 export const buildHawkeyeViewLiquidationPriceIx = (
-  params: HawkeyeTraderViewAccounts & { assetId: number }
+  params: HawkeyeTraderViewAccounts & { assetId: number },
 ): HawkeyeIx => buildTraderViewIx(params, "liquidation", params.assetId);
 
 export const buildHawkeyeViewFundingIx = (
-  params: HawkeyeTraderViewAccounts & { assetId: number }
+  params: HawkeyeTraderViewAccounts & { assetId: number },
 ): HawkeyeIx => buildTraderViewIx(params, "funding", params.assetId);
 
 export const buildHawkeyeViewBboIx = (
-  params: HawkeyeBboViewAccounts
+  params: HawkeyeBboViewAccounts,
 ): HawkeyeIx => ({
   programAddress: HAWKEYE_PROGRAM_ADDRESS,
   accounts: [
@@ -256,7 +256,7 @@ export const buildHawkeyeViewBboIx = (
 });
 
 export const buildSetComputeUnitLimitIx = (
-  units: number = HAWKEYE_SIMULATION_COMPUTE_UNIT_LIMIT
+  units: number = HAWKEYE_SIMULATION_COMPUTE_UNIT_LIMIT,
 ): Instruction => {
   const data = new Uint8Array(5);
   const view = new DataView(data.buffer);
@@ -285,16 +285,16 @@ export const encodeHawkeyeSimulationTransaction = (params: {
       },
       setTransactionMessageFeePayer(
         params.feePayer ?? HAWKEYE_SIMULATION_FEE_PAYER,
-        createTransactionMessage({ version: 0 })
-      )
-    )
+        createTransactionMessage({ version: 0 }),
+      ),
+    ),
   );
 
   return getBase64EncodedWireTransaction(compileTransaction(message));
 };
 
 export const decodeHawkeyeReturnData = (
-  bytes: Uint8Array
+  bytes: Uint8Array,
 ): HawkeyeReturnData => {
   const kind = identifyHawkeyeReturnKind(bytes);
   switch (kind) {
@@ -314,7 +314,7 @@ export const decodeHawkeyeReturnData = (
 const buildTraderViewIx = (
   params: HawkeyeTraderViewAccounts,
   kind: "margin" | "asset" | "liquidation" | "funding",
-  assetId?: number
+  assetId?: number,
 ): HawkeyeIx => ({
   programAddress: HAWKEYE_PROGRAM_ADDRESS,
   accounts: [
@@ -334,7 +334,7 @@ const buildBaseAccounts = (params: HawkeyeBaseAccounts) => [
 
 const buildHawkeyeInstructionData = (
   kind: HawkeyeViewKind,
-  assetId?: number
+  assetId?: number,
 ): Uint8Array => {
   const needsAsset =
     kind === "asset" || kind === "liquidation" || kind === "funding";
@@ -411,7 +411,7 @@ const decodeAsset = (bytes: Uint8Array): HawkeyeAssetReturn => {
 };
 
 const decodeLiquidation = (
-  bytes: Uint8Array
+  bytes: Uint8Array,
 ): HawkeyeLiquidationPriceReturn => {
   const view = viewFor(bytes, 56, "view_liquidation_price");
   return {
@@ -473,11 +473,11 @@ const decodeFunding = (bytes: Uint8Array): HawkeyeFundingReturn => {
 const viewFor = (
   bytes: Uint8Array,
   expectedLength: number,
-  label: string
+  label: string,
 ): DataView => {
   if (bytes.byteLength !== expectedLength) {
     throw new Error(
-      `${label} return data expected ${expectedLength} bytes, got ${bytes.byteLength}`
+      `${label} return data expected ${expectedLength} bytes, got ${bytes.byteLength}`,
     );
   }
   return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
@@ -486,11 +486,11 @@ const viewFor = (
 const expectLengthAtLeast = (
   bytes: Uint8Array,
   expectedLength: number,
-  label: string
+  label: string,
 ) => {
   if (bytes.byteLength < expectedLength) {
     throw new Error(
-      `${label} expected at least ${expectedLength} bytes, got ${bytes.byteLength}`
+      `${label} expected at least ${expectedLength} bytes, got ${bytes.byteLength}`,
     );
   }
 };
@@ -499,7 +499,7 @@ const readMagic = (bytes: Uint8Array): HawkeyeMagic => {
   const value = new DataView(
     bytes.buffer,
     bytes.byteOffset,
-    bytes.byteLength
+    bytes.byteLength,
   ).getBigUint64(0, true);
   return {
     decimal: value.toString(),
@@ -509,7 +509,7 @@ const readMagic = (bytes: Uint8Array): HawkeyeMagic => {
 
 const codeLabel = <T extends readonly string[]>(
   labels: T,
-  code: number
+  code: number,
 ): HawkeyeCodeLabel<T[number]> => ({
   code,
   label: labels[code] ?? "unknown",

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -93,6 +93,7 @@ export * from "./auth";
 export * as flight from "./flight";
 export * from "./exchange-cache";
 export * from "./margin";
+export * from "./hawkeye";
 
 export type { HttpTransport, RequestOptions, QueryParams } from "./http";
 export { send, get, post, put, patch, del } from "./http";

--- a/ts/src/ixs/client.ts
+++ b/ts/src/ixs/client.ts
@@ -61,6 +61,11 @@ const IX_METHOD_NAMES = [
   "buildSyncParentToChild",
   "buildDepositIxs",
   "buildWithdrawIxs",
+  "buildHawkeyeViewMargin",
+  "buildHawkeyeViewMarginForAsset",
+  "buildHawkeyeViewLiquidationPrice",
+  "buildHawkeyeViewBbo",
+  "buildHawkeyeViewFunding",
 ] as const satisfies readonly IxMethodName[];
 
 const summarizeIxParams = (params: unknown): Record<string, unknown> => {

--- a/ts/src/ixs/operations.ts
+++ b/ts/src/ixs/operations.ts
@@ -4,6 +4,13 @@ import {
   type CreateConditionalOrdersAccountIx,
 } from "@/core/ixBuilders/CreateConditionalOrdersAccount";
 import {
+  buildHawkeyeViewBboIx,
+  buildHawkeyeViewFundingIx,
+  buildHawkeyeViewLiquidationPriceIx,
+  buildHawkeyeViewMarginForAssetIx,
+  buildHawkeyeViewMarginIx,
+} from "@/hawkeye";
+import {
   buildPlaceAttachedConditionalOrderIx,
   type PlaceAttachedConditionalOrderIx,
 } from "@/core/ixBuilders/PlaceAttachedConditionalOrder";
@@ -79,6 +86,9 @@ import type {
   ClientCreateEscrowRequestInput,
   ClientDepositInput,
   ClientDelegateTraderInput,
+  ClientHawkeyeBboInput,
+  ClientHawkeyeTraderAssetInput,
+  ClientHawkeyeTraderInput,
   ClientOnboardTraderDelegatedInput,
   ClientPlaceAttachedConditionalOrderInput,
   ClientPlaceLimitOrderWithConditionalsInput,
@@ -232,6 +242,55 @@ export const createPhoenixIxOperations = (
       traderAccount,
       phoenixProgramAddress: context.phoenixProgramAddress,
     });
+
+  const resolveHawkeyeBaseAccounts = async () => {
+    const exchangeAccounts = await context.resolveExchangeInstructionAccounts();
+    return {
+      phoenixProgramAddress: exchangeAccounts.phoenixProgramAddress,
+      globalConfigurationAddress: exchangeAccounts.globalConfigurationAddress,
+      globalTraderIndex: exchangeAccounts.globalTraderIndex,
+      activeTraderBuffer: exchangeAccounts.activeTraderBuffer,
+      perpAssetMap: exchangeAccounts.perpAssetMap,
+    };
+  };
+
+  const resolveHawkeyeTraderAccounts = async (
+    params: ClientHawkeyeTraderInput
+  ) => ({
+    ...(await resolveHawkeyeBaseAccounts()),
+    traderAccount:
+      params.traderAccount !== undefined
+        ? params.traderAccount
+        : await context.resolveTraderAccount({
+            authority: params.authority,
+            traderPdaIndex: params.traderPdaIndex,
+            traderSubaccountIndex: params.traderSubaccountIndex,
+          }),
+  });
+
+  const resolveHawkeyeAssetId = async (
+    params: ClientHawkeyeTraderAssetInput
+  ): Promise<number> => {
+    if (params.assetId !== undefined) {
+      return params.assetId;
+    }
+    if (!params.symbol) {
+      throw new Error("symbol or assetId is required for this Hawkeye view");
+    }
+    return (await context.resolveMarketContext(params.symbol)).assetId;
+  };
+
+  const resolveHawkeyeBboAccounts = async (params: ClientHawkeyeBboInput) => {
+    const [baseAccounts, market] = await Promise.all([
+      resolveHawkeyeBaseAccounts(),
+      context.resolveMarketContext(params.symbol),
+    ]);
+    return {
+      ...baseAccounts,
+      orderbook: market.marketAddress,
+      splineCollection: market.splineCollection,
+    };
+  };
 
   const buildCreateConditionalOrdersAccount = async (
     params: ClientCreateConditionalOrdersAccountInput
@@ -1013,5 +1072,28 @@ export const createPhoenixIxOperations = (
         amount: params.amount,
       });
     },
+    buildHawkeyeViewMargin: async (params: ClientHawkeyeTraderInput) =>
+      buildHawkeyeViewMarginIx(await resolveHawkeyeTraderAccounts(params)),
+    buildHawkeyeViewMarginForAsset: async (
+      params: ClientHawkeyeTraderAssetInput
+    ) =>
+      buildHawkeyeViewMarginForAssetIx({
+        ...(await resolveHawkeyeTraderAccounts(params)),
+        assetId: await resolveHawkeyeAssetId(params),
+      }),
+    buildHawkeyeViewLiquidationPrice: async (
+      params: ClientHawkeyeTraderAssetInput
+    ) =>
+      buildHawkeyeViewLiquidationPriceIx({
+        ...(await resolveHawkeyeTraderAccounts(params)),
+        assetId: await resolveHawkeyeAssetId(params),
+      }),
+    buildHawkeyeViewBbo: async (params: ClientHawkeyeBboInput) =>
+      buildHawkeyeViewBboIx(await resolveHawkeyeBboAccounts(params)),
+    buildHawkeyeViewFunding: async (params: ClientHawkeyeTraderAssetInput) =>
+      buildHawkeyeViewFundingIx({
+        ...(await resolveHawkeyeTraderAccounts(params)),
+        assetId: await resolveHawkeyeAssetId(params),
+      }),
   };
 };

--- a/ts/src/ixs/types.ts
+++ b/ts/src/ixs/types.ts
@@ -22,6 +22,7 @@ import type { SyncParentToChildIx } from "@/core/ixBuilders/SyncParentToChild";
 import type { TransferCollateralChildToParentIx } from "@/core/ixBuilders/TransferCollateralChildToParent";
 import type { TransferCollateralIx } from "@/core/ixBuilders/TransferCollateral";
 import type { WithdrawFundsIx } from "@/core/ixBuilders/WithdrawFunds";
+import type { HawkeyeIx } from "@/hawkeye";
 import type { PhoenixOrderPacketBuilders } from "@/orderPackets";
 import type {
   ActiveTraderBufferAddressArray,
@@ -273,6 +274,29 @@ export interface ClientPlaceLimitOrderWithConditionalsInput {
   lessTriggerOrder?: TriggerOrderParamsInput | null;
   traderPdaIndex?: number;
   traderSubaccountIndex?: number;
+}
+
+export type ClientHawkeyeTraderInput =
+  | {
+      authority: Authority;
+      traderAccount?: never;
+      traderPdaIndex?: number;
+      traderSubaccountIndex?: number;
+    }
+  | {
+      authority?: never;
+      traderAccount: TraderAddress;
+      traderPdaIndex?: never;
+      traderSubaccountIndex?: never;
+    };
+
+export type ClientHawkeyeTraderAssetInput = ClientHawkeyeTraderInput & {
+  assetId?: number;
+  symbol?: Symbol;
+};
+
+export interface ClientHawkeyeBboInput {
+  symbol: Symbol;
 }
 
 interface BaseBuildRegisterTraderParams {
@@ -654,4 +678,15 @@ export interface PhoenixIxClient {
   ): Promise<SyncParentToChildIx>;
   buildDepositIxs(params: ClientDepositInput): Promise<DepositIxsResult>;
   buildWithdrawIxs(params: ClientWithdrawInput): Promise<WithdrawIxsResult>;
+  buildHawkeyeViewMargin(params: ClientHawkeyeTraderInput): Promise<HawkeyeIx>;
+  buildHawkeyeViewMarginForAsset(
+    params: ClientHawkeyeTraderAssetInput
+  ): Promise<HawkeyeIx>;
+  buildHawkeyeViewLiquidationPrice(
+    params: ClientHawkeyeTraderAssetInput
+  ): Promise<HawkeyeIx>;
+  buildHawkeyeViewBbo(params: ClientHawkeyeBboInput): Promise<HawkeyeIx>;
+  buildHawkeyeViewFunding(
+    params: ClientHawkeyeTraderAssetInput
+  ): Promise<HawkeyeIx>;
 }

--- a/ts/src/rpc.ts
+++ b/ts/src/rpc.ts
@@ -12,9 +12,39 @@ import {
 } from "@/accounts";
 import type { AccountFetcherClient } from "@/accounts/fetcherFactory";
 import type { PhoenixExchangeMetadata } from "@/exchange-cache";
+import {
+  HAWKEYE_PROGRAM_ADDRESS,
+  HAWKEYE_SIMULATION_COMPUTE_UNIT_LIMIT,
+  buildHawkeyeViewBboIx,
+  buildHawkeyeViewFundingIx,
+  buildHawkeyeViewLiquidationPriceIx,
+  buildHawkeyeViewMarginForAssetIx,
+  buildHawkeyeViewMarginIx,
+  decodeHawkeyeReturnData,
+  encodeHawkeyeSimulationTransaction,
+  type HawkeyeAssetReturn,
+  type HawkeyeBboReturn,
+  type HawkeyeFundingReturn,
+  type HawkeyeLiquidationPriceReturn,
+  type HawkeyeMarginReturn,
+  type HawkeyeReturnData,
+  type HawkeyeTraderViewAccounts,
+} from "@/hawkeye";
 import type { PhoenixPdaClient } from "@/pdaClient";
 import type { Address } from "@solana/kit";
+import type { Blockhash, Instruction } from "@solana/kit";
 import type { Symbol } from "./primitives";
+import type {
+  ActiveTraderBufferAddressArray,
+  Authority,
+  GlobalConfigurationAddress,
+  GlobalTraderIndexAddressArray,
+  MarketAddress,
+  PerpAssetMapAddress,
+  PhoenixProgramAddress,
+  SplineCollectionAddress,
+  TraderAddress,
+} from "./primitives";
 import { decodeBase64ToBytes } from "./base64";
 import { resolvePhoenixRpcUrl } from "./rpcUrl";
 
@@ -65,10 +95,7 @@ const decodeRpcAccountData = (
 export class PhoenixRpcAccountFetcherClient implements AccountFetcherClient {
   constructor(private readonly url: string) {}
 
-  private async request<TResult>(
-    method: string,
-    params: unknown[]
-  ): Promise<TResult> {
+  async request<TResult>(method: string, params: unknown[]): Promise<TResult> {
     const response = await globalThis.fetch(this.url, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -146,6 +173,7 @@ export interface PhoenixRpcClient {
     getOrderbook(symbol: Symbol): Promise<Orderbook>;
     getSplineCollection(symbol: Symbol): Promise<SplineCollection>;
   };
+  hawkeye: PhoenixHawkeyeRpcClient;
 }
 
 const assertRpcClient = (
@@ -175,6 +203,263 @@ const getMarketOrThrow = async (
   throw new Error(
     `Unknown market symbol '${symbol}'. Available symbols: ${availableSymbols}`
   );
+};
+
+export type HawkeyeTraderLookup =
+  | {
+      authority: Authority;
+      traderAccount?: never;
+      traderPdaIndex?: number;
+      traderSubaccountIndex?: number;
+    }
+  | {
+      authority?: never;
+      traderAccount: TraderAddress;
+      traderPdaIndex?: never;
+      traderSubaccountIndex?: never;
+    };
+
+export type HawkeyeAssetLookup =
+  | { assetId: number; symbol?: Symbol }
+  | { symbol: Symbol; assetId?: number };
+
+export type HawkeyeTraderAssetLookup = HawkeyeTraderLookup & HawkeyeAssetLookup;
+
+export interface HawkeyeSimulationReturnData<
+  TDecoded extends HawkeyeReturnData,
+> {
+  programId: string | null;
+  encoding: string;
+  base64: string;
+  hex: string;
+  byteLength: number;
+  decoded: TDecoded;
+}
+
+export interface HawkeyeSimulation<TDecoded extends HawkeyeReturnData> {
+  err: unknown;
+  logs: string[];
+  unitsConsumed: number | null;
+  returnData: HawkeyeSimulationReturnData<TDecoded> | null;
+}
+
+export interface PhoenixHawkeyeRpcClient {
+  simulateInstruction<TDecoded extends HawkeyeReturnData = HawkeyeReturnData>(
+    instruction: Instruction
+  ): Promise<HawkeyeSimulation<TDecoded>>;
+  viewMargin(
+    params: HawkeyeTraderLookup
+  ): Promise<HawkeyeSimulation<HawkeyeMarginReturn>>;
+  viewMarginForAsset(
+    params: HawkeyeTraderAssetLookup
+  ): Promise<HawkeyeSimulation<HawkeyeAssetReturn>>;
+  viewLiquidationPrice(
+    params: HawkeyeTraderAssetLookup
+  ): Promise<HawkeyeSimulation<HawkeyeLiquidationPriceReturn>>;
+  viewBbo(params: {
+    symbol: Symbol;
+  }): Promise<HawkeyeSimulation<HawkeyeBboReturn>>;
+  viewFunding(
+    params: HawkeyeTraderAssetLookup
+  ): Promise<HawkeyeSimulation<HawkeyeFundingReturn>>;
+}
+
+type RpcLatestBlockhashResult = {
+  value: {
+    blockhash: string;
+    lastValidBlockHeight: string | number | bigint;
+  };
+};
+
+type RpcSimulationResult = {
+  value: {
+    err?: unknown;
+    logs?: string[] | null;
+    unitsConsumed?: number | null;
+    returnData?: {
+      programId?: string;
+      data?: [string, string] | string;
+    } | null;
+  };
+};
+
+const toHex = (bytes: Uint8Array): string =>
+  Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+
+const toBigInt = (value: string | number | bigint): bigint =>
+  typeof value === "bigint" ? value : BigInt(value);
+
+const decodeSimulationReturnData = <TDecoded extends HawkeyeReturnData>(
+  returnData: RpcSimulationResult["value"]["returnData"]
+): HawkeyeSimulationReturnData<TDecoded> | null => {
+  if (!returnData) {
+    return null;
+  }
+  const dataField = returnData.data;
+  const base64 = Array.isArray(dataField) ? dataField[0] : dataField;
+  const encoding = Array.isArray(dataField) ? dataField[1] : "base64";
+  if (typeof base64 !== "string") {
+    return null;
+  }
+  if (encoding !== "base64") {
+    throw new Error(`Unsupported Hawkeye return-data encoding '${encoding}'`);
+  }
+  if (
+    returnData.programId &&
+    returnData.programId !== HAWKEYE_PROGRAM_ADDRESS
+  ) {
+    throw new Error(
+      `Hawkeye simulation returned data for program ${returnData.programId}, expected ${HAWKEYE_PROGRAM_ADDRESS}`
+    );
+  }
+  const bytes = decodeBase64ToBytes(base64);
+  return {
+    programId: returnData.programId ?? null,
+    encoding,
+    base64,
+    hex: toHex(bytes),
+    byteLength: bytes.byteLength,
+    decoded: decodeHawkeyeReturnData(bytes) as TDecoded,
+  };
+};
+
+const createPhoenixHawkeyeRpcClient = (config: {
+  fetcher?: PhoenixRpcAccountFetcherClient;
+  exchange: PhoenixExchangeMetadata;
+  pda: PhoenixPdaClient;
+}): PhoenixHawkeyeRpcClient => {
+  const simulateInstruction = async <
+    TDecoded extends HawkeyeReturnData = HawkeyeReturnData,
+  >(
+    instruction: Instruction
+  ): Promise<HawkeyeSimulation<TDecoded>> => {
+    const client = assertRpcClient(config.fetcher);
+    const latestBlockhash = await client.request<RpcLatestBlockhashResult>(
+      "getLatestBlockhash",
+      [{ commitment: "confirmed" }]
+    );
+    const encodedTransaction = encodeHawkeyeSimulationTransaction({
+      instruction,
+      blockhash: latestBlockhash.value.blockhash as Blockhash,
+      lastValidBlockHeight: toBigInt(
+        latestBlockhash.value.lastValidBlockHeight
+      ),
+      computeUnitLimit: HAWKEYE_SIMULATION_COMPUTE_UNIT_LIMIT,
+    });
+    const result = await client.request<RpcSimulationResult>(
+      "simulateTransaction",
+      [
+        encodedTransaction,
+        {
+          commitment: "confirmed",
+          encoding: "base64",
+          replaceRecentBlockhash: true,
+          sigVerify: false,
+        },
+      ]
+    );
+
+    return {
+      err: result.value.err ?? null,
+      logs: result.value.logs ?? [],
+      unitsConsumed: result.value.unitsConsumed ?? null,
+      returnData: decodeSimulationReturnData<TDecoded>(
+        result.value.returnData ?? null
+      ),
+    };
+  };
+
+  const resolveExchangeAccounts = async () => {
+    await config.exchange.ready();
+    const exchange = config.exchange.snapshot().exchange;
+    return {
+      phoenixProgramAddress: (exchange.programId ??
+        config.pda.getProgramAddress()) as PhoenixProgramAddress,
+      globalConfigurationAddress:
+        exchange.globalConfig as GlobalConfigurationAddress,
+      globalTraderIndex:
+        exchange.globalTraderIndex as GlobalTraderIndexAddressArray,
+      activeTraderBuffer:
+        exchange.activeTraderBuffer as ActiveTraderBufferAddressArray,
+      perpAssetMap: exchange.perpAssetMap as PerpAssetMapAddress,
+    };
+  };
+
+  const resolveTraderAccount = async (
+    params: HawkeyeTraderLookup
+  ): Promise<TraderAddress> => {
+    if (params.traderAccount !== undefined) {
+      return params.traderAccount;
+    }
+    return config.pda.getTraderAddress({
+      authority: params.authority,
+      traderPdaIndex: params.traderPdaIndex ?? 0,
+      subaccountIndex: params.traderSubaccountIndex ?? 0,
+      phoenixProgramAddress: config.pda.getProgramAddress(),
+    });
+  };
+
+  const resolveTraderAccounts = async (
+    params: HawkeyeTraderLookup
+  ): Promise<HawkeyeTraderViewAccounts> => ({
+    ...(await resolveExchangeAccounts()),
+    traderAccount: await resolveTraderAccount(params),
+  });
+
+  const resolveAssetId = async (
+    params: HawkeyeAssetLookup
+  ): Promise<number> => {
+    if (params.assetId !== undefined) {
+      return params.assetId;
+    }
+    if (params.symbol === undefined) {
+      throw new Error("symbol or assetId is required for this Hawkeye view");
+    }
+    const market = await getMarketOrThrow(config.exchange, params.symbol);
+    return market.assetId;
+  };
+
+  return {
+    simulateInstruction,
+    viewMargin: async (params) =>
+      simulateInstruction<HawkeyeMarginReturn>(
+        buildHawkeyeViewMarginIx(await resolveTraderAccounts(params))
+      ),
+    viewMarginForAsset: async (params) =>
+      simulateInstruction<HawkeyeAssetReturn>(
+        buildHawkeyeViewMarginForAssetIx({
+          ...(await resolveTraderAccounts(params)),
+          assetId: await resolveAssetId(params),
+        })
+      ),
+    viewLiquidationPrice: async (params) =>
+      simulateInstruction<HawkeyeLiquidationPriceReturn>(
+        buildHawkeyeViewLiquidationPriceIx({
+          ...(await resolveTraderAccounts(params)),
+          assetId: await resolveAssetId(params),
+        })
+      ),
+    viewBbo: async (params) => {
+      const [exchangeAccounts, market] = await Promise.all([
+        resolveExchangeAccounts(),
+        getMarketOrThrow(config.exchange, params.symbol),
+      ]);
+      return simulateInstruction<HawkeyeBboReturn>(
+        buildHawkeyeViewBboIx({
+          ...exchangeAccounts,
+          orderbook: market.marketPubkey as MarketAddress,
+          splineCollection: market.splinePubkey as SplineCollectionAddress,
+        })
+      );
+    },
+    viewFunding: async (params) =>
+      simulateInstruction<HawkeyeFundingReturn>(
+        buildHawkeyeViewFundingIx({
+          ...(await resolveTraderAccounts(params)),
+          assetId: await resolveAssetId(params),
+        })
+      ),
+  };
 };
 
 export const createPhoenixRpcClient = (config: {
@@ -245,5 +530,10 @@ export const createPhoenixRpcClient = (config: {
         return decodeSplineCollection(account.data);
       },
     },
+    hawkeye: createPhoenixHawkeyeRpcClient({
+      fetcher,
+      exchange: config.exchange,
+      pda: config.pda,
+    }),
   };
 };

--- a/ts/tests/public-surface.manifest.ts
+++ b/ts/tests/public-surface.manifest.ts
@@ -114,6 +114,15 @@ export const ROOT_PRESENT_PROPERTIES = [
   "createPhoenixClient",
   "createPhoenixIxClient",
   "createPhoenixRpcClient",
+  "buildHawkeyeViewMarginIx",
+  "buildHawkeyeViewMarginForAssetIx",
+  "buildHawkeyeViewLiquidationPriceIx",
+  "buildHawkeyeViewBboIx",
+  "buildHawkeyeViewFundingIx",
+  "decodeHawkeyeReturnData",
+  "encodeHawkeyeSimulationTransaction",
+  "HAWKEYE_PROGRAM_ADDRESS",
+  "HAWKEYE_SIMULATION_COMPUTE_UNIT_LIMIT",
   "buildLimitOrderPacketFromMarketParams",
   "buildMarketOrderPacketFromMarketParams",
   "buildDepositFundsIxResolved",
@@ -254,10 +263,16 @@ export const PHOENIX_IX_PROPERTIES = [
   "placeMarketOrderDelegated",
   "placePositionConditionalOrder",
   "placePostOnlyOrder",
+  "buildHawkeyeViewMargin",
+  "buildHawkeyeViewMarginForAsset",
+  "buildHawkeyeViewLiquidationPrice",
+  "buildHawkeyeViewBbo",
+  "buildHawkeyeViewFunding",
 ] as const;
 
 export const PHOENIX_RPC_PROPERTIES = [
   "available",
   "exchange",
   "markets",
+  "hawkeye",
 ] as const;

--- a/ts/tests/sdk-localnet-flows.test.ts
+++ b/ts/tests/sdk-localnet-flows.test.ts
@@ -3,6 +3,7 @@ import {
   address,
   createKeyPairSignerFromPrivateKeyBytes,
   getArrayEncoder,
+  getBase58Decoder,
   getBooleanEncoder,
   getConstantEncoder,
   getHiddenPrefixEncoder,
@@ -15,10 +16,16 @@ import type { TransactionSigner } from "@solana/kit";
 import { describe, expect, test } from "vitest";
 import {
   Direction,
+  HAWKEYE_PROGRAM_ADDRESS,
   OrderFlags,
   SelfTradeBehavior,
   Side,
   StopLossOrderKind,
+  buildHawkeyeViewBboIx,
+  buildHawkeyeViewFundingIx,
+  buildHawkeyeViewLiquidationPriceIx,
+  buildHawkeyeViewMarginForAssetIx,
+  buildHawkeyeViewMarginIx,
   buildCreatePermissionIx,
   buildCancelAllIxResolved,
   buildCancelOrdersByIdIxResolved,
@@ -39,6 +46,7 @@ import {
   buildTransferCollateralIxResolved,
   buildUpdateTraderStateIx,
   buildWithdrawIxsResolved,
+  decodeHawkeyeReturnData,
   executionPriceFromSlippageBps,
   generateArenaAccounts,
   generateReadonlyAccount,
@@ -52,15 +60,21 @@ import {
   priceUsdToTicksWithMarketParams,
   sha2_const,
 } from "../src";
+import type { HawkeyeIx, HawkeyeReturnData } from "../src";
 import {
   decodeConditionalOrderCollection,
   decodeStopLosses,
 } from "../src/accounts";
 import type {
+  ActiveTraderBufferAddressArray,
   Authority,
   FIFOOrderId,
+  GlobalConfigurationAddress,
+  GlobalTraderIndexAddressArray,
   MarketAddress,
+  PerpAssetMapAddress,
   PhoenixProgramAddress,
+  SplineCollectionAddress,
   TraderAddress,
 } from "../src";
 import type {
@@ -195,6 +209,127 @@ describe("SDK localnet common flows", () => {
         "market order"
       );
       expect(position.position.baseLotPosition).toBeGreaterThan(0n);
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  vmTest(
+    "executes Hawkeye view functions and decodes return data",
+    async () => {
+      if (!programPaths?.hawkeye) {
+        if (isSdkLocalnetVmRequired()) {
+          throw new Error(
+            "Missing local Hawkeye SBF artifact; set RISE_SDK_LOCALNET_HAWKEYE_SO"
+          );
+        }
+        console.warn(
+          "skipping Hawkeye LiteSVM flow because phoenix_hawkeye.so is missing"
+        );
+        return;
+      }
+
+      const context = await createContext();
+      const actor = context.getActor("taker0");
+      const market = context.getMarket("BTC");
+      const baseAccounts = {
+        phoenixProgramAddress: context.fixture.programs
+          .phoenixEternal as PhoenixProgramAddress,
+        globalConfigurationAddress: context.fixture.addresses
+          .globalConfig as GlobalConfigurationAddress,
+        globalTraderIndex: context.fixture.addresses
+          .globalTraderIndex as GlobalTraderIndexAddressArray,
+        activeTraderBuffer: context.fixture.addresses
+          .activeTraderBuffer as ActiveTraderBufferAddressArray,
+        perpAssetMap: context.fixture.addresses
+          .perpAssetMap as PerpAssetMapAddress,
+      };
+      const traderAccounts = {
+        ...baseAccounts,
+        traderAccount: actor.traderAccount as TraderAddress,
+      };
+
+      await placeMarketOrder(context, {
+        actorName: actor.name,
+        symbol: "BTC",
+        side: Side.Bid,
+        baseUnits: "0.01",
+        priceLimitUsd: "101000",
+      });
+
+      const margin = await executeHawkeyeView(
+        context,
+        buildHawkeyeViewMarginIx(traderAccounts),
+        "hawkeye:view-margin"
+      );
+      expect(margin.kind).toBe("view_margin");
+      if (margin.kind !== "view_margin") {
+        throw new Error(`unexpected Hawkeye return kind ${margin.kind}`);
+      }
+      expect(margin.positionCount).toBeGreaterThan(0);
+      expect(margin.initialMarginQuoteLots).toBeGreaterThan(0n);
+
+      const asset = await executeHawkeyeView(
+        context,
+        buildHawkeyeViewMarginForAssetIx({
+          ...traderAccounts,
+          assetId: 0,
+        }),
+        "hawkeye:view-margin-for-asset"
+      );
+      expect(asset.kind).toBe("view_margin_for_asset");
+      if (asset.kind !== "view_margin_for_asset") {
+        throw new Error(`unexpected Hawkeye return kind ${asset.kind}`);
+      }
+      expect(asset.assetId).toBe(0);
+      expect(asset.baseLots).not.toBe(0n);
+      expect(asset.markPriceTicks).toBeGreaterThan(0n);
+
+      const liquidation = await executeHawkeyeView(
+        context,
+        buildHawkeyeViewLiquidationPriceIx({
+          ...traderAccounts,
+          assetId: 0,
+        }),
+        "hawkeye:view-liquidation-price"
+      );
+      expect(liquidation.kind).toBe("view_liquidation_price");
+      if (liquidation.kind !== "view_liquidation_price") {
+        throw new Error(`unexpected Hawkeye return kind ${liquidation.kind}`);
+      }
+      expect(liquidation.assetId).toBe(0);
+      expect(liquidation.markPriceTicks).toBeGreaterThan(0n);
+
+      const bbo = await executeHawkeyeView(
+        context,
+        buildHawkeyeViewBboIx({
+          ...baseAccounts,
+          orderbook: market.orderbook as MarketAddress,
+          splineCollection: market.spline as SplineCollectionAddress,
+        }),
+        "hawkeye:view-bbo"
+      );
+      expect(bbo.kind).toBe("view_bbo");
+      if (bbo.kind !== "view_bbo") {
+        throw new Error(`unexpected Hawkeye return kind ${bbo.kind}`);
+      }
+      expect(bbo.bestBidTicks ?? bbo.bestAskTicks).not.toBeNull();
+      expect(bbo.markPriceTicks).toBeGreaterThan(0n);
+      expect(bbo.indexPriceTicks).toBeGreaterThan(0n);
+
+      const funding = await executeHawkeyeView(
+        context,
+        buildHawkeyeViewFundingIx({
+          ...traderAccounts,
+          assetId: 0,
+        }),
+        "hawkeye:view-funding"
+      );
+      expect(funding.kind).toBe("view_funding");
+      if (funding.kind !== "view_funding") {
+        throw new Error(`unexpected Hawkeye return kind ${funding.kind}`);
+      }
+      expect(funding.assetId).toBe(0);
+      expect(funding.totalAccumulatedFundingQuoteLots).not.toBeNull();
     },
     TEST_TIMEOUT_MS
   );
@@ -1051,6 +1186,26 @@ const expectSuccess = async (
   const execution = await result;
   expect(execution.metadata.computeUnitsConsumed()).toBeGreaterThan(0n);
   return execution;
+};
+
+const executeHawkeyeView = async (
+  context: SdkLocalnetContext,
+  instruction: HawkeyeIx,
+  label: string
+): Promise<HawkeyeReturnData> => {
+  const execution = await expectSuccess(
+    context.sendInstructions([instruction], {
+      feePayerSeed: "payer",
+      label,
+    })
+  );
+  const returnData = execution.metadata.returnData();
+  const bytes = returnData.data();
+  expect(bytes.byteLength, `${label} return data length`).toBeGreaterThan(0);
+  expect(getBase58Decoder().decode(returnData.programId())).toBe(
+    HAWKEYE_PROGRAM_ADDRESS
+  );
+  return decodeHawkeyeReturnData(bytes);
 };
 
 const expectFixtureSuccess = async (

--- a/ts/tests/test-harness/localnet.ts
+++ b/ts/tests/test-harness/localnet.ts
@@ -27,6 +27,7 @@ import type {
   TransactionSigner,
 } from "@solana/kit";
 import { decodeOrderbook, decodeTrader } from "../../src/accounts";
+import { HAWKEYE_PROGRAM_ADDRESS } from "../../src/hawkeye";
 import type {
   Orderbook,
   Trader,
@@ -79,6 +80,7 @@ import type {
 export interface SdkLocalnetProgramPaths {
   phoenixEternal: string;
   ember: string;
+  hawkeye?: string;
 }
 
 export interface FindSdkLocalnetProgramPathsOptions {
@@ -190,6 +192,7 @@ const REQUIRED_PROGRAM_ARTIFACT_ENV = "RISE_SDK_LOCALNET_REQUIRE_PROGRAMS";
 const PHOENIX_REPO_ROOT_ENV = "PHOENIX_REPO_ROOT";
 const ETERNAL_PROGRAM_ENV = "RISE_SDK_LOCALNET_ETERNAL_SO";
 const EMBER_PROGRAM_ENV = "RISE_SDK_LOCALNET_EMBER_SO";
+const HAWKEYE_PROGRAM_ENV = "RISE_SDK_LOCALNET_HAWKEYE_SO";
 const DEFAULT_LAST_VALID_BLOCK_HEIGHT = 1_000_000n;
 
 export const isSdkLocalnetVmRequired = (): boolean =>
@@ -659,6 +662,12 @@ export const loadSdkLocalnetPrograms = (
     toLiteSvmAddress(fixture.programs.ember),
     programPaths.ember
   );
+  if (programPaths.hawkeye) {
+    vm.addProgramFromFile(
+      toLiteSvmAddress(HAWKEYE_PROGRAM_ADDRESS),
+      programPaths.hawkeye
+    );
+  }
 };
 
 export const fundSdkLocalnetSigners = (
@@ -1080,14 +1089,16 @@ const explicitProgramPaths = (
   const phoenixEternal =
     programPaths?.phoenixEternal ?? process.env[ETERNAL_PROGRAM_ENV];
   const ember = programPaths?.ember ?? process.env[EMBER_PROGRAM_ENV];
+  const hawkeye = programPaths?.hawkeye ?? process.env[HAWKEYE_PROGRAM_ENV];
 
-  if (!phoenixEternal && !ember) {
+  if (!phoenixEternal && !ember && !hawkeye) {
     return null;
   }
 
   return {
     phoenixEternal: resolveRequiredPath(phoenixEternal, ETERNAL_PROGRAM_ENV),
     ember: resolveRequiredPath(ember, EMBER_PROGRAM_ENV),
+    ...(hawkeye ? { hawkeye: resolve(hawkeye) } : {}),
   };
 };
 
@@ -1102,7 +1113,9 @@ const resolveRequiredPath = (
 };
 
 const allProgramPathsExist = (programPaths: SdkLocalnetProgramPaths): boolean =>
-  existsSync(programPaths.phoenixEternal) && existsSync(programPaths.ember);
+  existsSync(programPaths.phoenixEternal) &&
+  existsSync(programPaths.ember) &&
+  (programPaths.hawkeye === undefined || existsSync(programPaths.hawkeye));
 
 const defaultProgramPathCandidates = (
   repoRoot?: string
@@ -1129,10 +1142,15 @@ const defaultProgramPathCandidates = (
           "programs/target/deploy/phoenix_eternal.so"
         ),
         ember: resolve(root, "programs/target/deploy/phoenix_ember_program.so"),
+        ...optionalProgramPath(
+          root,
+          "programs/target/deploy/phoenix_hawkeye.so"
+        ),
       },
       {
         phoenixEternal: resolve(root, "target/deploy/phoenix_eternal.so"),
         ember: resolve(root, "target/deploy/phoenix_ember_program.so"),
+        ...optionalProgramPath(root, "target/deploy/phoenix_hawkeye.so"),
       },
       {
         phoenixEternal: resolve(
@@ -1143,11 +1161,23 @@ const defaultProgramPathCandidates = (
           root,
           "programs/ember/target/deploy/phoenix_ember_program.so"
         ),
+        ...optionalProgramPath(
+          root,
+          "programs/phoenix-hawkeye/target/deploy/phoenix_hawkeye.so"
+        ),
       }
     );
   }
 
   return candidates;
+};
+
+const optionalProgramPath = (
+  root: string,
+  path: string
+): Pick<SdkLocalnetProgramPaths, "hawkeye"> => {
+  const resolved = resolve(root, path);
+  return existsSync(resolved) ? { hawkeye: resolved } : {};
 };
 
 const moduleDirectory = (): string => dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `e01d6bf79f112b8f9c7c6e7e3ad84fb83050eb43`
- Mode: automatic
- Synced paths:

- `rise/ts` -> `ts`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `ts/CHANGELOG.md`

### Summary

- **Hawkeye program client**: Added a full read-only simulation client for the Hawkeye program (`RiSeVw3ZjNfsaXPRb4mgaqYaEEt41pNNJoDvVh7pgQj`). Call `client.rpc.hawkeye.viewMargin(...)`, `.viewMarginForAsset(...)`, `.viewLiquidationPrice(...)`, `.viewBbo(...)`, and `.viewFunding(...)` to query on-chain margin, risk state, liquidation price, BBO, and funding data via transaction simulation — no signature required.
- **New root-level exports**: Five instruction builders (`buildHawkeyeViewMarginIx`, `buildHawkeyeViewMarginForAssetIx`, `buildHawkeyeViewLiquidationPriceIx`, `buildHawkeyeViewBboIx`, `buildHawkeyeViewFundingIx`), `decodeHawkeyeReturnData`, `encodeHawkeyeSimulationTransaction`, `HAWKEYE_PROGRAM_ADDRESS`, `HAWKEYE_SIMULATION_COMPUTE_UNIT_LIMIT`, and all associated TypeScript types (`HawkeyeReturnData`, `HawkeyeMarginReturn`, `HawkeyeAssetReturn`, `HawkeyeLiquidationPriceReturn`, `HawkeyeBboReturn`, `HawkeyeFundingReturn`, etc.) are now exported from the package root.
- **`PhoenixIxClient` additions**: Five new `buildHawkeyeView*` methods on the ix client automatically resolve trader accounts and asset IDs from authority/symbol, mirroring the existing client pattern.
- **`zod` pinned to `4.4.3`** (previously `^4.3.6`).

### Breaking Changes

- None identified in the synced diff.

### Consumer Notes

- `PhoenixRpcAccountFetcherClient.request` was widened from `private` to `public`; this is additive and does not break existing code, but the method is now formally part of the class surface.
- The `zod` dependency is now pinned to the exact version `4.4.3`. If your project declares `zod` as a direct dependency and previously resolved `^4.3.6` to a different patch, verify your lockfile resolves cleanly after upgrading to this version of `@ellipsis-labs/rise`.