### PR TITLE
sync: Rise Rust v0.1.10

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -125,3 +125,25 @@ Source Phoenix commit: `00d34904a9c9e981dcc62666906e2985a98624d9`
 
 - The `opentelemetry` feature does not install a global propagator automatically — callers must call `opentelemetry::global::set_text_map_propagator(...)` (e.g., with `TraceContextPropagator`) before trace headers will be injected into requests.
 - The `permission_account` builder method is additive and optional; existing `TransferCollateralParams` construction code requires no changes.
+
+## v0.1.10 - 2026-06-17
+
+Source Phoenix commit: `e01d6bf79f112b8f9c7c6e7e3ad84fb83050eb43`
+
+### Summary
+
+- Added the **Phoenix Hawkeye** read-only view layer: instruction builders, typed return-data structs, a decode pipeline, and a high-level async RPC client for querying margin, per-asset risk, liquidation prices, BBO, and funding state via simulated transactions.
+- New top-level exports from `phoenix_rise`: `PhoenixHawkeyeClient`, `HawkeyeSimulation<T>`, `PhoenixHawkeyeClientError`, `HawkeyeReturnData`, `HawkeyeReturnDataError`, all `View*Return` structs, `Hawkeye*ViewAccounts` account-list structs, low-level instruction builders (`create_hawkeye_view_*_ix`), and decode helpers (`decode_hawkeye_return_data`, `decode_hawkeye_return`).
+- `PhoenixTxBuilder` gains nine new `build_hawkeye_view_*` methods that construct Hawkeye simulation instructions from a `PhoenixMetadata` context, with both PDA-derived and explicit-trader variants.
+- Three new mandatory runtime dependencies: `solana-rpc-client-api ~2.3`, `solana-transaction-error ~2.2`, and `solana-transaction-status-client-types ~2.3`; `solana-compute-budget-interface ~2.2` is also added. Downstream `Cargo.toml` files that pin Solana crate ranges tightly may need adjustments.
+
+### Breaking Changes
+
+- None identified in the synced diff.
+
+### Consumer Notes
+
+- `PhoenixHawkeyeClient::new(rpc_url, &metadata)` is the recommended entry point; it defaults to an unsigned simulation fee payer (`HAWKEYE_SIMULATION_FEE_PAYER`) and a 1.4M CU limit, both overridable via builder methods.
+- All Hawkeye view calls are **read-only simulations** — no fee payer signature required and no state is mutated on-chain.
+- Return data is versioned (`HAWKEYE_RETURN_VERSION = 1`); callers should assert `version` matches if they hard-code struct layouts.
+- `ViewBboReturn::best_bid_ticks()` / `best_ask_ticks()` return `Option<u64>` based on presence flags — a `None` means no resting orders on that side, not an error.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "async-trait",
  "axum",
@@ -2656,8 +2656,11 @@ dependencies = [
  "solana-keypair",
  "solana-pubkey",
  "solana-rpc-client",
+ "solana-rpc-client-api",
  "solana-signer",
  "solana-transaction",
+ "solana-transaction-error",
+ "solana-transaction-status-client-types",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -2672,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-sdk-cli"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "clap",
  "phoenix-rise",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -172,41 +172,46 @@ ignored = [
 ]
 
 [dependencies]
-async-trait           = { workspace = true }
-base64                = { workspace = true }
-borsh                 = { workspace = true }
-bs58                  = { workspace = true }
-bytemuck              = { workspace = true }
-chrono                = { workspace = true }
-ed25519-dalek         = { workspace = true, optional = true }
-fixed                 = { workspace = true }
-futures-util          = { workspace = true }
-opentelemetry         = { workspace = true, optional = true }
-opentelemetry-http    = { workspace = true, optional = true }
-parking_lot           = { workspace = true }
-pastey                = { workspace = true }
-rand                  = { workspace = true }
-reqwest               = { workspace = true }
-rust_decimal          = { workspace = true }
-serde                 = { workspace = true }
-serde_json            = { workspace = true }
-serde_urlencoded      = { workspace = true }
-serde_with            = { workspace = true }
-sha2                  = { workspace = true }
-sha2-const-stable     = { workspace = true }
-solana-instruction    = { workspace = true }
-solana-keypair        = { workspace = true, optional = true }
-solana-pubkey         = { workspace = true }
-solana-rpc-client     = { workspace = true }
-solana-signer         = { workspace = true, optional = true }
-thiserror             = { workspace = true }
-tokio                 = { workspace = true }
-tokio-stream          = "0.1"
-tokio-tungstenite     = { workspace = true }
-tracing               = { workspace = true }
-tracing-opentelemetry = { workspace = true, optional = true }
-url                   = { workspace = true }
-utoipa                = { workspace = true, optional = true }
+async-trait                            = { workspace = true }
+base64                                 = { workspace = true }
+borsh                                  = { workspace = true }
+bs58                                   = { workspace = true }
+bytemuck                               = { workspace = true }
+chrono                                 = { workspace = true }
+ed25519-dalek                          = { workspace = true, optional = true }
+fixed                                  = { workspace = true }
+futures-util                           = { workspace = true }
+opentelemetry                          = { workspace = true, optional = true }
+opentelemetry-http                     = { workspace = true, optional = true }
+parking_lot                            = { workspace = true }
+pastey                                 = { workspace = true }
+rand                                   = { workspace = true }
+reqwest                                = { workspace = true }
+rust_decimal                           = { workspace = true }
+serde                                  = { workspace = true }
+serde_json                             = { workspace = true }
+serde_urlencoded                       = { workspace = true }
+serde_with                             = { workspace = true }
+sha2                                   = { workspace = true }
+sha2-const-stable                      = { workspace = true }
+solana-compute-budget-interface        = { workspace = true }
+solana-instruction                     = { workspace = true }
+solana-keypair                         = { workspace = true, optional = true }
+solana-pubkey                          = { workspace = true }
+solana-rpc-client                      = { workspace = true }
+solana-rpc-client-api                  = { workspace = true }
+solana-signer                          = { workspace = true, optional = true }
+solana-transaction                     = { workspace = true }
+solana-transaction-error               = { workspace = true }
+solana-transaction-status-client-types = { workspace = true }
+thiserror                              = { workspace = true }
+tokio                                  = { workspace = true }
+tokio-stream                           = "0.1"
+tokio-tungstenite                      = { workspace = true }
+tracing                                = { workspace = true }
+tracing-opentelemetry                  = { workspace = true, optional = true }
+url                                    = { workspace = true }
+utoipa                                 = { workspace = true, optional = true }
 
 [dev-dependencies]
 axum                            = "0.8"
@@ -235,7 +240,7 @@ publish      = true
 readme       = "CRATES.md"
 repository   = "https://github.com/Ellipsis-Labs/rise"
 rust-version = "1.84.0"
-version      = "0.1.9"
+version      = "0.1.10"
 
 [workspace.dependencies]
 async-trait = "0.1"
@@ -266,14 +271,18 @@ serde_with = "3.12"
 sha2 = "0.10"
 sha2-const-stable = "0.1"
 solana-commitment-config = { version = "~2.2" }
+solana-compute-budget-interface = "~2.2"
 solana-instruction = { version = "~2.3", default-features = false, features = [
   "std",
 ] }
 solana-keypair = { version = "~2.2" }
 solana-pubkey = { version = "~2.4", features = ["curve25519"] }
 solana-rpc-client = "~2.3"
+solana-rpc-client-api = "~2.3"
 solana-signer = { version = "~2.2" }
 solana-transaction = { version = "~2.2" }
+solana-transaction-error = "~2.2"
+solana-transaction-status-client-types = "~2.3"
 thiserror = "2.0"
 tokio = { version = "1.44", features = [
   "sync",

--- a/rust/ix/src/hawkeye.rs
+++ b/rust/ix/src/hawkeye.rs
@@ -2,7 +2,7 @@
 
 use core::mem::size_of;
 
-use bytemuck::{Pod, Zeroable, try_from_bytes};
+use bytemuck::{try_from_bytes, Pod, Zeroable};
 use solana_pubkey::Pubkey;
 use thiserror::Error;
 
@@ -15,7 +15,7 @@ pub const HAWKEYE_PROGRAM_ID: Pubkey =
 
 /// Default fee payer for unsigned Hawkeye simulations.
 pub const HAWKEYE_SIMULATION_FEE_PAYER: Pubkey =
-    solana_pubkey::pubkey!("Hik5qWJvfgZR9HAGfNqYXfhxbYNGRoZbABEkP91zgC5h");
+    solana_pubkey::pubkey!("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
 
 /// Default compute-unit limit used by Hawkeye simulation helpers.
 pub const HAWKEYE_SIMULATION_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
@@ -38,11 +38,11 @@ pub const VIEW_FUNDING_HAS_UNSETTLED: u8 = 1 << 1;
 #[repr(u64)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PhoenixHawkeyeInstruction {
-    ViewMargin           = sha2_const(b"global:view_margin"),
-    ViewMarginForAsset   = sha2_const(b"global:view_margin_for_asset"),
+    ViewMargin = sha2_const(b"global:view_margin"),
+    ViewMarginForAsset = sha2_const(b"global:view_margin_for_asset"),
     ViewLiquidationPrice = sha2_const(b"global:view_liquidation_price"),
-    ViewBbo              = sha2_const(b"global:view_bbo"),
-    ViewFunding          = sha2_const(b"global:view_funding"),
+    ViewBbo = sha2_const(b"global:view_bbo"),
+    ViewFunding = sha2_const(b"global:view_funding"),
 }
 
 impl PhoenixHawkeyeInstruction {

--- a/rust/ix/src/hawkeye.rs
+++ b/rust/ix/src/hawkeye.rs
@@ -1,0 +1,455 @@
+//! Phoenix Hawkeye instruction builders and return-data decoding.
+
+use core::mem::size_of;
+
+use bytemuck::{Pod, Zeroable, try_from_bytes};
+use solana_pubkey::Pubkey;
+use thiserror::Error;
+
+use crate::ix::types::{AccountMeta, Instruction};
+use crate::math::sha2_const;
+
+/// Phoenix Hawkeye program ID.
+pub const HAWKEYE_PROGRAM_ID: Pubkey =
+    solana_pubkey::pubkey!("RiSeVw3ZjNfsaXPRb4mgaqYaEEt41pNNJoDvVh7pgQj");
+
+/// Default fee payer for unsigned Hawkeye simulations.
+pub const HAWKEYE_SIMULATION_FEE_PAYER: Pubkey =
+    solana_pubkey::pubkey!("Hik5qWJvfgZR9HAGfNqYXfhxbYNGRoZbABEkP91zgC5h");
+
+/// Default compute-unit limit used by Hawkeye simulation helpers.
+pub const HAWKEYE_SIMULATION_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
+
+/// Current Hawkeye return-data version.
+pub const HAWKEYE_RETURN_VERSION: u16 = 1;
+
+pub const VIEW_MARGIN_RETURN_MAGIC: u64 = sha2_const(b"return:phoenix_hawkeye_margin");
+pub const VIEW_ASSET_RETURN_MAGIC: u64 = sha2_const(b"return:phoenix_hawkeye_asset");
+pub const VIEW_LIQUIDATION_PRICE_RETURN_MAGIC: u64 =
+    sha2_const(b"return:phoenix_hawkeye_liquidation_price");
+pub const VIEW_BBO_RETURN_MAGIC: u64 = sha2_const(b"return:phoenix_hawkeye_bbo");
+pub const VIEW_FUNDING_RETURN_MAGIC: u64 = sha2_const(b"return:phoenix_hawkeye_funding");
+
+pub const VIEW_BBO_HAS_BID: u8 = 1 << 0;
+pub const VIEW_BBO_HAS_ASK: u8 = 1 << 1;
+pub const VIEW_FUNDING_HAS_ACCUMULATED: u8 = 1 << 0;
+pub const VIEW_FUNDING_HAS_UNSETTLED: u8 = 1 << 1;
+
+#[repr(u64)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum PhoenixHawkeyeInstruction {
+    ViewMargin           = sha2_const(b"global:view_margin"),
+    ViewMarginForAsset   = sha2_const(b"global:view_margin_for_asset"),
+    ViewLiquidationPrice = sha2_const(b"global:view_liquidation_price"),
+    ViewBbo              = sha2_const(b"global:view_bbo"),
+    ViewFunding          = sha2_const(b"global:view_funding"),
+}
+
+impl PhoenixHawkeyeInstruction {
+    pub fn from_tag(tag: u64) -> Option<Self> {
+        match tag {
+            x if x == Self::ViewMargin as u64 => Some(Self::ViewMargin),
+            x if x == Self::ViewMarginForAsset as u64 => Some(Self::ViewMarginForAsset),
+            x if x == Self::ViewLiquidationPrice as u64 => Some(Self::ViewLiquidationPrice),
+            x if x == Self::ViewBbo as u64 => Some(Self::ViewBbo),
+            x if x == Self::ViewFunding as u64 => Some(Self::ViewFunding),
+            _ => None,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Pod, Zeroable)]
+pub struct ViewAssetParams {
+    pub asset_id: u32,
+    pub _padding: [u8; 4],
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Pod, Zeroable)]
+pub struct ViewMarginReturn {
+    pub magic: u64,
+    pub version: u16,
+    pub position_count: u16,
+    pub risk_state: u8,
+    pub risk_tier: u8,
+    pub is_liquidatable: u8,
+    pub _padding: u8,
+    pub collateral_quote_lots: i64,
+    pub effective_collateral_quote_lots: i64,
+    pub free_collateral_quote_lots: i64,
+    pub withdrawable_collateral_quote_lots: u64,
+    pub initial_margin_quote_lots: u64,
+    pub maintenance_margin_quote_lots: u64,
+    pub cancel_margin_quote_lots: u64,
+    pub backstop_margin_quote_lots: u64,
+    pub high_risk_margin_quote_lots: u64,
+    pub unrealized_pnl_quote_lots: i64,
+    pub discounted_unrealized_pnl_quote_lots: i64,
+    pub unsettled_funding_quote_lots: i64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Pod, Zeroable)]
+pub struct ViewAssetReturn {
+    pub magic: u64,
+    pub asset_id: u32,
+    pub version: u16,
+    pub has_position_or_orders: u8,
+    pub _padding: u8,
+    pub risk_state: u8,
+    pub risk_tier: u8,
+    pub _padding1: [u8; 6],
+    pub base_lots: i64,
+    pub virtual_quote_lots: i64,
+    pub mark_price_ticks: u64,
+    pub entry_price_quote_lots_per_base_lot: u64,
+    pub position_value_quote_lots: i64,
+    pub unrealized_pnl_quote_lots: i64,
+    pub discounted_unrealized_pnl_quote_lots: i64,
+    pub unsettled_funding_quote_lots: i64,
+    pub initial_margin_quote_lots: u64,
+    pub maintenance_margin_quote_lots: u64,
+    pub cancel_margin_quote_lots: u64,
+    pub backstop_margin_quote_lots: u64,
+    pub high_risk_margin_quote_lots: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Pod, Zeroable)]
+pub struct ViewLiquidationPriceReturn {
+    pub magic: u64,
+    pub asset_id: u32,
+    pub version: u16,
+    pub status: u8,
+    pub side: u8,
+    pub liquidation_price_ticks: u64,
+    pub mark_price_ticks: u64,
+    pub entry_price_quote_lots_per_base_lot: u64,
+    pub effective_collateral_quote_lots: i64,
+    pub maintenance_margin_quote_lots: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Pod, Zeroable)]
+pub struct ViewBboReturn {
+    pub magic: u64,
+    pub version: u16,
+    pub flags: u8,
+    pub _padding: [u8; 5],
+    pub best_bid_ticks: u64,
+    pub best_ask_ticks: u64,
+    pub mark_price_ticks: u64,
+    pub index_price_ticks: u64,
+    pub mark_price_last_updated_slot: u64,
+    pub index_price_last_updated_slot: u64,
+}
+
+impl ViewBboReturn {
+    pub fn best_bid_ticks(&self) -> Option<u64> {
+        ((self.flags & VIEW_BBO_HAS_BID) != 0).then_some(self.best_bid_ticks)
+    }
+
+    pub fn best_ask_ticks(&self) -> Option<u64> {
+        ((self.flags & VIEW_BBO_HAS_ASK) != 0).then_some(self.best_ask_ticks)
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Pod, Zeroable)]
+pub struct ViewFundingReturn {
+    pub magic: u64,
+    pub asset_id: u32,
+    pub version: u16,
+    pub flags: u8,
+    pub _padding: u8,
+    pub total_accumulated_funding_quote_lots: i64,
+    pub total_unsettled_funding_quote_lots: i64,
+    pub current_funding_rate_micro_bps: i64,
+    pub projected_1h_funding_rate_micro_bps: i64,
+}
+
+impl ViewFundingReturn {
+    pub fn total_accumulated_funding_quote_lots(&self) -> Option<i64> {
+        ((self.flags & VIEW_FUNDING_HAS_ACCUMULATED) != 0)
+            .then_some(self.total_accumulated_funding_quote_lots)
+    }
+
+    pub fn total_unsettled_funding_quote_lots(&self) -> Option<i64> {
+        ((self.flags & VIEW_FUNDING_HAS_UNSETTLED) != 0)
+            .then_some(self.total_unsettled_funding_quote_lots)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum HawkeyeReturnData {
+    Margin(ViewMarginReturn),
+    Asset(ViewAssetReturn),
+    LiquidationPrice(ViewLiquidationPriceReturn),
+    Bbo(ViewBboReturn),
+    Funding(ViewFundingReturn),
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum HawkeyeReturnDataError {
+    #[error("Hawkeye return data is too short: got {actual} bytes, expected at least 8")]
+    MissingMagic { actual: usize },
+
+    #[error("Unknown Hawkeye return data magic {magic}")]
+    UnknownMagic { magic: u64 },
+
+    #[error(
+        "Invalid Hawkeye return data length for {kind}: got {actual} bytes, expected {expected}"
+    )]
+    InvalidLength {
+        kind: &'static str,
+        actual: usize,
+        expected: usize,
+    },
+
+    #[error("Invalid Hawkeye return data layout for {kind}")]
+    InvalidLayout { kind: &'static str },
+}
+
+pub fn decode_hawkeye_return_data(
+    bytes: &[u8],
+) -> Result<HawkeyeReturnData, HawkeyeReturnDataError> {
+    if bytes.len() < size_of::<u64>() {
+        return Err(HawkeyeReturnDataError::MissingMagic {
+            actual: bytes.len(),
+        });
+    }
+
+    let magic = u64::from_le_bytes(bytes[..size_of::<u64>()].try_into().expect("u64 slice"));
+    match magic {
+        VIEW_MARGIN_RETURN_MAGIC => {
+            decode_typed(bytes, "view_margin").map(HawkeyeReturnData::Margin)
+        }
+        VIEW_ASSET_RETURN_MAGIC => {
+            decode_typed(bytes, "view_margin_for_asset").map(HawkeyeReturnData::Asset)
+        }
+        VIEW_LIQUIDATION_PRICE_RETURN_MAGIC => {
+            decode_typed(bytes, "view_liquidation_price").map(HawkeyeReturnData::LiquidationPrice)
+        }
+        VIEW_BBO_RETURN_MAGIC => decode_typed(bytes, "view_bbo").map(HawkeyeReturnData::Bbo),
+        VIEW_FUNDING_RETURN_MAGIC => {
+            decode_typed(bytes, "view_funding").map(HawkeyeReturnData::Funding)
+        }
+        magic => Err(HawkeyeReturnDataError::UnknownMagic { magic }),
+    }
+}
+
+pub fn decode_hawkeye_return<T: Pod + Copy>(
+    bytes: &[u8],
+    kind: &'static str,
+) -> Result<T, HawkeyeReturnDataError> {
+    decode_typed(bytes, kind)
+}
+
+fn decode_typed<T: Pod + Copy>(
+    bytes: &[u8],
+    kind: &'static str,
+) -> Result<T, HawkeyeReturnDataError> {
+    if bytes.len() != size_of::<T>() {
+        return Err(HawkeyeReturnDataError::InvalidLength {
+            kind,
+            actual: bytes.len(),
+            expected: size_of::<T>(),
+        });
+    }
+
+    try_from_bytes::<T>(bytes)
+        .copied()
+        .map_err(|_| HawkeyeReturnDataError::InvalidLayout { kind })
+}
+
+#[derive(Debug, Clone)]
+pub struct HawkeyeTraderViewAccounts {
+    pub phoenix_program_id: Pubkey,
+    pub global_config: Pubkey,
+    pub global_trader_index: Vec<Pubkey>,
+    pub active_trader_buffer: Vec<Pubkey>,
+    pub perp_asset_map: Pubkey,
+    pub trader: Pubkey,
+}
+
+#[derive(Debug, Clone)]
+pub struct HawkeyeBboViewAccounts {
+    pub phoenix_program_id: Pubkey,
+    pub global_config: Pubkey,
+    pub global_trader_index: Vec<Pubkey>,
+    pub active_trader_buffer: Vec<Pubkey>,
+    pub perp_asset_map: Pubkey,
+    pub orderbook: Pubkey,
+    pub spline_collection: Pubkey,
+}
+
+pub fn create_hawkeye_view_margin_ix(accounts: HawkeyeTraderViewAccounts) -> Instruction {
+    hawkeye_trader_instruction(PhoenixHawkeyeInstruction::ViewMargin, &[], accounts)
+}
+
+pub fn create_hawkeye_view_margin_for_asset_ix(
+    accounts: HawkeyeTraderViewAccounts,
+    asset_id: u32,
+) -> Instruction {
+    let params = ViewAssetParams {
+        asset_id,
+        _padding: [0; 4],
+    };
+    hawkeye_trader_instruction(
+        PhoenixHawkeyeInstruction::ViewMarginForAsset,
+        bytemuck::bytes_of(&params),
+        accounts,
+    )
+}
+
+pub fn create_hawkeye_view_liquidation_price_ix(
+    accounts: HawkeyeTraderViewAccounts,
+    asset_id: u32,
+) -> Instruction {
+    let params = ViewAssetParams {
+        asset_id,
+        _padding: [0; 4],
+    };
+    hawkeye_trader_instruction(
+        PhoenixHawkeyeInstruction::ViewLiquidationPrice,
+        bytemuck::bytes_of(&params),
+        accounts,
+    )
+}
+
+pub fn create_hawkeye_view_funding_ix(
+    accounts: HawkeyeTraderViewAccounts,
+    asset_id: u32,
+) -> Instruction {
+    let params = ViewAssetParams {
+        asset_id,
+        _padding: [0; 4],
+    };
+    hawkeye_trader_instruction(
+        PhoenixHawkeyeInstruction::ViewFunding,
+        bytemuck::bytes_of(&params),
+        accounts,
+    )
+}
+
+pub fn create_hawkeye_view_bbo_ix(accounts: HawkeyeBboViewAccounts) -> Instruction {
+    let mut account_metas = Vec::with_capacity(
+        5 + accounts.global_trader_index.len() + accounts.active_trader_buffer.len(),
+    );
+    push_hawkeye_base_accounts(
+        &mut account_metas,
+        accounts.phoenix_program_id,
+        accounts.global_config,
+        &accounts.global_trader_index,
+        &accounts.active_trader_buffer,
+        accounts.perp_asset_map,
+    );
+    account_metas.push(AccountMeta::readonly(accounts.orderbook));
+    account_metas.push(AccountMeta::readonly(accounts.spline_collection));
+    hawkeye_instruction(PhoenixHawkeyeInstruction::ViewBbo, &[], account_metas)
+}
+
+fn hawkeye_trader_instruction(
+    instruction: PhoenixHawkeyeInstruction,
+    params: &[u8],
+    accounts: HawkeyeTraderViewAccounts,
+) -> Instruction {
+    let mut account_metas = Vec::with_capacity(
+        4 + accounts.global_trader_index.len() + accounts.active_trader_buffer.len(),
+    );
+    push_hawkeye_base_accounts(
+        &mut account_metas,
+        accounts.phoenix_program_id,
+        accounts.global_config,
+        &accounts.global_trader_index,
+        &accounts.active_trader_buffer,
+        accounts.perp_asset_map,
+    );
+    account_metas.push(AccountMeta::readonly(accounts.trader));
+    hawkeye_instruction(instruction, params, account_metas)
+}
+
+fn push_hawkeye_base_accounts(
+    account_metas: &mut Vec<AccountMeta>,
+    phoenix_program_id: Pubkey,
+    global_config: Pubkey,
+    global_trader_index: &[Pubkey],
+    active_trader_buffer: &[Pubkey],
+    perp_asset_map: Pubkey,
+) {
+    account_metas.push(AccountMeta::readonly(phoenix_program_id));
+    account_metas.push(AccountMeta::readonly(global_config));
+    account_metas.extend(
+        global_trader_index
+            .iter()
+            .copied()
+            .map(AccountMeta::readonly),
+    );
+    account_metas.extend(
+        active_trader_buffer
+            .iter()
+            .copied()
+            .map(AccountMeta::readonly),
+    );
+    account_metas.push(AccountMeta::readonly(perp_asset_map));
+}
+
+fn hawkeye_instruction(
+    instruction: PhoenixHawkeyeInstruction,
+    params: &[u8],
+    accounts: Vec<AccountMeta>,
+) -> Instruction {
+    let mut data = Vec::with_capacity(size_of::<u64>() + params.len());
+    data.extend_from_slice(&(instruction as u64).to_le_bytes());
+    data.extend_from_slice(params);
+
+    Instruction {
+        program_id: HAWKEYE_PROGRAM_ID,
+        accounts,
+        data,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_bbo_options() {
+        let ret = ViewBboReturn {
+            magic: VIEW_BBO_RETURN_MAGIC,
+            version: HAWKEYE_RETURN_VERSION,
+            flags: VIEW_BBO_HAS_BID,
+            best_bid_ticks: 99,
+            best_ask_ticks: 101,
+            ..ViewBboReturn::default()
+        };
+
+        assert_eq!(ret.best_bid_ticks(), Some(99));
+        assert_eq!(ret.best_ask_ticks(), None);
+        assert_eq!(
+            decode_hawkeye_return_data(bytemuck::bytes_of(&ret)).unwrap(),
+            HawkeyeReturnData::Bbo(ret)
+        );
+    }
+
+    #[test]
+    fn decodes_funding_options() {
+        let ret = ViewFundingReturn {
+            magic: VIEW_FUNDING_RETURN_MAGIC,
+            version: HAWKEYE_RETURN_VERSION,
+            flags: VIEW_FUNDING_HAS_UNSETTLED,
+            total_accumulated_funding_quote_lots: -10,
+            total_unsettled_funding_quote_lots: -20,
+            ..ViewFundingReturn::default()
+        };
+
+        assert_eq!(ret.total_accumulated_funding_quote_lots(), None);
+        assert_eq!(ret.total_unsettled_funding_quote_lots(), Some(-20));
+        assert_eq!(
+            decode_hawkeye_return_data(bytemuck::bytes_of(&ret)).unwrap(),
+            HawkeyeReturnData::Funding(ret)
+        );
+    }
+}

--- a/rust/ix/src/lib.rs
+++ b/rust/ix/src/lib.rs
@@ -36,6 +36,7 @@ mod ember_deposit;
 mod ember_withdraw;
 mod error;
 pub mod flight;
+mod hawkeye;
 mod limit_order;
 mod market_order;
 mod multi_limit_order;
@@ -64,6 +65,7 @@ pub use deposit_funds::{DepositFundsParams, create_deposit_funds_ix};
 pub use ember_deposit::{EmberDepositParams, create_ember_deposit_ix};
 pub use ember_withdraw::{EmberWithdrawParams, create_ember_withdraw_ix};
 pub use error::PhoenixIxError;
+pub use hawkeye::*;
 pub use limit_order::{
     IsolatedLimitOrderParams, LimitOrderParams, LimitOrderParamsBuilder,
     create_place_limit_order_ix,

--- a/rust/sdk/src/hawkeye_client.rs
+++ b/rust/sdk/src/hawkeye_client.rs
@@ -1,0 +1,293 @@
+use base64::Engine as _;
+use solana_compute_budget_interface::ComputeBudgetInstruction;
+use solana_instruction::Instruction;
+use solana_pubkey::Pubkey;
+use solana_rpc_client::nonblocking::rpc_client::RpcClient;
+use solana_rpc_client_api::config::RpcSimulateTransactionConfig;
+use solana_rpc_client_api::response::RpcSimulateTransactionResult;
+use solana_transaction::Transaction;
+use thiserror::Error;
+
+use crate::PhoenixMetadata;
+use crate::phoenix_rise_ix::{
+    HAWKEYE_PROGRAM_ID, HAWKEYE_SIMULATION_COMPUTE_UNIT_LIMIT, HAWKEYE_SIMULATION_FEE_PAYER,
+    HawkeyeReturnData, HawkeyeReturnDataError, ViewAssetReturn, ViewBboReturn, ViewFundingReturn,
+    ViewLiquidationPriceReturn, ViewMarginReturn, decode_hawkeye_return,
+    decode_hawkeye_return_data,
+};
+use crate::tx_builder::{PhoenixTxBuilder, PhoenixTxBuilderError};
+
+#[derive(Debug, Clone)]
+pub struct HawkeyeSimulation<T> {
+    pub value: T,
+    pub logs: Vec<String>,
+    pub units_consumed: Option<u64>,
+    pub raw_return_data: Vec<u8>,
+}
+
+#[derive(Debug, Error)]
+pub enum PhoenixHawkeyeClientError {
+    #[error("Phoenix transaction builder error: {0}")]
+    Builder(#[from] PhoenixTxBuilderError),
+
+    #[error("RPC error: {0}")]
+    Rpc(String),
+
+    #[error("Hawkeye simulation failed: {0:?}")]
+    SimulationFailed(solana_transaction_error::TransactionError),
+
+    #[error("Hawkeye simulation did not set return data")]
+    MissingReturnData,
+
+    #[error("Hawkeye simulation returned data for program {actual}, expected {expected}")]
+    WrongReturnProgram { actual: String, expected: Pubkey },
+
+    #[error("Hawkeye simulation returned unsupported return-data encoding")]
+    UnsupportedReturnDataEncoding,
+
+    #[error("Hawkeye builder produced {actual} instructions, expected exactly 1")]
+    UnexpectedInstructionCount { actual: usize },
+
+    #[error("Failed to base64 decode Hawkeye return data: {0}")]
+    Base64(#[from] base64::DecodeError),
+
+    #[error("Hawkeye return-data decode error: {0}")]
+    Decode(#[from] HawkeyeReturnDataError),
+}
+
+pub struct PhoenixHawkeyeClient<'a> {
+    rpc_client: RpcClient,
+    builder: PhoenixTxBuilder<'a>,
+    fee_payer: Pubkey,
+    compute_unit_limit: u32,
+}
+
+impl<'a> PhoenixHawkeyeClient<'a> {
+    pub fn new(rpc_url: impl Into<String>, metadata: &'a PhoenixMetadata) -> Self {
+        Self {
+            rpc_client: RpcClient::new(rpc_url.into()),
+            builder: PhoenixTxBuilder::new(metadata),
+            fee_payer: HAWKEYE_SIMULATION_FEE_PAYER,
+            compute_unit_limit: HAWKEYE_SIMULATION_COMPUTE_UNIT_LIMIT,
+        }
+    }
+
+    pub fn with_fee_payer(mut self, fee_payer: Pubkey) -> Self {
+        self.fee_payer = fee_payer;
+        self
+    }
+
+    pub fn with_compute_unit_limit(mut self, compute_unit_limit: u32) -> Self {
+        self.compute_unit_limit = compute_unit_limit;
+        self
+    }
+
+    pub async fn simulate_instruction(
+        &self,
+        instruction: Instruction,
+    ) -> Result<HawkeyeSimulation<HawkeyeReturnData>, PhoenixHawkeyeClientError> {
+        let result = self.simulate_raw(instruction).await?;
+        let bytes = decode_simulation_return_data(&result, HAWKEYE_PROGRAM_ID)?;
+        let value = decode_hawkeye_return_data(&bytes)?;
+        Ok(HawkeyeSimulation {
+            value,
+            logs: result.logs.unwrap_or_default(),
+            units_consumed: result.units_consumed,
+            raw_return_data: bytes,
+        })
+    }
+
+    pub async fn view_margin(
+        &self,
+        authority: Pubkey,
+        pda_index: u8,
+        subaccount_index: u8,
+    ) -> Result<HawkeyeSimulation<ViewMarginReturn>, PhoenixHawkeyeClientError> {
+        let instruction = only_instruction(self.builder.build_hawkeye_view_margin(
+            authority,
+            pda_index,
+            subaccount_index,
+        )?)?;
+        self.simulate_typed(instruction, "view_margin").await
+    }
+
+    pub async fn view_margin_for_trader(
+        &self,
+        trader: Pubkey,
+    ) -> Result<HawkeyeSimulation<ViewMarginReturn>, PhoenixHawkeyeClientError> {
+        let instruction =
+            only_instruction(self.builder.build_hawkeye_view_margin_for_trader(trader)?)?;
+        self.simulate_typed(instruction, "view_margin").await
+    }
+
+    pub async fn view_margin_for_asset(
+        &self,
+        authority: Pubkey,
+        pda_index: u8,
+        subaccount_index: u8,
+        asset_id: u32,
+    ) -> Result<HawkeyeSimulation<ViewAssetReturn>, PhoenixHawkeyeClientError> {
+        let instruction = only_instruction(self.builder.build_hawkeye_view_margin_for_asset(
+            authority,
+            pda_index,
+            subaccount_index,
+            asset_id,
+        )?)?;
+        self.simulate_typed(instruction, "view_margin_for_asset")
+            .await
+    }
+
+    pub async fn view_margin_for_asset_for_trader(
+        &self,
+        trader: Pubkey,
+        asset_id: u32,
+    ) -> Result<HawkeyeSimulation<ViewAssetReturn>, PhoenixHawkeyeClientError> {
+        let instruction = only_instruction(
+            self.builder
+                .build_hawkeye_view_margin_for_asset_for_trader(trader, asset_id)?,
+        )?;
+        self.simulate_typed(instruction, "view_margin_for_asset")
+            .await
+    }
+
+    pub async fn view_liquidation_price(
+        &self,
+        authority: Pubkey,
+        pda_index: u8,
+        subaccount_index: u8,
+        asset_id: u32,
+    ) -> Result<HawkeyeSimulation<ViewLiquidationPriceReturn>, PhoenixHawkeyeClientError> {
+        let instruction = only_instruction(self.builder.build_hawkeye_view_liquidation_price(
+            authority,
+            pda_index,
+            subaccount_index,
+            asset_id,
+        )?)?;
+        self.simulate_typed(instruction, "view_liquidation_price")
+            .await
+    }
+
+    pub async fn view_liquidation_price_for_trader(
+        &self,
+        trader: Pubkey,
+        asset_id: u32,
+    ) -> Result<HawkeyeSimulation<ViewLiquidationPriceReturn>, PhoenixHawkeyeClientError> {
+        let instruction = only_instruction(
+            self.builder
+                .build_hawkeye_view_liquidation_price_for_trader(trader, asset_id)?,
+        )?;
+        self.simulate_typed(instruction, "view_liquidation_price")
+            .await
+    }
+
+    pub async fn view_bbo(
+        &self,
+        symbol: &str,
+    ) -> Result<HawkeyeSimulation<ViewBboReturn>, PhoenixHawkeyeClientError> {
+        let instruction = only_instruction(self.builder.build_hawkeye_view_bbo(symbol)?)?;
+        self.simulate_typed(instruction, "view_bbo").await
+    }
+
+    pub async fn view_funding(
+        &self,
+        authority: Pubkey,
+        pda_index: u8,
+        subaccount_index: u8,
+        asset_id: u32,
+    ) -> Result<HawkeyeSimulation<ViewFundingReturn>, PhoenixHawkeyeClientError> {
+        let instruction = only_instruction(self.builder.build_hawkeye_view_funding(
+            authority,
+            pda_index,
+            subaccount_index,
+            asset_id,
+        )?)?;
+        self.simulate_typed(instruction, "view_funding").await
+    }
+
+    pub async fn view_funding_for_trader(
+        &self,
+        trader: Pubkey,
+        asset_id: u32,
+    ) -> Result<HawkeyeSimulation<ViewFundingReturn>, PhoenixHawkeyeClientError> {
+        let instruction = only_instruction(
+            self.builder
+                .build_hawkeye_view_funding_for_trader(trader, asset_id)?,
+        )?;
+        self.simulate_typed(instruction, "view_funding").await
+    }
+
+    async fn simulate_typed<T: bytemuck::Pod + Copy>(
+        &self,
+        instruction: Instruction,
+        label: &'static str,
+    ) -> Result<HawkeyeSimulation<T>, PhoenixHawkeyeClientError> {
+        let result = self.simulate_raw(instruction).await?;
+        let bytes = decode_simulation_return_data(&result, HAWKEYE_PROGRAM_ID)?;
+        let value = decode_hawkeye_return::<T>(&bytes, label)?;
+        Ok(HawkeyeSimulation {
+            value,
+            logs: result.logs.unwrap_or_default(),
+            units_consumed: result.units_consumed,
+            raw_return_data: bytes,
+        })
+    }
+
+    async fn simulate_raw(
+        &self,
+        instruction: Instruction,
+    ) -> Result<RpcSimulateTransactionResult, PhoenixHawkeyeClientError> {
+        let compute_budget_ix =
+            ComputeBudgetInstruction::set_compute_unit_limit(self.compute_unit_limit);
+        let instructions = [compute_budget_ix, instruction];
+        let transaction = Transaction::new_with_payer(&instructions, Some(&self.fee_payer));
+        let config = RpcSimulateTransactionConfig {
+            sig_verify: false,
+            replace_recent_blockhash: true,
+            commitment: Some(self.rpc_client.commitment()),
+            encoding: None,
+            accounts: None,
+            min_context_slot: None,
+            inner_instructions: false,
+        };
+        let response = self
+            .rpc_client
+            .simulate_transaction_with_config(&transaction, config)
+            .await
+            .map_err(|error| PhoenixHawkeyeClientError::Rpc(error.to_string()))?;
+        if let Some(err) = response.value.err {
+            return Err(PhoenixHawkeyeClientError::SimulationFailed(err));
+        }
+        Ok(response.value)
+    }
+}
+
+fn only_instruction(
+    mut instructions: Vec<Instruction>,
+) -> Result<Instruction, PhoenixHawkeyeClientError> {
+    if instructions.len() != 1 {
+        return Err(PhoenixHawkeyeClientError::UnexpectedInstructionCount {
+            actual: instructions.len(),
+        });
+    }
+    Ok(instructions.pop().expect("checked one instruction"))
+}
+
+fn decode_simulation_return_data(
+    result: &RpcSimulateTransactionResult,
+    expected_program_id: Pubkey,
+) -> Result<Vec<u8>, PhoenixHawkeyeClientError> {
+    let return_data = result
+        .return_data
+        .as_ref()
+        .ok_or(PhoenixHawkeyeClientError::MissingReturnData)?;
+    if return_data.program_id != expected_program_id.to_string() {
+        return Err(PhoenixHawkeyeClientError::WrongReturnProgram {
+            actual: return_data.program_id.clone(),
+            expected: expected_program_id,
+        });
+    }
+    if return_data.data.1 != solana_transaction_status_client_types::UiReturnDataEncoding::Base64 {
+        return Err(PhoenixHawkeyeClientError::UnsupportedReturnDataEncoding);
+    }
+    Ok(base64::engine::general_purpose::STANDARD.decode(&return_data.data.0)?)
+}

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -73,6 +73,7 @@ mod client;
 mod env;
 mod exchange_cache;
 mod flight_client;
+mod hawkeye_client;
 mod http_client;
 mod order_tickets;
 mod transport;
@@ -111,6 +112,7 @@ pub use exchange_cache::{
     PhoenixExchangeCacheStore,
 };
 pub use flight_client::PhoenixFlightClient;
+pub use hawkeye_client::{HawkeyeSimulation, PhoenixHawkeyeClient, PhoenixHawkeyeClientError};
 pub use http_client::{PhoenixHttpClient, PhoenixHttpClientBuilder, RateLimitRetryConfig};
 pub use order_tickets::{
     BracketLeg, BracketLegExecution, BracketLegOrders, BracketLegSize, BracketLegTicket,
@@ -123,12 +125,21 @@ pub use ws_client::{PhoenixWSClient, SubscriptionHandle, WsConnectionStatus};
 
 pub use crate::phoenix_rise_ix::{
     CancelConditionalOrderParams, CancelId, CancelStopLossParams, CondensedOrder,
-    CreateConditionalOrdersAccountParams, Direction, FifoOrderId, IsolatedCollateralFlow,
-    IsolatedLimitOrderParams, IsolatedMarketOrderParams, MarketOrderDelegatedParams,
-    MultiLimitOrderParams, OnboardTraderDelegatedParams, OrderFlags,
-    PlaceAttachedConditionalOrderParams, PlaceLimitOrderWithConditionalsParams,
-    PlacePositionConditionalOrderParams, RegisterTraderParams, SelfTradeBehavior, Side,
-    StopLossOrderKind, TransferCollateralParams, TriggerOrderParams,
+    CreateConditionalOrdersAccountParams, Direction, FifoOrderId, HAWKEYE_PROGRAM_ID,
+    HAWKEYE_RETURN_VERSION, HAWKEYE_SIMULATION_COMPUTE_UNIT_LIMIT, HAWKEYE_SIMULATION_FEE_PAYER,
+    HawkeyeBboViewAccounts, HawkeyeReturnData, HawkeyeReturnDataError, HawkeyeTraderViewAccounts,
+    IsolatedCollateralFlow, IsolatedLimitOrderParams, IsolatedMarketOrderParams,
+    MarketOrderDelegatedParams, MultiLimitOrderParams, OnboardTraderDelegatedParams, OrderFlags,
+    PhoenixHawkeyeInstruction, PlaceAttachedConditionalOrderParams,
+    PlaceLimitOrderWithConditionalsParams, PlacePositionConditionalOrderParams,
+    RegisterTraderParams, SelfTradeBehavior, Side, StopLossOrderKind, TransferCollateralParams,
+    TriggerOrderParams, VIEW_ASSET_RETURN_MAGIC, VIEW_BBO_HAS_ASK, VIEW_BBO_HAS_BID,
+    VIEW_BBO_RETURN_MAGIC, VIEW_FUNDING_HAS_ACCUMULATED, VIEW_FUNDING_HAS_UNSETTLED,
+    VIEW_FUNDING_RETURN_MAGIC, VIEW_LIQUIDATION_PRICE_RETURN_MAGIC, VIEW_MARGIN_RETURN_MAGIC,
+    ViewAssetParams, ViewAssetReturn, ViewBboReturn, ViewFundingReturn, ViewLiquidationPriceReturn,
+    ViewMarginReturn, create_hawkeye_view_bbo_ix, create_hawkeye_view_funding_ix,
+    create_hawkeye_view_liquidation_price_ix, create_hawkeye_view_margin_for_asset_ix,
+    create_hawkeye_view_margin_ix, decode_hawkeye_return, decode_hawkeye_return_data,
     get_conditional_orders_address, phoenix_global_configuration, phoenix_instruction_addresses,
     phoenix_log_authority, phoenix_program_id, resolve_phoenix_instruction_addresses_for_env,
 };

--- a/rust/sdk/src/tx_builder.rs
+++ b/rust/sdk/src/tx_builder.rs
@@ -18,16 +18,19 @@ use crate::order_tickets::{
 use crate::phoenix_rise_ix::{
     CancelId, CancelOrdersByIdParams, CancelStopLossParams, CondensedOrder,
     CreateConditionalOrdersAccountParams, DepositFundsParams, Direction, EmberDepositParams,
-    EmberWithdrawParams, IsolatedCollateralFlow, IsolatedLimitOrderParams,
-    IsolatedMarketOrderParams, LimitOrderParams, MarketOrderDelegatedParams, MarketOrderParams,
-    MultiLimitOrderParams, OrderPacket, PHOENIX_PROGRAM_ID, PlaceLimitOrderWithConditionalsParams,
-    PlacePositionConditionalOrderParams, PlaceStopLossParams, RegisterTraderParams, Side,
-    SplApproveParams, StopLossOrderKind, SyncParentToChildParams,
-    TransferCollateralChildToParentParams, TransferCollateralParams, TriggerOrderParams, USDC_MINT,
-    WithdrawFundsParams, client_order_id_to_bytes, create_associated_token_account_idempotent_ix,
-    create_cancel_orders_by_id_ix, create_cancel_stop_loss_ix,
-    create_create_conditional_orders_account_ix, create_deposit_funds_ix, create_ember_deposit_ix,
-    create_ember_withdraw_ix, create_place_limit_order_ix,
+    EmberWithdrawParams, HawkeyeBboViewAccounts, HawkeyeTraderViewAccounts, IsolatedCollateralFlow,
+    IsolatedLimitOrderParams, IsolatedMarketOrderParams, LimitOrderParams,
+    MarketOrderDelegatedParams, MarketOrderParams, MultiLimitOrderParams, OrderPacket,
+    PHOENIX_PROGRAM_ID, PlaceLimitOrderWithConditionalsParams, PlacePositionConditionalOrderParams,
+    PlaceStopLossParams, RegisterTraderParams, Side, SplApproveParams, StopLossOrderKind,
+    SyncParentToChildParams, TransferCollateralChildToParentParams, TransferCollateralParams,
+    TriggerOrderParams, USDC_MINT, WithdrawFundsParams, client_order_id_to_bytes,
+    create_associated_token_account_idempotent_ix, create_cancel_orders_by_id_ix,
+    create_cancel_stop_loss_ix, create_create_conditional_orders_account_ix,
+    create_deposit_funds_ix, create_ember_deposit_ix, create_ember_withdraw_ix,
+    create_hawkeye_view_bbo_ix, create_hawkeye_view_funding_ix,
+    create_hawkeye_view_liquidation_price_ix, create_hawkeye_view_margin_for_asset_ix,
+    create_hawkeye_view_margin_ix, create_place_limit_order_ix,
     create_place_limit_order_with_conditionals_ix, create_place_market_order_delegated_ix,
     create_place_market_order_ix, create_place_multi_limit_order_ix,
     create_place_position_conditional_order_ix, create_place_stop_loss_ix,
@@ -899,6 +902,121 @@ impl<'a> PhoenixTxBuilder<'a> {
         Ok(vec![ix.into()])
     }
 
+    /// Build a Hawkeye `view_margin` instruction for a derived trader account.
+    pub fn build_hawkeye_view_margin(
+        &self,
+        authority: Pubkey,
+        pda_index: u8,
+        subaccount_index: u8,
+    ) -> Result<Vec<Instruction>, PhoenixTxBuilderError> {
+        let trader = Self::trader_pda(&authority, pda_index, subaccount_index);
+        self.build_hawkeye_view_margin_for_trader(trader)
+    }
+
+    /// Build a Hawkeye `view_margin` instruction for an explicit trader
+    /// account.
+    pub fn build_hawkeye_view_margin_for_trader(
+        &self,
+        trader: Pubkey,
+    ) -> Result<Vec<Instruction>, PhoenixTxBuilderError> {
+        Ok(vec![
+            create_hawkeye_view_margin_ix(self.hawkeye_trader_accounts(trader)?).into(),
+        ])
+    }
+
+    /// Build a Hawkeye `view_margin_for_asset` instruction for a derived trader
+    /// account.
+    pub fn build_hawkeye_view_margin_for_asset(
+        &self,
+        authority: Pubkey,
+        pda_index: u8,
+        subaccount_index: u8,
+        asset_id: u32,
+    ) -> Result<Vec<Instruction>, PhoenixTxBuilderError> {
+        let trader = Self::trader_pda(&authority, pda_index, subaccount_index);
+        self.build_hawkeye_view_margin_for_asset_for_trader(trader, asset_id)
+    }
+
+    /// Build a Hawkeye `view_margin_for_asset` instruction for an explicit
+    /// trader account.
+    pub fn build_hawkeye_view_margin_for_asset_for_trader(
+        &self,
+        trader: Pubkey,
+        asset_id: u32,
+    ) -> Result<Vec<Instruction>, PhoenixTxBuilderError> {
+        Ok(vec![
+            create_hawkeye_view_margin_for_asset_ix(
+                self.hawkeye_trader_accounts(trader)?,
+                asset_id,
+            )
+            .into(),
+        ])
+    }
+
+    /// Build a Hawkeye `view_liquidation_price` instruction for a derived
+    /// trader account.
+    pub fn build_hawkeye_view_liquidation_price(
+        &self,
+        authority: Pubkey,
+        pda_index: u8,
+        subaccount_index: u8,
+        asset_id: u32,
+    ) -> Result<Vec<Instruction>, PhoenixTxBuilderError> {
+        let trader = Self::trader_pda(&authority, pda_index, subaccount_index);
+        self.build_hawkeye_view_liquidation_price_for_trader(trader, asset_id)
+    }
+
+    /// Build a Hawkeye `view_liquidation_price` instruction for an explicit
+    /// trader account.
+    pub fn build_hawkeye_view_liquidation_price_for_trader(
+        &self,
+        trader: Pubkey,
+        asset_id: u32,
+    ) -> Result<Vec<Instruction>, PhoenixTxBuilderError> {
+        Ok(vec![
+            create_hawkeye_view_liquidation_price_ix(
+                self.hawkeye_trader_accounts(trader)?,
+                asset_id,
+            )
+            .into(),
+        ])
+    }
+
+    /// Build a Hawkeye `view_funding` instruction for a derived trader account
+    /// and asset.
+    pub fn build_hawkeye_view_funding(
+        &self,
+        authority: Pubkey,
+        pda_index: u8,
+        subaccount_index: u8,
+        asset_id: u32,
+    ) -> Result<Vec<Instruction>, PhoenixTxBuilderError> {
+        let trader = Self::trader_pda(&authority, pda_index, subaccount_index);
+        self.build_hawkeye_view_funding_for_trader(trader, asset_id)
+    }
+
+    /// Build a Hawkeye `view_funding` instruction for an explicit trader
+    /// account and asset.
+    pub fn build_hawkeye_view_funding_for_trader(
+        &self,
+        trader: Pubkey,
+        asset_id: u32,
+    ) -> Result<Vec<Instruction>, PhoenixTxBuilderError> {
+        Ok(vec![
+            create_hawkeye_view_funding_ix(self.hawkeye_trader_accounts(trader)?, asset_id).into(),
+        ])
+    }
+
+    /// Build a Hawkeye `view_bbo` instruction for a market symbol.
+    pub fn build_hawkeye_view_bbo(
+        &self,
+        symbol: &str,
+    ) -> Result<Vec<Instruction>, PhoenixTxBuilderError> {
+        Ok(vec![
+            create_hawkeye_view_bbo_ix(self.hawkeye_bbo_accounts(symbol)?).into(),
+        ])
+    }
+
     /// Build a transfer collateral instruction.
     ///
     /// Transfers collateral between two subaccounts (e.g., from cross-margin
@@ -1572,6 +1690,53 @@ impl<'a> PhoenixTxBuilder<'a> {
             ));
         }
         Ok(())
+    }
+
+    fn hawkeye_trader_accounts(
+        &self,
+        trader: Pubkey,
+    ) -> Result<HawkeyeTraderViewAccounts, PhoenixTxBuilderError> {
+        let keys = self.metadata.keys();
+        Ok(HawkeyeTraderViewAccounts {
+            phoenix_program_id: keys
+                .program_id
+                .as_deref()
+                .map(Pubkey::from_str)
+                .transpose()?
+                .unwrap_or(*PHOENIX_PROGRAM_ID),
+            global_config: Pubkey::from_str(&keys.global_config)?,
+            global_trader_index: parse_pubkey_vec(&keys.global_trader_index)?,
+            active_trader_buffer: parse_pubkey_vec(&keys.active_trader_buffer)?,
+            perp_asset_map: Pubkey::from_str(&keys.perp_asset_map)?,
+            trader,
+        })
+    }
+
+    fn hawkeye_bbo_accounts(
+        &self,
+        symbol: &str,
+    ) -> Result<HawkeyeBboViewAccounts, PhoenixTxBuilderError> {
+        let market = self
+            .metadata
+            .get_market(symbol)
+            .ok_or_else(|| PhoenixTxBuilderError::UnknownSymbol(symbol.to_string()))?;
+        let keys = self.metadata.keys();
+        let addrs = self.parse_addresses(market)?;
+
+        Ok(HawkeyeBboViewAccounts {
+            phoenix_program_id: keys
+                .program_id
+                .as_deref()
+                .map(Pubkey::from_str)
+                .transpose()?
+                .unwrap_or(*PHOENIX_PROGRAM_ID),
+            global_config: Pubkey::from_str(&keys.global_config)?,
+            global_trader_index: addrs.global_trader_index,
+            active_trader_buffer: addrs.active_trader_buffer,
+            perp_asset_map: addrs.perp_asset_map,
+            orderbook: addrs.orderbook,
+            spline_collection: addrs.spline_collection,
+        })
     }
 
     /// Parse all required addresses from the exchange metadata for a given

--- a/rust/tests/sdk_localnet_fixture_tests.rs
+++ b/rust/tests/sdk_localnet_fixture_tests.rs
@@ -7,9 +7,11 @@ use std::sync::Arc;
 
 use borsh::{BorshSerialize, to_vec};
 use litesvm::LiteSVM;
+use litesvm::types::TransactionMetadata;
 use phoenix_rise::math::WrapperNum;
 use phoenix_rise::phoenix_rise_ix::{
-    create_onboard_trader_delegated_ix, create_register_trader_ix,
+    HAWKEYE_PROGRAM_ID, HawkeyeReturnData, create_onboard_trader_delegated_ix,
+    create_register_trader_ix, decode_hawkeye_return_data,
 };
 use phoenix_rise::types::accounts::{
     ConditionalOrderCollection, Orderbook, StopLossOrderKind as AccountStopLossOrderKind, Trader,
@@ -41,6 +43,7 @@ const REQUIRED_PROGRAM_ARTIFACT_ENV: &str = "RISE_SDK_LOCALNET_REQUIRE_PROGRAMS"
 const PHOENIX_REPO_ROOT_ENV: &str = "PHOENIX_REPO_ROOT";
 const ETERNAL_PROGRAM_ENV: &str = "RISE_SDK_LOCALNET_ETERNAL_SO";
 const EMBER_PROGRAM_ENV: &str = "RISE_SDK_LOCALNET_EMBER_SO";
+const HAWKEYE_PROGRAM_ENV: &str = "RISE_SDK_LOCALNET_HAWKEYE_SO";
 const STOP_LOSS_PERMISSION: u64 = 1 << 2;
 const TRADER_ONBOARDING_PERMISSION: u64 = 1 << 4;
 const ORACLE_UPDATE_TIMESTAMP: u64 = 1_900_000_001;
@@ -467,9 +470,148 @@ fn rise_sdk_onboard_trader_delegated_ix_executes() {
     );
 }
 
+#[tokio::test]
+async fn rise_sdk_hawkeye_views_execute_and_decode_return_data() {
+    let Some(program_paths) = find_sdk_localnet_program_paths() else {
+        if sdk_localnet_vm_required() {
+            panic!(
+                "missing local SBF artifacts; run `mise build-sbf` or set \
+                 {ETERNAL_PROGRAM_ENV}/{EMBER_PROGRAM_ENV}/{HAWKEYE_PROGRAM_ENV}"
+            );
+        }
+        eprintln!("skipping Hawkeye LiteSVM flow because local SBF artifacts are missing");
+        return;
+    };
+    if program_paths.hawkeye.is_none() {
+        if sdk_localnet_vm_required() {
+            panic!("missing local Hawkeye SBF artifact; set {HAWKEYE_PROGRAM_ENV}");
+        }
+        eprintln!("skipping Hawkeye LiteSVM flow because phoenix_hawkeye.so is missing");
+        return;
+    }
+
+    let fixture = default_sdk_localnet_fixture().expect("fixture should deserialize");
+    let mut context = SdkLocalnetContext::new(fixture, program_paths);
+    context.execute_setup();
+
+    let metadata = phoenix_metadata_from_fixture(&context.fixture);
+    let builder = PhoenixTxBuilder::new(&metadata);
+    let actor = context.actor("taker0");
+    let authority = parse_pubkey(&actor.pubkey);
+    let trader = parse_pubkey(&actor.trader_account);
+
+    let ticket = MarketOrderTicket::builder()
+        .authority(authority)
+        .trader_account(trader)
+        .symbol("BTC")
+        .side(Side::Bid)
+        .price(101_000.0)
+        .num_base_lots(100)
+        .self_trade_behavior(SelfTradeBehavior::CancelProvide)
+        .order_flags(OrderFlags::None)
+        .build()
+        .unwrap();
+    context.send_instructions(
+        builder.place_market_order(ticket).await.unwrap(),
+        &actor.seed,
+        "hawkeye-open-position",
+    );
+
+    let margin = decode_hawkeye_return(
+        &context.send_instructions_with_metadata(
+            builder
+                .build_hawkeye_view_margin_for_trader(trader)
+                .unwrap(),
+            "payer",
+            "hawkeye-view-margin",
+        ),
+    );
+    let HawkeyeReturnData::Margin(margin) = margin else {
+        panic!("view_margin returned unexpected Hawkeye payload: {margin:?}");
+    };
+    assert_eq!(margin.version, phoenix_rise::HAWKEYE_RETURN_VERSION);
+    assert!(
+        margin.position_count > 0,
+        "opened position should appear in margin view"
+    );
+    assert!(
+        margin.initial_margin_quote_lots > 0,
+        "margin view should include position margin"
+    );
+
+    let asset = decode_hawkeye_return(
+        &context.send_instructions_with_metadata(
+            builder
+                .build_hawkeye_view_margin_for_asset_for_trader(trader, BTC_ASSET_ID)
+                .unwrap(),
+            "payer",
+            "hawkeye-view-margin-for-asset",
+        ),
+    );
+    let HawkeyeReturnData::Asset(asset) = asset else {
+        panic!("view_margin_for_asset returned unexpected Hawkeye payload: {asset:?}");
+    };
+    assert_eq!(asset.asset_id, BTC_ASSET_ID);
+    assert_eq!(asset.version, phoenix_rise::HAWKEYE_RETURN_VERSION);
+    assert_ne!(asset.base_lots, 0);
+    assert!(asset.mark_price_ticks > 0);
+
+    let liquidation = decode_hawkeye_return(
+        &context.send_instructions_with_metadata(
+            builder
+                .build_hawkeye_view_liquidation_price_for_trader(trader, BTC_ASSET_ID)
+                .unwrap(),
+            "payer",
+            "hawkeye-view-liquidation-price",
+        ),
+    );
+    let HawkeyeReturnData::LiquidationPrice(liquidation) = liquidation else {
+        panic!("view_liquidation_price returned unexpected Hawkeye payload: {liquidation:?}");
+    };
+    assert_eq!(liquidation.asset_id, BTC_ASSET_ID);
+    assert_eq!(liquidation.version, phoenix_rise::HAWKEYE_RETURN_VERSION);
+    assert!(liquidation.mark_price_ticks > 0);
+
+    let bbo = decode_hawkeye_return(&context.send_instructions_with_metadata(
+        builder.build_hawkeye_view_bbo("BTC").unwrap(),
+        "payer",
+        "hawkeye-view-bbo",
+    ));
+    let HawkeyeReturnData::Bbo(bbo) = bbo else {
+        panic!("view_bbo returned unexpected Hawkeye payload: {bbo:?}");
+    };
+    assert_eq!(bbo.version, phoenix_rise::HAWKEYE_RETURN_VERSION);
+    assert!(
+        bbo.best_bid_ticks().is_some() || bbo.best_ask_ticks().is_some(),
+        "fixture should have BBO liquidity"
+    );
+    assert!(bbo.mark_price_ticks > 0);
+    assert!(bbo.index_price_ticks > 0);
+
+    let funding = decode_hawkeye_return(
+        &context.send_instructions_with_metadata(
+            builder
+                .build_hawkeye_view_funding_for_trader(trader, BTC_ASSET_ID)
+                .unwrap(),
+            "payer",
+            "hawkeye-view-funding",
+        ),
+    );
+    let HawkeyeReturnData::Funding(funding) = funding else {
+        panic!("view_funding returned unexpected Hawkeye payload: {funding:?}");
+    };
+    assert_eq!(funding.asset_id, BTC_ASSET_ID);
+    assert_eq!(funding.version, phoenix_rise::HAWKEYE_RETURN_VERSION);
+    assert!(
+        funding.total_accumulated_funding_quote_lots().is_some(),
+        "opened position should expose accumulated funding"
+    );
+}
+
 struct SdkLocalnetProgramPaths {
     phoenix_eternal: PathBuf,
     ember: PathBuf,
+    hawkeye: Option<PathBuf>,
 }
 
 struct SdkLocalnetContext {
@@ -488,6 +630,9 @@ impl SdkLocalnetContext {
             &program_paths.phoenix_eternal,
         );
         load_program(&mut svm, &fixture.programs.ember, &program_paths.ember);
+        if let Some(hawkeye) = program_paths.hawkeye.as_ref() {
+            load_program(&mut svm, &HAWKEYE_PROGRAM_ID.to_string(), hawkeye);
+        }
 
         let mut signers_by_seed = HashMap::new();
         let mut signer_seed_by_pubkey = HashMap::new();
@@ -579,6 +724,15 @@ impl SdkLocalnetContext {
         fee_payer_seed: &str,
         label: &str,
     ) {
+        self.send_instructions_with_metadata(instructions, fee_payer_seed, label);
+    }
+
+    fn send_instructions_with_metadata(
+        &mut self,
+        instructions: Vec<Instruction>,
+        fee_payer_seed: &str,
+        label: &str,
+    ) -> TransactionMetadata {
         let fee_payer = self
             .signers_by_seed
             .get(fee_payer_seed)
@@ -618,7 +772,7 @@ impl SdkLocalnetContext {
                 error.err,
                 error.meta.logs.join("\n")
             )
-        });
+        })
     }
 
     fn signer_pubkey(&self, seed: &str) -> Pubkey {
@@ -666,10 +820,12 @@ fn find_sdk_localnet_program_paths() -> Option<SdkLocalnetProgramPaths> {
     let explicit = match (
         std::env::var(ETERNAL_PROGRAM_ENV),
         std::env::var(EMBER_PROGRAM_ENV),
+        std::env::var(HAWKEYE_PROGRAM_ENV),
     ) {
-        (Ok(phoenix_eternal), Ok(ember)) => Some(SdkLocalnetProgramPaths {
+        (Ok(phoenix_eternal), Ok(ember), hawkeye) => Some(SdkLocalnetProgramPaths {
             phoenix_eternal: PathBuf::from(phoenix_eternal),
             ember: PathBuf::from(ember),
+            hawkeye: hawkeye.ok().map(PathBuf::from),
         }),
         _ => None,
     };
@@ -682,14 +838,21 @@ fn find_sdk_localnet_program_paths() -> Option<SdkLocalnetProgramPaths> {
             SdkLocalnetProgramPaths {
                 phoenix_eternal: root.join("programs/target/deploy/phoenix_eternal.so"),
                 ember: root.join("programs/target/deploy/phoenix_ember_program.so"),
+                hawkeye: optional_program_path(
+                    root.join("programs/target/deploy/phoenix_hawkeye.so"),
+                ),
             },
             SdkLocalnetProgramPaths {
                 phoenix_eternal: root.join("target/deploy/phoenix_eternal.so"),
                 ember: root.join("target/deploy/phoenix_ember_program.so"),
+                hawkeye: optional_program_path(root.join("target/deploy/phoenix_hawkeye.so")),
             },
             SdkLocalnetProgramPaths {
                 phoenix_eternal: root.join("programs/eternal/target/deploy/phoenix_eternal.so"),
                 ember: root.join("programs/ember/target/deploy/phoenix_ember_program.so"),
+                hawkeye: optional_program_path(
+                    root.join("programs/phoenix-hawkeye/target/deploy/phoenix_hawkeye.so"),
+                ),
             },
         ] {
             if program_paths_exist(&program_paths) {
@@ -716,7 +879,16 @@ fn default_program_roots() -> Vec<PathBuf> {
 }
 
 fn program_paths_exist(paths: &SdkLocalnetProgramPaths) -> bool {
-    paths.phoenix_eternal.exists() && paths.ember.exists()
+    paths.phoenix_eternal.exists()
+        && paths.ember.exists()
+        && match paths.hawkeye.as_ref() {
+            Some(hawkeye) => hawkeye.exists(),
+            None => true,
+        }
+}
+
+fn optional_program_path(path: PathBuf) -> Option<PathBuf> {
+    path.exists().then_some(path)
 }
 
 fn load_program(svm: &mut LiteSVM, program_id: &str, path: &Path) {
@@ -836,6 +1008,15 @@ fn account_data(context: &SdkLocalnetContext, address: &Pubkey) -> Vec<u8> {
         .get_account(address)
         .unwrap_or_else(|| panic!("missing account {address}"))
         .data
+}
+
+fn decode_hawkeye_return(tx: &TransactionMetadata) -> HawkeyeReturnData {
+    assert_eq!(tx.return_data.program_id, HAWKEYE_PROGRAM_ID);
+    assert!(
+        !tx.return_data.data.is_empty(),
+        "Hawkeye transaction should set return data"
+    );
+    decode_hawkeye_return_data(&tx.return_data.data).expect("decode Hawkeye return data")
 }
 
 fn orderbook_has_resting_price(


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `e01d6bf79f112b8f9c7c6e7e3ad84fb83050eb43`
- Mode: automatic
- Synced paths:

- `rise/rust` -> `rust`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `rust/CHANGELOG.md`

### Summary

- Added the **Phoenix Hawkeye** read-only view layer: instruction builders, typed return-data structs, a decode pipeline, and a high-level async RPC client for querying margin, per-asset risk, liquidation prices, BBO, and funding state via simulated transactions.
- New top-level exports from `phoenix_rise`: `PhoenixHawkeyeClient`, `HawkeyeSimulation<T>`, `PhoenixHawkeyeClientError`, `HawkeyeReturnData`, `HawkeyeReturnDataError`, all `View*Return` structs, `Hawkeye*ViewAccounts` account-list structs, low-level instruction builders (`create_hawkeye_view_*_ix`), and decode helpers (`decode_hawkeye_return_data`, `decode_hawkeye_return`).
- `PhoenixTxBuilder` gains nine new `build_hawkeye_view_*` methods that construct Hawkeye simulation instructions from a `PhoenixMetadata` context, with both PDA-derived and explicit-trader variants.
- Three new mandatory runtime dependencies: `solana-rpc-client-api ~2.3`, `solana-transaction-error ~2.2`, and `solana-transaction-status-client-types ~2.3`; `solana-compute-budget-interface ~2.2` is also added. Downstream `Cargo.toml` files that pin Solana crate ranges tightly may need adjustments.

### Breaking Changes

- None identified in the synced diff.

### Consumer Notes

- `PhoenixHawkeyeClient::new(rpc_url, &metadata)` is the recommended entry point; it defaults to an unsigned simulation fee payer (`HAWKEYE_SIMULATION_FEE_PAYER`) and a 1.4M CU limit, both overridable via builder methods.
- All Hawkeye view calls are **read-only simulations** — no fee payer signature required and no state is mutated on-chain.
- Return data is versioned (`HAWKEYE_RETURN_VERSION = 1`); callers should assert `version` matches if they hard-code struct layouts.
- `ViewBboReturn::best_bid_ticks()` / `best_ask_ticks()` return `Option<u64>` based on presence flags — a `None` means no resting orders on that side, not an error.