### PR TITLE
sync: Rise TypeScript v0.4.45

### DIFF
--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -338,3 +338,22 @@ Source Phoenix commit: `2d72d1003db4c5e852d3eef26572cd24da068745`
 - `feeBpsOverride` (`bigint | null`) is an optional, additive field on both `PhoenixFlightClientConfig` and `ProxyInstructionParams`; omitting it (or passing `null`) preserves existing behavior with no code changes required.
 - When `feeBpsOverride` is provided, `buildProxyInstructionIx` validates that the value is in the range `0n–10_000n` (inclusive) and throws `"Fee bps override must be in the range 0..=10000"` if not.
 - The fee-override path emits an on-chain instruction with a different discriminant (`PROXY_INSTRUCTION_WITH_FEE_OVERRIDE`), so infrastructure that inspects raw instruction bytes or discriminants (parsers, indexers, monitoring) should be updated to recognize the new variant.
+
+## v0.4.45 - 2026-06-18
+
+Source Phoenix commit: `5b7f20375f7eee51e309f9c4bc994609f5be2d1e`
+
+### Summary
+
+- **Auth-gated channel subscriptions are now deferred on external-session clients.** Subscriptions to the `events`, `notifications`, `trader`, `traderVolume`, and `transaction` channels will no longer be sent over an anonymous WebSocket connection. If no external session has been imported yet, the subscription message is held and replayed automatically on the authenticated connection once a session arrives.
+- **Public subscriptions flow immediately over anonymous connections.** Channels not in the auth-required set (e.g. `allMids`, orderbook, trades) are sent to the server right away, even while the client is waiting for an external session to be imported — no unnecessary reconnect is triggered for these channels.
+- **Reduced reconnect churn in `external` session control mode.** When a session has not yet been provided, the client now keeps the existing anonymous socket open instead of immediately scheduling a reconnect every time a subscription is registered, resulting in fewer connection disruptions during the authentication waiting period.
+
+### Breaking Changes
+
+- None identified in the synced diff.
+
+### Consumer Notes
+
+- If your application subscribes to auth-required channels (`events`, `notifications`, `trader`, `traderVolume`, `transaction`) before calling `sessionManager.importSnapshot(...)`, those subscribe messages will be buffered and sent once the authenticated connection is established. No code changes are required, but you should be aware that these subscriptions are not active until authentication completes.
+- Public channel subscriptions registered before an external session is available will now be active on the anonymous socket immediately, so data for those channels will begin arriving sooner than before.

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/rise",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "packageManager": "bun@1.3.13",
   "repository": {
     "type": "git",

--- a/ts/src/ws/WsClient.ts
+++ b/ts/src/ws/WsClient.ts
@@ -25,12 +25,20 @@ import type {
   WsServerErrorListener,
 } from "./types";
 
+const ACCESS_REFRESH_WINDOW_MS = 60_000;
+const WS_OPEN = 1;
+const DEFER_CONNECT_FOR_SESSION_OWNER = Symbol(
+  "defer-connect-for-session-owner"
+);
+const AUTH_REQUIRED_SUBSCRIPTION_CHANNELS: ReadonlySet<string> = new Set([
+  "events",
+  "notifications",
+  "trader",
+  "traderVolume",
+  "transaction",
+]);
+
 export const createWsClient = (opts: WsClientOpts): WsClient => {
-  const ACCESS_REFRESH_WINDOW_MS = 60_000;
-  const WS_OPEN = 1;
-  const DEFER_CONNECT_FOR_SESSION_OWNER = Symbol(
-    "defer-connect-for-session-owner"
-  );
   type DeferredSessionOwnerConnect = typeof DEFER_CONNECT_FOR_SESSION_OWNER;
   type ResolvedProtocol = WsClientConfig["protocol"];
   let ws: WebSocket | undefined;
@@ -135,7 +143,7 @@ export const createWsClient = (opts: WsClientOpts): WsClient => {
       onResub: () => {
         const [listener] = getListenersForRoutingKey(routingKey);
         if (!listener) return;
-        send(listener.subMsg);
+        sendSubscriptionMessage(listener.subMsg);
       },
     });
   };
@@ -144,6 +152,22 @@ export const createWsClient = (opts: WsClientOpts): WsClient => {
 
   const shouldMaintainConnection = () =>
     config.connectMode === "eager" || hasActiveSubscriptions();
+
+  const wantsAuthenticatedConnection = () => {
+    if (authMode === "authenticated") return true;
+    if (authMode === "anonymous") return false;
+    return lifecycle.knownAuthToken !== null;
+  };
+
+  const isOpenSocket = (socket: WebSocket | undefined): socket is WebSocket =>
+    socket !== undefined &&
+    (typeof socket.readyState !== "number" || socket.readyState === WS_OPEN);
+
+  const canUseAnonymousSocketWhileAwaitingAuth = () =>
+    authMode === "auto" &&
+    lifecycle.isAwaitingAuth &&
+    lifecycle.connectionAuth === "anonymous" &&
+    !wantsAuthenticatedConnection();
 
   const clearReconnectTimer = () => {
     if (!reconnectTimer) return;
@@ -188,6 +212,9 @@ export const createWsClient = (opts: WsClientOpts): WsClient => {
   const ensureConnection = () => {
     clearIdleCloseTimer();
     if (!shouldMaintainConnection()) {
+      return;
+    }
+    if (canUseAnonymousSocketWhileAwaitingAuth() && isOpenSocket(ws)) {
       return;
     }
     if (lifecycle.isConnected || connectInFlight || reconnectTimer) {
@@ -248,8 +275,6 @@ export const createWsClient = (opts: WsClientOpts): WsClient => {
     flushEffects();
   };
 
-  const scheduleReconnect = () => requestReconnect("immediate");
-
   const scheduleAuthRefreshRetry = (
     error: unknown,
     retry: () => void
@@ -273,21 +298,61 @@ export const createWsClient = (opts: WsClientOpts): WsClient => {
     lifecycle.send({ type: "AWAIT_AUTH" });
   };
 
-  const wantsAuthenticatedConnection = () => {
-    if (authMode === "authenticated") return true;
-    if (authMode === "anonymous") return false;
-    return lifecycle.knownAuthToken !== null;
+  const subscriptionRequiresAuth = (message: SubscriptionMessage): boolean => {
+    const channel = message.subscription.channel;
+    return (
+      typeof channel === "string" &&
+      AUTH_REQUIRED_SUBSCRIPTION_CHANNELS.has(channel)
+    );
   };
 
   const isCurrentSocket = (socket: WebSocket): boolean => ws === socket;
 
-  const isOpenSocket = (socket: WebSocket | undefined): socket is WebSocket =>
-    socket !== undefined &&
-    (typeof socket.readyState !== "number" || socket.readyState === WS_OPEN);
+  const canUseCurrentSocketForMessage = (
+    message: SubscriptionMessage
+  ): boolean => {
+    if (lifecycle.isConnected) return true;
+    return (
+      canUseAnonymousSocketWhileAwaitingAuth() &&
+      !subscriptionRequiresAuth(message)
+    );
+  };
+
+  const requestAuthenticatedTransport = () => {
+    if (authMode === "anonymous") return;
+    if (sessionIsExternallyManaged && !lifecycle.knownAuthToken) {
+      awaitExternalSessionChange();
+      return;
+    }
+    requestReconnect("immediate");
+  };
+
+  const canSendSubscriptionMessage = (
+    message: SubscriptionMessage
+  ): boolean => {
+    if (
+      authMode !== "anonymous" &&
+      lifecycle.connectionAuth === "anonymous" &&
+      subscriptionRequiresAuth(message)
+    ) {
+      requestAuthenticatedTransport();
+      return false;
+    }
+
+    if (
+      lifecycle.connectionAuth === "anonymous" &&
+      wantsAuthenticatedConnection()
+    ) {
+      requestReconnect("immediate");
+      return false;
+    }
+
+    return true;
+  };
 
   const sendSerialized = (payload: string) => {
     const socket = ws;
-    if (!socket || !lifecycle.isConnected || !isOpenSocket(socket)) return;
+    if (!socket || !isOpenSocket(socket)) return;
     if (
       lifecycle.connectionAuth === "anonymous" &&
       wantsAuthenticatedConnection()
@@ -298,8 +363,9 @@ export const createWsClient = (opts: WsClientOpts): WsClient => {
     socket.send(payload);
   };
 
-  const send = (obj: unknown) => {
-    sendSerialized(JSON.stringify(obj));
+  const sendSubscriptionMessage = (message: SubscriptionMessage) => {
+    if (!canSendSubscriptionMessage(message)) return;
+    sendSerialized(JSON.stringify(message));
   };
 
   const onClose = async (socket: WebSocket, evt?: CloseEvent) => {
@@ -608,16 +674,9 @@ export const createWsClient = (opts: WsClientOpts): WsClient => {
       syncRoutingSubscription(routingKey);
       ensureConnection();
 
-      if (lifecycle.isConnected) {
-        if (
-          lifecycle.connectionAuth === "anonymous" &&
-          wantsAuthenticatedConnection()
-        ) {
-          scheduleReconnect();
-          return;
-        }
+      if (canUseCurrentSocketForMessage(subMsg)) {
         if (isFirstRoutingListener || existingListener) {
-          send(subMsg);
+          sendSubscriptionMessage(subMsg);
         }
       }
     },
@@ -641,16 +700,9 @@ export const createWsClient = (opts: WsClientOpts): WsClient => {
         scheduleIdleClose();
       }
 
-      if (lifecycle.isConnected) {
-        if (
-          lifecycle.connectionAuth === "anonymous" &&
-          wantsAuthenticatedConnection()
-        ) {
-          scheduleReconnect();
-          return;
-        }
+      if (canUseCurrentSocketForMessage(unsubMsg)) {
         if (isLastRoutingListener) {
-          send(unsubMsg);
+          sendSubscriptionMessage(unsubMsg);
         }
       }
     },

--- a/ts/tests/external-session-control-ws.test.ts
+++ b/ts/tests/external-session-control-ws.test.ts
@@ -33,8 +33,21 @@ const makeSnapshot = (
   };
 };
 
+const makeNextSnapshot = () =>
+  makeSnapshot({
+    sessionId: "sid-2",
+    accessJti: "jti-2",
+    refreshToken: "refresh-token-2",
+    popKey: Buffer.from(
+      Uint8Array.from({ length: 32 }, (_, index) => index + 1)
+    ).toString("base64url"),
+    expiresAt: Date.now() + 120_000,
+    refreshExpiresAt: Date.now() + 240_000,
+  });
+
 class MockWebSocket {
   static instances: MockWebSocket[] = [];
+  sent: string[] = [];
   onopen: (() => void) | null = null;
   onmessage: ((evt: { data: string }) => void) | null = null;
   onclose: ((evt: { code: number; reason?: string }) => void) | null = null;
@@ -48,9 +61,13 @@ class MockWebSocket {
     queueMicrotask(() => this.onopen?.());
   }
 
-  send() {}
+  send(payload: string) {
+    this.sent.push(payload);
+  }
 
-  close() {}
+  close() {
+    queueMicrotask(() => this.onclose?.({ code: 1000 }));
+  }
 }
 
 const stubWebSocket = () => {
@@ -66,6 +83,32 @@ const stubSuccessfulFetch = () => {
   });
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
+};
+
+const createSessionManager = () =>
+  new auth.AuthSessionManager(new auth.MemoryAuthSessionStorage());
+
+const createExternalSessionClient = (sessionManager = createSessionManager()) =>
+  createPhoenixClient({
+    baseUrl: "https://example.com",
+    auth: true,
+    authConfig: {
+      sessionManager,
+      sessionControl: "external",
+    },
+    ws: {
+      url: "wss://example.com/v1/ws",
+      connectMode: "eager",
+    },
+  });
+
+const sentMessages = (socket: MockWebSocket | undefined): unknown[] =>
+  (socket?.sent ?? []).map((payload): unknown => JSON.parse(payload));
+
+const flushWs = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await vi.advanceTimersByTimeAsync(0);
 };
 
 afterEach(() => {
@@ -108,25 +151,14 @@ describe("rise external session control websocket integration", () => {
       },
     });
 
-    await Promise.resolve();
-    await vi.advanceTimersByTimeAsync(0);
+    await flushWs();
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(MockWebSocket.instances).toHaveLength(0);
 
-    const nextSnapshot = makeSnapshot({
-      sessionId: "sid-2",
-      accessJti: "jti-2",
-      refreshToken: "refresh-token-2",
-      popKey: Buffer.from(
-        Uint8Array.from({ length: 32 }, (_, index) => index + 1)
-      ).toString("base64url"),
-      expiresAt: Date.now() + 120_000,
-      refreshExpiresAt: Date.now() + 240_000,
-    });
+    const nextSnapshot = makeNextSnapshot();
     await sessionManager.importSnapshot(nextSnapshot);
-    await Promise.resolve();
-    await vi.advanceTimersByTimeAsync(0);
+    await flushWs();
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(MockWebSocket.instances).toHaveLength(1);
@@ -170,8 +202,7 @@ describe("rise external session control websocket integration", () => {
       },
     });
 
-    await Promise.resolve();
-    await vi.advanceTimersByTimeAsync(0);
+    await flushWs();
 
     expect(MockWebSocket.instances).toHaveLength(1);
 
@@ -179,30 +210,164 @@ describe("rise external session control websocket integration", () => {
       code: 4401,
       reason: "invalid_access_token",
     });
-    await Promise.resolve();
-    await vi.advanceTimersByTimeAsync(0);
+    await flushWs();
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(MockWebSocket.instances).toHaveLength(1);
 
-    const nextSnapshot = makeSnapshot({
-      sessionId: "sid-2",
-      accessJti: "jti-2",
-      refreshToken: "refresh-token-2",
-      popKey: Buffer.from(
-        Uint8Array.from({ length: 32 }, (_, index) => index + 1)
-      ).toString("base64url"),
-      expiresAt: Date.now() + 120_000,
-      refreshExpiresAt: Date.now() + 240_000,
-    });
+    const nextSnapshot = makeNextSnapshot();
     await sessionManager.importSnapshot(nextSnapshot);
-    await Promise.resolve();
-    await vi.advanceTimersByTimeAsync(0);
+    await flushWs();
 
     expect(MockWebSocket.instances).toHaveLength(2);
     expect(MockWebSocket.instances[1].protocol).toEqual([
       "phoenix-jwt",
       nextSnapshot.accessToken,
+    ]);
+
+    client.dispose();
+  });
+
+  it("does not send auth-required subscriptions over an anonymous socket", async () => {
+    vi.useFakeTimers();
+
+    stubWebSocket();
+    const fetchMock = stubSuccessfulFetch();
+
+    const client = createExternalSessionClient();
+
+    await flushWs();
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0].protocol).toBeUndefined();
+
+    client.streams?.notifications({ authority: "authority-1" });
+    await flushWs();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(sentMessages(MockWebSocket.instances[0])).toEqual([]);
+
+    client.dispose();
+  });
+
+  it("still sends public subscriptions over an anonymous socket", async () => {
+    vi.useFakeTimers();
+
+    stubWebSocket();
+    const fetchMock = stubSuccessfulFetch();
+
+    const client = createExternalSessionClient();
+
+    await flushWs();
+
+    client.streams?.allMids();
+    await flushWs();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(sentMessages(MockWebSocket.instances[0])).toEqual([
+      {
+        type: "subscribe",
+        subscription: {
+          channel: "allMids",
+        },
+      },
+    ]);
+
+    client.dispose();
+  });
+
+  it("keeps public subscriptions on the anonymous socket while private subscriptions wait for external auth", async () => {
+    vi.useFakeTimers();
+
+    stubWebSocket();
+    const fetchMock = stubSuccessfulFetch();
+
+    const sessionManager = createSessionManager();
+    const client = createExternalSessionClient(sessionManager);
+
+    await flushWs();
+
+    client.streams?.notifications({ authority: "authority-1" });
+    await flushWs();
+
+    client.streams?.allMids();
+    await flushWs();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0].protocol).toBeUndefined();
+    expect(sentMessages(MockWebSocket.instances[0])).toEqual([
+      {
+        type: "subscribe",
+        subscription: {
+          channel: "allMids",
+        },
+      },
+    ]);
+
+    const nextSnapshot = makeNextSnapshot();
+    await sessionManager.importSnapshot(nextSnapshot);
+    await flushWs();
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+    expect(MockWebSocket.instances[1].protocol).toEqual([
+      "phoenix-jwt",
+      nextSnapshot.accessToken,
+    ]);
+    expect(sentMessages(MockWebSocket.instances[1])).toEqual([
+      {
+        type: "subscribe",
+        subscription: {
+          channel: "notifications",
+          authority: "authority-1",
+        },
+      },
+      {
+        type: "subscribe",
+        subscription: {
+          channel: "allMids",
+        },
+      },
+    ]);
+
+    client.dispose();
+  });
+
+  it("sends deferred auth-required subscriptions after an external session appears", async () => {
+    vi.useFakeTimers();
+
+    stubWebSocket();
+    const fetchMock = stubSuccessfulFetch();
+
+    const sessionManager = createSessionManager();
+    const client = createExternalSessionClient(sessionManager);
+
+    await flushWs();
+
+    client.streams?.notifications({ authority: "authority-1" });
+    await flushWs();
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(sentMessages(MockWebSocket.instances[0])).toEqual([]);
+
+    const nextSnapshot = makeNextSnapshot();
+    await sessionManager.importSnapshot(nextSnapshot);
+    await flushWs();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(MockWebSocket.instances).toHaveLength(2);
+    expect(MockWebSocket.instances[1].protocol).toEqual([
+      "phoenix-jwt",
+      nextSnapshot.accessToken,
+    ]);
+    expect(sentMessages(MockWebSocket.instances[1])).toEqual([
+      {
+        type: "subscribe",
+        subscription: {
+          channel: "notifications",
+          authority: "authority-1",
+        },
+      },
     ]);
 
     client.dispose();


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `5b7f20375f7eee51e309f9c4bc994609f5be2d1e`
- Mode: automatic
- Synced paths:

- `rise/ts` -> `ts`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `ts/CHANGELOG.md`

### Summary

- **Auth-gated channel subscriptions are now deferred on external-session clients.** Subscriptions to the `events`, `notifications`, `trader`, `traderVolume`, and `transaction` channels will no longer be sent over an anonymous WebSocket connection. If no external session has been imported yet, the subscription message is held and replayed automatically on the authenticated connection once a session arrives.
- **Public subscriptions flow immediately over anonymous connections.** Channels not in the auth-required set (e.g. `allMids`, orderbook, trades) are sent to the server right away, even while the client is waiting for an external session to be imported — no unnecessary reconnect is triggered for these channels.
- **Reduced reconnect churn in `external` session control mode.** When a session has not yet been provided, the client now keeps the existing anonymous socket open instead of immediately scheduling a reconnect every time a subscription is registered, resulting in fewer connection disruptions during the authentication waiting period.

### Breaking Changes

- None identified in the synced diff.

### Consumer Notes

- If your application subscribes to auth-required channels (`events`, `notifications`, `trader`, `traderVolume`, `transaction`) before calling `sessionManager.importSnapshot(...)`, those subscribe messages will be buffered and sent once the authenticated connection is established. No code changes are required, but you should be aware that these subscriptions are not active until authentication completes.
- Public channel subscriptions registered before an external session is available will now be active on the anonymous socket immediately, so data for those channels will begin arriving sooner than before.