### PR TITLE
sync: Rise TypeScript v0.4.46

### DIFF
--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -357,3 +357,22 @@ Source Phoenix commit: `5b7f20375f7eee51e309f9c4bc994609f5be2d1e`
 
 - If your application subscribes to auth-required channels (`events`, `notifications`, `trader`, `traderVolume`, `transaction`) before calling `sessionManager.importSnapshot(...)`, those subscribe messages will be buffered and sent once the authenticated connection is established. No code changes are required, but you should be aware that these subscriptions are not active until authentication completes.
 - Public channel subscriptions registered before an external session is available will now be active on the anonymous socket immediately, so data for those channels will begin arriving sooner than before.
+
+## v0.4.46 - 2026-06-22
+
+Source Phoenix commit: `fd9d044ad0e76e6bcbef1333b1ebc8648f511b7a`
+
+### Summary
+
+- Added `MarketStatsSnapshot` interface and `MarketStatsSnapshotSchema` as new public exports from `@ellipsis-labs/rise`.
+- `ExchangeMarketConfig` now includes an optional `statsSnapshot?: MarketStatsSnapshot` field containing slot, open interest, funding interval timestamp, and cumulative funding rate.
+- Numeric fields (`openInterestBaseLots`, `fundingStartIntervalTimestamp`, `cumulativeFundingRate`) are coerced to strings at parse time, so the API may return either strings or numbers and the SDK normalizes them.
+
+### Breaking Changes
+
+- None identified in the synced diff.
+
+### Consumer Notes
+
+- Access per-market stats via `market.statsSnapshot` when calling `getMarkets()`. The field is optional and will be `undefined` if the server does not include it.
+- `MarketStatsSnapshot` and `MarketStatsSnapshotSchema` are now available as named exports for consumers who want to validate or type this shape independently.

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/rise",
-  "version": "0.4.45",
+  "version": "0.4.46",
   "packageManager": "bun@1.3.13",
   "repository": {
     "type": "git",

--- a/ts/src/_exports/public-api-schemas.ts
+++ b/ts/src/_exports/public-api-schemas.ts
@@ -47,6 +47,8 @@ export {
   MarketCalendarSchema,
   type MarketPublicMetadata,
   MarketPublicMetadataSchema,
+  type MarketStatsSnapshot,
+  MarketStatsSnapshotSchema,
   type ExchangeSnapshotView,
   ExchangeSnapshotViewSchema,
   type ExchangeStateSnapshot,

--- a/ts/src/api/exchange/types.ts
+++ b/ts/src/api/exchange/types.ts
@@ -173,6 +173,25 @@ export const MarketPublicMetadataSchema: z.ZodType<MarketPublicMetadata> =
     displayColor: z.string().nullable().optional(),
   });
 
+export interface MarketStatsSnapshot {
+  slot: number;
+  slotIndex: number;
+  openInterestBaseLots: string;
+  fundingStartIntervalTimestamp: string;
+  cumulativeFundingRate: string;
+}
+
+export const MarketStatsSnapshotSchema: z.ZodType<MarketStatsSnapshot> =
+  z.object({
+    slot: z.number(),
+    slotIndex: z.number(),
+    openInterestBaseLots: z.union([z.string(), z.number()]).transform(String),
+    fundingStartIntervalTimestamp: z
+      .union([z.string(), z.number()])
+      .transform(String),
+    cumulativeFundingRate: z.union([z.string(), z.number()]).transform(String),
+  });
+
 export interface ExchangeMarketConfig {
   symbol: string;
   assetId: number;
@@ -195,6 +214,7 @@ export interface ExchangeMarketConfig {
   openInterestCapBaseLots: string;
   maxLiquidationSizeBaseLots: string;
   isolatedOnly: boolean;
+  statsSnapshot?: MarketStatsSnapshot;
 }
 
 export const ExchangeMarketConfigSchema: z.ZodType<ExchangeMarketConfig> =
@@ -227,6 +247,7 @@ export const ExchangeMarketConfigSchema: z.ZodType<ExchangeMarketConfig> =
       .union([z.string(), z.number()])
       .transform(String),
     isolatedOnly: z.boolean(),
+    statsSnapshot: MarketStatsSnapshotSchema.optional(),
   });
 
 export interface ExchangeViewMarketPriceBand {

--- a/ts/tests/public-client-routes.test.ts
+++ b/ts/tests/public-client-routes.test.ts
@@ -219,6 +219,45 @@ const createTransport = (
 });
 
 describe("public client route mapping", () => {
+  it("parses optional exchange market stats snapshots", async () => {
+    const records: RequestRecord[] = [];
+    const responses = new Map<string, unknown>([
+      [
+        "/v1/view/exchange/markets",
+        [
+          {
+            ...EXCHANGE_MARKET_RESPONSE,
+            statsSnapshot: {
+              slot: 123,
+              slotIndex: 4,
+              openInterestBaseLots: 12345,
+              fundingStartIntervalTimestamp: "1700000000",
+              cumulativeFundingRate: "-42",
+            },
+          },
+        ],
+      ],
+    ]);
+    const transport = createTransport(responses, records);
+    const exchange = new V1ExchangeClient(transport);
+
+    const [market] = await exchange.getMarkets();
+
+    expect(market?.statsSnapshot).toEqual({
+      slot: 123,
+      slotIndex: 4,
+      openInterestBaseLots: "12345",
+      fundingStartIntervalTimestamp: "1700000000",
+      cumulativeFundingRate: "-42",
+    });
+
+    responses.set("/v1/view/exchange/markets", [EXCHANGE_MARKET_RESPONSE]);
+    const markets = new V1MarketsClient(transport);
+    const [legacyMarket] = await markets.getMarkets();
+
+    expect(legacyMarket?.statsSnapshot).toBeUndefined();
+  });
+
   it("uses the public exchange and market routes", async () => {
     const records: RequestRecord[] = [];
     const transport = createTransport(


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `fd9d044ad0e76e6bcbef1333b1ebc8648f511b7a`
- Mode: manual
- Synced paths:

- `rise/ts` -> `ts`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `ts/CHANGELOG.md`

### Summary

- Added `MarketStatsSnapshot` interface and `MarketStatsSnapshotSchema` as new public exports from `@ellipsis-labs/rise`.
- `ExchangeMarketConfig` now includes an optional `statsSnapshot?: MarketStatsSnapshot` field containing slot, open interest, funding interval timestamp, and cumulative funding rate.
- Numeric fields (`openInterestBaseLots`, `fundingStartIntervalTimestamp`, `cumulativeFundingRate`) are coerced to strings at parse time, so the API may return either strings or numbers and the SDK normalizes them.

### Breaking Changes

- None identified in the synced diff.

### Consumer Notes

- Access per-market stats via `market.statsSnapshot` when calling `getMarkets()`. The field is optional and will be `undefined` if the server does not include it.
- `MarketStatsSnapshot` and `MarketStatsSnapshotSchema` are now available as named exports for consumers who want to validate or type this shape independently.