### PR TITLE
sync: Rise Rust v0.1.11

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -147,3 +147,27 @@ Source Phoenix commit: `e01d6bf79f112b8f9c7c6e7e3ad84fb83050eb43`
 - All Hawkeye view calls are **read-only simulations** — no fee payer signature required and no state is mutated on-chain.
 - Return data is versioned (`HAWKEYE_RETURN_VERSION = 1`); callers should assert `version` matches if they hard-code struct layouts.
 - `ViewBboReturn::best_bid_ticks()` / `best_ask_ticks()` return `Option<u64>` based on presence flags — a `None` means no resting orders on that side, not an error.
+
+## v0.1.11 - 2026-06-22
+
+Source Phoenix commit: `fd9d044ad0e76e6bcbef1333b1ebc8648f511b7a`
+
+### Summary
+
+- **Flight per-order fee override**: `ProxyInstructionParams::builder()` now accepts `.fee_bps_override(bps: u64)` (0–10 000). When set, `create_proxy_instruction_ix` emits the `proxy_instruction_with_fee_override` variant with a different discriminant and a Borsh `Option<u64>` prefix before the inner instruction data. `PhoenixFlightClient` gains a matching `try_wrap_order_instruction_with_fee_bps_override(ix, trader_wallet, fee_bps_override: Option<u64>)` method; the existing `try_wrap_order_instruction` is unchanged and delegates to it with `None`.
+- **WebSocket subscription event channel**: `WsSubscriptionEvent` is now a public export. Call `client.subscription_event_receiver()` (once) to receive `Status` and `Error` lifecycle events for every subscription acknowledgement or rejection. New `PhoenixWSClient::new_with_connection_status_and_auth` constructor combines authenticated and connection-status modes.
+- **Automatic auth reconnect on WS close**: The client now detects auth-related close codes (4401, 4403, 1008) and reason strings (`access_token_expired`, `invalid_access_token`, etc.), refreshes the session, reconnects, and resubmits active subscriptions transparently.
+- **`ExchangeMarketConfig` gains `stats_snapshot: Option<MarketStatsSnapshot>`**: The new field is `#[serde(default)]` so deserialization of existing payloads is unchanged, but Rust struct literal construction must now include `stats_snapshot: None`.
+- **New `JsSafeI64` type** added to `phoenix_rise::types::js_safe_ints` (mirrors `JsSafeU64` for signed values; serialises as a decimal string).
+
+### Breaking Changes
+
+- `AdminChallengeRequest` and `AdminLoginRequest` are removed from `phoenix_rise::types::auth`. Code referencing these types will fail to compile.
+- `CreateServiceAccountRequest.role` and `ServiceAccountDto.role` fields are removed. Struct construction and pattern matching on these types must be updated.
+- `ExchangeMarketConfig` requires a new `stats_snapshot` field for struct literal construction (e.g. in tests). Add `stats_snapshot: None` to any existing struct literals.
+
+### Consumer Notes
+
+- The `fee_bps_override` builder method validates the range at `build()` time and returns `PhoenixIxError::InvalidFeeBpsOverride` for values above 10 000. Pass `None` (or omit the call) to continue using the builder's registered fee.
+- `subscription_event_receiver()` takes ownership of the channel and can only be called once per client instance; subsequent calls return `None`.
+- `ServerMessage` now has a `SubscriptionStatus(SubscriptionStatusMessage)` variant — match arms with `ServerMessage::Other` that previously caught subscription-status frames will now route through the new variant instead.

--- a/rust/CRATES.md
+++ b/rust/CRATES.md
@@ -9,7 +9,7 @@
 
 ```toml
 [dependencies]
-phoenix-rise = "0.1.1"
+phoenix-rise = "0.1.10"
 ```
 
 Optional features:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "axum",
@@ -2675,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-sdk-cli"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "clap",
  "phoenix-rise",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -240,7 +240,7 @@ publish      = true
 readme       = "CRATES.md"
 repository   = "https://github.com/Ellipsis-Labs/rise"
 rust-version = "1.84.0"
-version      = "0.1.10"
+version      = "0.1.11"
 
 [workspace.dependencies]
 async-trait = "0.1"

--- a/rust/README.md
+++ b/rust/README.md
@@ -105,7 +105,9 @@ metadata rather than server-assisted order helpers.
 ### `PhoenixFlightClient`
 
 Use this when you want to wrap supported Phoenix placement instructions through
-Flight.
+Flight. Use `try_wrap_order_instruction_with_fee_bps_override(...)` when a
+specific wrapped order should use Flight's `proxy_instruction_with_fee_override`
+variant instead of the builder's registered fee.
 
 > **Use embedded wallets for Flight integrations.** Integrators are strongly
 > encouraged to provision an embedded wallet per user rather than routing

--- a/rust/ix/examples/build_all_ix.rs
+++ b/rust/ix/examples/build_all_ix.rs
@@ -506,7 +506,41 @@ fn main() {
         results.insert("ProxyInstruction".to_string(), hex_encode(&ix.data));
     }
 
-    // 24. Flight client wrapper for deterministic Flight-supported instructions.
+    // 24. Flight ProxyInstructionWithFeeOverride (wrapping a deterministic
+    //     PlaceLimitOrder)
+    {
+        let inner_params = LimitOrderParams::builder()
+            .trader(pubkeys[0])
+            .trader_account(pubkeys[1])
+            .perp_asset_map(pubkeys[2])
+            .orderbook(pubkeys[3])
+            .spline_collection(pubkeys[4])
+            .global_trader_index(vec2(5, 6))
+            .active_trader_buffer(vec2(7, 8))
+            .side(Side::Bid)
+            .price_in_ticks(1000)
+            .num_base_lots(100)
+            .build()
+            .unwrap();
+        let inner = create_place_limit_order_ix(inner_params).unwrap();
+
+        let params = phoenix_rise_ix::flight::ProxyInstructionParams::builder()
+            .builder_authority(pubkeys[9])
+            .builder_trader_account(pubkeys[10])
+            .trader_wallet(pubkeys[0])
+            .fee_bps_override(5)
+            .inner_instruction(inner)
+            .build()
+            .unwrap();
+
+        let ix = phoenix_rise_ix::flight::create_proxy_instruction_ix(params).unwrap();
+        results.insert(
+            "ProxyInstructionWithFeeOverride".to_string(),
+            hex_encode(&ix.data),
+        );
+    }
+
+    // 25. Flight client wrapper for deterministic Flight-supported instructions.
     {
         let flight_client = PhoenixFlightClient::new(pubkeys[9], 0, 0);
 

--- a/rust/ix/src/error.rs
+++ b/rust/ix/src/error.rs
@@ -50,6 +50,9 @@ pub enum PhoenixIxError {
     #[error("Inner instruction must target the Phoenix program")]
     InvalidInnerProgram,
 
+    #[error("Invalid fee bps override (must be in 0..=10000)")]
+    InvalidFeeBpsOverride,
+
     #[error("Invalid conditional orders capacity (must be greater than 0)")]
     InvalidConditionalOrdersCapacity,
 

--- a/rust/ix/src/flight/constants.rs
+++ b/rust/ix/src/flight/constants.rs
@@ -17,6 +17,10 @@ pub fn flight_proxy_instruction_discriminant() -> [u8; 8] {
     compute_discriminant("global:proxy_instruction")
 }
 
+pub fn flight_proxy_instruction_with_fee_override_discriminant() -> [u8; 8] {
+    compute_discriminant("global:proxy_instruction_with_fee_override")
+}
+
 /// Derives the global state PDA for the Flight program.
 ///
 /// Seeds: [PHOENIX_PROGRAM_ID, "global_state"] against Flight program

--- a/rust/ix/src/flight/proxy_instruction.rs
+++ b/rust/ix/src/flight/proxy_instruction.rs
@@ -10,10 +10,13 @@ use solana_pubkey::Pubkey;
 use crate::ix::constants::PHOENIX_PROGRAM_ID;
 use crate::ix::error::PhoenixIxError;
 use crate::ix::flight::constants::{
-    FLIGHT_PROGRAM_ID, flight_proxy_instruction_discriminant, get_flight_builder_state_address,
+    FLIGHT_PROGRAM_ID, flight_proxy_instruction_discriminant,
+    flight_proxy_instruction_with_fee_override_discriminant, get_flight_builder_state_address,
     get_flight_global_state_address,
 };
 use crate::ix::types::{AccountMeta, Instruction};
+
+const MAX_FEE_BPS_OVERRIDE: u64 = 10_000;
 
 /// Parameters for the Flight `proxy_instruction` wrapper.
 #[derive(Debug, Clone)]
@@ -28,6 +31,9 @@ pub struct ProxyInstructionParams {
     /// the Phoenix program; its accounts and data are appended verbatim to the
     /// proxy instruction.
     inner_instruction: Instruction,
+    /// Optional builder fee override in basis points. When present, the
+    /// instruction uses Flight's `proxy_instruction_with_fee_override` variant.
+    fee_bps_override: Option<u64>,
 }
 
 impl ProxyInstructionParams {
@@ -50,6 +56,10 @@ impl ProxyInstructionParams {
     pub fn inner_instruction(&self) -> &Instruction {
         &self.inner_instruction
     }
+
+    pub fn fee_bps_override(&self) -> Option<u64> {
+        self.fee_bps_override
+    }
 }
 
 #[derive(Default)]
@@ -58,6 +68,7 @@ pub struct ProxyInstructionParamsBuilder {
     builder_trader_account: Option<Pubkey>,
     trader_wallet: Option<Pubkey>,
     inner_instruction: Option<Instruction>,
+    fee_bps_override: Option<u64>,
 }
 
 impl ProxyInstructionParamsBuilder {
@@ -85,7 +96,19 @@ impl ProxyInstructionParamsBuilder {
         self
     }
 
+    pub fn fee_bps_override(mut self, fee_bps_override: u64) -> Self {
+        self.fee_bps_override = Some(fee_bps_override);
+        self
+    }
+
     pub fn build(self) -> Result<ProxyInstructionParams, PhoenixIxError> {
+        if self
+            .fee_bps_override
+            .is_some_and(|fee_bps_override| fee_bps_override > MAX_FEE_BPS_OVERRIDE)
+        {
+            return Err(PhoenixIxError::InvalidFeeBpsOverride);
+        }
+
         Ok(ProxyInstructionParams {
             builder_authority: self
                 .builder_authority
@@ -99,16 +122,19 @@ impl ProxyInstructionParamsBuilder {
             inner_instruction: self
                 .inner_instruction
                 .ok_or(PhoenixIxError::MissingField("inner_instruction"))?,
+            fee_bps_override: self.fee_bps_override,
         })
     }
 }
 
-/// Create a Flight `proxy_instruction` wrapping an inner Phoenix instruction.
+/// Create a Flight proxy instruction wrapping an inner Phoenix instruction.
 ///
 /// The inner instruction's data is appended verbatim after the Flight
 /// discriminant, and its accounts are appended verbatim after the six Flight
-/// accounts. Returns an error if `inner_instruction.program_id` is not the
-/// Phoenix program.
+/// accounts. When `fee_bps_override` is set, this emits Flight's
+/// `proxy_instruction_with_fee_override` variant with the Borsh
+/// `Option<u64>` fee prefix before the inner instruction data. Returns an
+/// error if `inner_instruction.program_id` is not the Phoenix program.
 pub fn create_proxy_instruction_ix(
     params: ProxyInstructionParams,
 ) -> Result<Instruction, PhoenixIxError> {
@@ -116,11 +142,8 @@ pub fn create_proxy_instruction_ix(
         return Err(PhoenixIxError::InvalidInnerProgram);
     }
 
-    let prefix = flight_proxy_instruction_discriminant();
     let inner_data = &params.inner_instruction().data;
-    let mut data = Vec::with_capacity(prefix.len() + inner_data.len());
-    data.extend_from_slice(&prefix);
-    data.extend_from_slice(inner_data);
+    let data = encode_proxy_instruction_data(params.fee_bps_override(), inner_data);
 
     let mut accounts = Vec::with_capacity(6 + params.inner_instruction().accounts.len());
     accounts.push(AccountMeta::readonly(get_flight_global_state_address()));
@@ -138,6 +161,27 @@ pub fn create_proxy_instruction_ix(
         accounts,
         data,
     })
+}
+
+fn encode_proxy_instruction_data(fee_bps_override: Option<u64>, inner_data: &[u8]) -> Vec<u8> {
+    match fee_bps_override {
+        Some(fee_bps_override) => {
+            let prefix = flight_proxy_instruction_with_fee_override_discriminant();
+            let mut data = Vec::with_capacity(prefix.len() + 1 + 8 + inner_data.len());
+            data.extend_from_slice(&prefix);
+            data.push(1);
+            data.extend_from_slice(&fee_bps_override.to_le_bytes());
+            data.extend_from_slice(inner_data);
+            data
+        }
+        None => {
+            let prefix = flight_proxy_instruction_discriminant();
+            let mut data = Vec::with_capacity(prefix.len() + inner_data.len());
+            data.extend_from_slice(&prefix);
+            data.extend_from_slice(inner_data);
+            data
+        }
+    }
 }
 
 #[cfg(test)]
@@ -187,6 +231,30 @@ mod tests {
         assert_eq!(ix.program_id, FLIGHT_PROGRAM_ID);
         assert_eq!(&ix.data[..8], &flight_proxy_instruction_discriminant());
         assert_eq!(&ix.data[8..], &inner_data[..]);
+    }
+
+    #[test]
+    fn test_data_with_fee_override_prefixed_with_discriminant_and_params() {
+        let inner_data = vec![0xAA, 0xBB, 0xCC];
+        let inner = make_inner_ix(inner_data.clone(), vec![]);
+        let params = ProxyInstructionParams::builder()
+            .builder_authority(Pubkey::new_unique())
+            .builder_trader_account(Pubkey::new_unique())
+            .trader_wallet(Pubkey::new_unique())
+            .fee_bps_override(5)
+            .inner_instruction(inner)
+            .build()
+            .unwrap();
+
+        let ix = create_proxy_instruction_ix(params).unwrap();
+        assert_eq!(ix.program_id, FLIGHT_PROGRAM_ID);
+        assert_eq!(
+            &ix.data[..8],
+            &flight_proxy_instruction_with_fee_override_discriminant()
+        );
+        assert_eq!(ix.data[8], 1);
+        assert_eq!(&ix.data[9..17], &5u64.to_le_bytes());
+        assert_eq!(&ix.data[17..], &inner_data[..]);
     }
 
     #[test]
@@ -255,5 +323,17 @@ mod tests {
             result,
             Err(PhoenixIxError::MissingField("inner_instruction"))
         ));
+    }
+
+    #[test]
+    fn test_invalid_fee_override() {
+        let result = ProxyInstructionParams::builder()
+            .builder_authority(Pubkey::new_unique())
+            .builder_trader_account(Pubkey::new_unique())
+            .trader_wallet(Pubkey::new_unique())
+            .fee_bps_override(10_001)
+            .inner_instruction(make_inner_ix(vec![], vec![]))
+            .build();
+        assert!(matches!(result, Err(PhoenixIxError::InvalidFeeBpsOverride)));
     }
 }

--- a/rust/ix/src/hawkeye.rs
+++ b/rust/ix/src/hawkeye.rs
@@ -2,7 +2,7 @@
 
 use core::mem::size_of;
 
-use bytemuck::{try_from_bytes, Pod, Zeroable};
+use bytemuck::{Pod, Zeroable, try_from_bytes};
 use solana_pubkey::Pubkey;
 use thiserror::Error;
 
@@ -38,11 +38,11 @@ pub const VIEW_FUNDING_HAS_UNSETTLED: u8 = 1 << 1;
 #[repr(u64)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PhoenixHawkeyeInstruction {
-    ViewMargin = sha2_const(b"global:view_margin"),
-    ViewMarginForAsset = sha2_const(b"global:view_margin_for_asset"),
+    ViewMargin           = sha2_const(b"global:view_margin"),
+    ViewMarginForAsset   = sha2_const(b"global:view_margin_for_asset"),
     ViewLiquidationPrice = sha2_const(b"global:view_liquidation_price"),
-    ViewBbo = sha2_const(b"global:view_bbo"),
-    ViewFunding = sha2_const(b"global:view_funding"),
+    ViewBbo              = sha2_const(b"global:view_bbo"),
+    ViewFunding          = sha2_const(b"global:view_funding"),
 }
 
 impl PhoenixHawkeyeInstruction {

--- a/rust/sdk/src/client.rs
+++ b/rust/sdk/src/client.rs
@@ -949,7 +949,9 @@ impl PhoenixClient {
                     subscribers_by_key,
                 ));
             }
-            ServerMessage::Error(_) | ServerMessage::Other => {}
+            ServerMessage::Error(_)
+            | ServerMessage::SubscriptionStatus(_)
+            | ServerMessage::Other => {}
         }
 
         stale

--- a/rust/sdk/src/flight_client.rs
+++ b/rust/sdk/src/flight_client.rs
@@ -55,18 +55,33 @@ impl PhoenixFlightClient {
         ix: Instruction,
         trader_wallet: Pubkey,
     ) -> Result<Instruction, PhoenixIxError> {
+        self.try_wrap_order_instruction_with_fee_bps_override(ix, trader_wallet, None)
+    }
+
+    /// Wrap `ix` in a Flight `proxy_instruction_with_fee_override` if Flight
+    /// supports routing it and `fee_bps_override` is `Some`; return it
+    /// unchanged for unsupported instructions.
+    pub fn try_wrap_order_instruction_with_fee_bps_override(
+        &self,
+        ix: Instruction,
+        trader_wallet: Pubkey,
+        fee_bps_override: Option<u64>,
+    ) -> Result<Instruction, PhoenixIxError> {
         if !is_flight_routable_instruction(&ix) {
             return Ok(ix);
         }
 
         let inner = to_phoenix_rise_ix_instruction(ix);
 
-        let params = ProxyInstructionParams::builder()
+        let mut params_builder = ProxyInstructionParams::builder()
             .builder_authority(self.builder_authority)
             .builder_trader_account(self.builder_trader_account())
             .trader_wallet(trader_wallet)
-            .inner_instruction(inner)
-            .build()?;
+            .inner_instruction(inner);
+        if let Some(fee_bps_override) = fee_bps_override {
+            params_builder = params_builder.fee_bps_override(fee_bps_override);
+        }
+        let params = params_builder.build()?;
 
         Ok(create_proxy_instruction_ix(params)?.into())
     }
@@ -166,6 +181,30 @@ mod tests {
             &crate::phoenix_rise_ix::flight::flight_proxy_instruction_discriminant()
         );
         assert_eq!(&wrapped.data[8..], &inner_data[..]);
+    }
+
+    #[test]
+    fn test_wraps_order_placing_ix_with_fee_bps_override() {
+        let client = PhoenixFlightClient::new(Pubkey::new_unique(), 0, 0);
+        let trader_wallet = Pubkey::new_unique();
+        let inner = build_sample_limit_ix();
+        let inner_data = inner.data.clone();
+
+        let wrapped = client
+            .try_wrap_order_instruction_with_fee_bps_override(inner, trader_wallet, Some(5))
+            .unwrap();
+
+        assert_eq!(
+            wrapped.program_id,
+            crate::phoenix_rise_ix::flight::FLIGHT_PROGRAM_ID
+        );
+        assert_eq!(
+            &wrapped.data[..8],
+            &crate::phoenix_rise_ix::flight::flight_proxy_instruction_with_fee_override_discriminant()
+        );
+        assert_eq!(wrapped.data[8], 1);
+        assert_eq!(&wrapped.data[9..17], &5u64.to_le_bytes());
+        assert_eq!(&wrapped.data[17..], &inner_data[..]);
     }
 
     #[test]

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -121,7 +121,7 @@ pub use order_tickets::{
 };
 pub use rust_decimal::Decimal;
 pub use tx_builder::{PhoenixTxBuilder, PhoenixTxBuilderError};
-pub use ws_client::{PhoenixWSClient, SubscriptionHandle, WsConnectionStatus};
+pub use ws_client::{PhoenixWSClient, SubscriptionHandle, WsConnectionStatus, WsSubscriptionEvent};
 
 pub use crate::phoenix_rise_ix::{
     CancelConditionalOrderParams, CancelId, CancelStopLossParams, CondensedOrder,

--- a/rust/sdk/src/tx_builder.rs
+++ b/rust/sdk/src/tx_builder.rs
@@ -1937,6 +1937,7 @@ mod tests {
             open_interest_cap_base_lots: 0u64.into(),
             max_liquidation_size_base_lots: 0u64.into(),
             isolated_only: false,
+            stats_snapshot: None,
         }
     }
 

--- a/rust/sdk/src/ws_client.rs
+++ b/rust/sdk/src/ws_client.rs
@@ -17,6 +17,7 @@ use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::http::HeaderMap;
 use tokio_tungstenite::tungstenite::http::header::{AUTHORIZATION, SEC_WEBSOCKET_PROTOCOL};
 use tokio_tungstenite::tungstenite::http::{HeaderValue, StatusCode};
+use tokio_tungstenite::tungstenite::protocol::frame::CloseFrame;
 use tokio_tungstenite::tungstenite::{Error as TungsteniteError, Message};
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
 #[cfg(feature = "opentelemetry")]
@@ -51,6 +52,22 @@ pub enum WsConnectionStatus {
     ConnectionFailed,
     /// Connection was closed or lost.
     Disconnected(String),
+}
+
+/// WebSocket subscription lifecycle events.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WsSubscriptionEvent {
+    /// The server acknowledged a subscription status.
+    Status {
+        status: String,
+        subscription: SubscriptionRequest,
+    },
+    /// The server rejected a subscription or sent a protocol error.
+    Error {
+        subscription: Option<SubscriptionRequest>,
+        code: String,
+        message: String,
+    },
 }
 
 /// Handle for managing an active subscription.
@@ -112,6 +129,22 @@ enum ControlMessage {
     Shutdown,
 }
 
+type PhoenixWsStream = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+type PhoenixWsSink = futures_util::stream::SplitSink<PhoenixWsStream, Message>;
+type PhoenixWsRead = futures_util::stream::SplitStream<PhoenixWsStream>;
+
+struct ActiveWebSocket {
+    sink: PhoenixWsSink,
+    read: PhoenixWsRead,
+}
+
+impl ActiveWebSocket {
+    fn new(stream: PhoenixWsStream) -> Self {
+        let (sink, read) = stream.split();
+        Self { sink, read }
+    }
+}
+
 /// WebSocket client for Phoenix API.
 ///
 /// Handles connection management and message routing to subscribers.
@@ -119,6 +152,7 @@ pub struct PhoenixWSClient {
     control_tx: mpsc::UnboundedSender<ControlMessage>,
     ws_url: Url,
     ws_connection_status_rx: Option<mpsc::UnboundedReceiver<WsConnectionStatus>>,
+    ws_subscription_event_rx: Option<mpsc::UnboundedReceiver<WsSubscriptionEvent>>,
     next_subscriber_id: AtomicU64,
 }
 
@@ -171,6 +205,21 @@ impl PhoenixWSClient {
     ) -> Result<Self, PhoenixWsError> {
         Self::new_internal(
             &env.ws_url,
+            true,
+            Some(auth_client),
+            #[cfg(feature = "opentelemetry")]
+            None,
+        )
+    }
+
+    /// Create a new authenticated WebSocket client with connection status
+    /// updates enabled.
+    pub fn new_with_connection_status_and_auth(
+        ws_url: &str,
+        auth_client: PhoenixHttpClient,
+    ) -> Result<Self, PhoenixWsError> {
+        Self::new_internal(
+            ws_url,
             true,
             Some(auth_client),
             #[cfg(feature = "opentelemetry")]
@@ -245,6 +294,7 @@ impl PhoenixWSClient {
     ) -> Result<Self, PhoenixWsError> {
         let url = Url::parse(ws_url)?;
         let (control_tx, control_rx) = mpsc::unbounded_channel();
+        let (ws_subscription_event_tx, ws_subscription_event_rx) = mpsc::unbounded_channel();
 
         let (ws_connection_status_tx, ws_connection_status_rx) = if receiver_connection_status {
             let (tx, rx) = mpsc::unbounded_channel();
@@ -257,6 +307,7 @@ impl PhoenixWSClient {
             control_tx,
             ws_url: url.clone(),
             ws_connection_status_rx,
+            ws_subscription_event_rx: Some(ws_subscription_event_rx),
             next_subscriber_id: AtomicU64::new(0),
         };
 
@@ -277,6 +328,7 @@ impl PhoenixWSClient {
             auth_client,
             control_rx,
             ws_connection_status_tx,
+            ws_subscription_event_tx,
             trace_context_provider,
         ));
         #[cfg(not(feature = "opentelemetry"))]
@@ -285,6 +337,7 @@ impl PhoenixWSClient {
             auth_client,
             control_rx,
             ws_connection_status_tx,
+            ws_subscription_event_tx,
         ));
 
         Ok(client)
@@ -600,6 +653,15 @@ impl PhoenixWSClient {
         self.ws_connection_status_rx.take()
     }
 
+    /// Returns the subscription event receiver.
+    ///
+    /// This takes ownership of the receiver, so it can only be called once.
+    pub fn subscription_event_receiver(
+        &mut self,
+    ) -> Option<mpsc::UnboundedReceiver<WsSubscriptionEvent>> {
+        self.ws_subscription_event_rx.take()
+    }
+
     /// Shutdown the client and close the connection.
     pub fn shutdown(&self) {
         let _ = self.control_tx.send(ControlMessage::Shutdown);
@@ -612,6 +674,7 @@ impl PhoenixWSClient {
         auth_client: Option<PhoenixHttpClient>,
         mut control_rx: mpsc::UnboundedReceiver<ControlMessage>,
         ws_connection_status_tx: Option<mpsc::UnboundedSender<WsConnectionStatus>>,
+        ws_subscription_event_tx: mpsc::UnboundedSender<WsSubscriptionEvent>,
         #[cfg(feature = "opentelemetry")] trace_context_provider: Option<TraceContextProvider>,
     ) {
         let mut subscribers: HashMap<SubscriptionKey, HashMap<u64, Subscriber>> = HashMap::new();
@@ -623,7 +686,6 @@ impl PhoenixWSClient {
             let _ = tx.send(WsConnectionStatus::Connecting);
         }
 
-        // Connect to WebSocket
         let ws_stream = match Self::connect(
             &url,
             auth_client.as_ref(),
@@ -648,22 +710,30 @@ impl PhoenixWSClient {
             }
         };
 
-        let (mut ws_sink, mut ws_stream) = ws_stream.split();
+        let mut active_ws = ActiveWebSocket::new(ws_stream);
 
         // Main message loop
         loop {
             tokio::select! {
                 // Handle incoming WebSocket messages
-                ws_msg = ws_stream.next() => {
+                ws_msg = active_ws.read.next() => {
                     match ws_msg {
                         Some(Ok(Message::Text(text))) => {
-                            Self::process_message(text.as_bytes(), &subscribers);
+                            Self::process_message(
+                                text.as_bytes(),
+                                &subscribers,
+                                &ws_subscription_event_tx,
+                            );
                         }
                         Some(Ok(Message::Binary(data))) => {
-                            Self::process_message(&data, &subscribers);
+                            Self::process_message(
+                                &data,
+                                &subscribers,
+                                &ws_subscription_event_tx,
+                            );
                         }
                         Some(Ok(Message::Ping(data))) => {
-                            if let Err(e) = ws_sink.send(Message::Pong(data)).await {
+                            if let Err(e) = active_ws.sink.send(Message::Pong(data)).await {
                                 debug!("Failed to respond to Ping: {e:?}");
                             }
                         }
@@ -671,13 +741,40 @@ impl PhoenixWSClient {
                             debug!("Received pong");
                         }
                         Some(Ok(Message::Close(frame))) => {
-                            let reason = if let Some(frame) = frame {
+                            let reason = Self::close_reason(frame.as_ref());
+                            if let Some(frame) = frame.as_ref() {
                                 warn!("WebSocket closed: code={}, reason={}", frame.code, frame.reason);
-                                format!("closed: code={}, reason={}", frame.code, frame.reason)
                             } else {
                                 warn!("WebSocket closed without frame");
-                                "closed without frame".to_string()
-                            };
+                            }
+                            if Self::is_recoverable_auth_close(frame.as_ref()) {
+                                let Some(auth_client) = auth_client.as_ref() else {
+                                    if let Some(ref tx) = ws_connection_status_tx {
+                                        let _ = tx.send(WsConnectionStatus::Disconnected(reason));
+                                    }
+                                    return;
+                                };
+                                match Self::refresh_and_reconnect(
+                                    &url,
+                                    auth_client,
+                                    &active_subscriptions,
+                                    &mut active_ws,
+                                    ws_connection_status_tx.as_ref(),
+                                    #[cfg(feature = "opentelemetry")]
+                                    trace_context_provider.as_ref(),
+                                )
+                                .await
+                                {
+                                    Ok(()) => continue,
+                                    Err(error) => {
+                                        error!("Failed to refresh and reconnect WebSocket auth: {:?}", error);
+                                        if let Some(ref tx) = ws_connection_status_tx {
+                                            let _ = tx.send(WsConnectionStatus::Disconnected(reason));
+                                        }
+                                        return;
+                                    }
+                                }
+                            }
                             if let Some(ref tx) = ws_connection_status_tx {
                                 let _ = tx.send(WsConnectionStatus::Disconnected(reason));
                             }
@@ -722,7 +819,7 @@ impl PhoenixWSClient {
                                 let msg = ClientMessage::Subscribe { subscription: request };
                                 if let Ok(bytes) = serde_json::to_vec(&msg) {
                                     debug!("Sending subscription: {}", String::from_utf8_lossy(&bytes));
-                                    if let Err(e) = ws_sink.send(Message::Binary(bytes.into())).await {
+                                    if let Err(e) = active_ws.sink.send(Message::Binary(bytes.into())).await {
                                         error!("Failed to send subscription: {:?}", e);
                                     }
                                 }
@@ -744,17 +841,70 @@ impl PhoenixWSClient {
                                     // Send unsubscription request
                                     let msg = ClientMessage::Unsubscribe { subscription: request };
                                     if let Ok(bytes) = serde_json::to_vec(&msg) {
-                                        let _ = ws_sink.send(Message::Binary(bytes.into())).await;
+                                        let _ = active_ws.sink.send(Message::Binary(bytes.into())).await;
                                     }
                                 }
                             }
                         }
                         Some(ControlMessage::Shutdown) | None => {
                             info!("Shutting down WebSocket client");
-                            let _ = ws_sink.close().await;
+                            let _ = active_ws.sink.close().await;
                             return;
                         }
                     }
+                }
+            }
+        }
+    }
+
+    async fn refresh_and_reconnect(
+        url: &Url,
+        auth_client: &PhoenixHttpClient,
+        active_subscriptions: &HashMap<SubscriptionKey, SubscriptionRequest>,
+        active_ws: &mut ActiveWebSocket,
+        ws_connection_status_tx: Option<&mpsc::UnboundedSender<WsConnectionStatus>>,
+        #[cfg(feature = "opentelemetry")] trace_context_provider: Option<&TraceContextProvider>,
+    ) -> Result<(), PhoenixWsError> {
+        auth_client
+            .refresh_auth_session()
+            .await
+            .map_err(ws_auth_error)?;
+        if let Some(tx) = ws_connection_status_tx {
+            let _ = tx.send(WsConnectionStatus::Connecting);
+        }
+        let next_ws_stream = Self::connect(
+            url,
+            Some(auth_client),
+            #[cfg(feature = "opentelemetry")]
+            trace_context_provider,
+        )
+        .await?;
+        *active_ws = ActiveWebSocket::new(next_ws_stream);
+        if let Some(tx) = ws_connection_status_tx {
+            let _ = tx.send(WsConnectionStatus::Connected);
+        }
+        Self::resend_active_subscriptions(&mut active_ws.sink, active_subscriptions).await;
+        Ok(())
+    }
+
+    async fn resend_active_subscriptions(
+        ws_sink: &mut PhoenixWsSink,
+        active_subscriptions: &HashMap<SubscriptionKey, SubscriptionRequest>,
+    ) {
+        for request in active_subscriptions.values() {
+            let msg = ClientMessage::Subscribe {
+                subscription: request.clone(),
+            };
+            if let Ok(bytes) = serde_json::to_vec(&msg) {
+                debug!(
+                    "Resending subscription after auth reconnect: {}",
+                    String::from_utf8_lossy(&bytes)
+                );
+                if let Err(error) = ws_sink.send(Message::Binary(bytes.into())).await {
+                    error!(
+                        "Failed to resend subscription after auth reconnect: {:?}",
+                        error
+                    );
                 }
             }
         }
@@ -765,7 +915,7 @@ impl PhoenixWSClient {
         url: &Url,
         auth_client: Option<&PhoenixHttpClient>,
         #[cfg(feature = "opentelemetry")] trace_context_provider: Option<&TraceContextProvider>,
-    ) -> Result<WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>, PhoenixWsError> {
+    ) -> Result<PhoenixWsStream, PhoenixWsError> {
         let auth_session = Self::auth_session_for_connect(auth_client).await?;
         let request = Self::connect_request(url, auth_session.as_ref())?;
         #[cfg(feature = "opentelemetry")]
@@ -865,6 +1015,28 @@ impl PhoenixWSClient {
         Ok(request)
     }
 
+    fn close_reason(frame: Option<&CloseFrame>) -> String {
+        frame
+            .map(|frame| format!("closed: code={}, reason={}", frame.code, frame.reason))
+            .unwrap_or_else(|| "closed without frame".to_string())
+    }
+
+    fn is_recoverable_auth_close(frame: Option<&CloseFrame>) -> bool {
+        let Some(frame) = frame else {
+            return false;
+        };
+        let code: u16 = frame.code.into();
+        matches!(code, 4401 | 4403 | 1008)
+            || matches!(
+                frame.reason.as_str(),
+                "access_token_expired"
+                    | "invalid_access_token"
+                    | "access_jti_mismatch"
+                    | "session_missing"
+                    | "authz_refresh_required"
+            )
+    }
+
     /// Broadcast a message to all subscribers for a given key.
     ///
     /// The `try_send` closure should attempt to send the message if the
@@ -892,6 +1064,7 @@ impl PhoenixWSClient {
     fn process_message(
         data: &[u8],
         subscribers: &HashMap<SubscriptionKey, HashMap<u64, Subscriber>>,
+        subscription_event_tx: &mpsc::UnboundedSender<WsSubscriptionEvent>,
     ) {
         let text = match std::str::from_utf8(data) {
             Ok(s) => s,
@@ -905,6 +1078,10 @@ impl PhoenixWSClient {
         // Handle subscription confirmed messages
         if let Ok(confirmed) = serde_json::from_slice::<SubscriptionConfirmedMessage>(data) {
             debug!("Subscription confirmed: {:?}", confirmed.subscription);
+            let _ = subscription_event_tx.send(WsSubscriptionEvent::Status {
+                status: "subscribed".to_string(),
+                subscription: confirmed.subscription,
+            });
             return;
         }
 
@@ -914,10 +1091,15 @@ impl PhoenixWSClient {
                 "Subscription error: code={}, message={}",
                 error.code, error.message
             );
+            let _ = subscription_event_tx.send(WsSubscriptionEvent::Error {
+                subscription: Some(error.subscription),
+                code: error.code,
+                message: error.message,
+            });
             return;
         }
 
-        Self::handle_message(data, text, subscribers);
+        Self::handle_message(data, text, subscribers, subscription_event_tx);
     }
 
     /// Handle a data message and route to subscribers.
@@ -925,6 +1107,7 @@ impl PhoenixWSClient {
         data: &[u8],
         text: &str,
         subscribers: &HashMap<SubscriptionKey, HashMap<u64, Subscriber>>,
+        subscription_event_tx: &mpsc::UnboundedSender<WsSubscriptionEvent>,
     ) {
         match serde_json::from_slice::<ServerMessage>(data) {
             Ok(ServerMessage::AllMids(msg)) => {
@@ -998,6 +1181,21 @@ impl PhoenixWSClient {
             }
             Ok(ServerMessage::Error(err)) => {
                 error!("Server error: code={}, error={}", err.code, err.error);
+                let _ = subscription_event_tx.send(WsSubscriptionEvent::Error {
+                    subscription: None,
+                    code: err.code.to_string(),
+                    message: err.error,
+                });
+            }
+            Ok(ServerMessage::SubscriptionStatus(status)) => {
+                debug!(
+                    "Subscription status: status={}, subscription={:?}",
+                    status.status, status.subscription
+                );
+                let _ = subscription_event_tx.send(WsSubscriptionEvent::Status {
+                    status: status.status,
+                    subscription: status.subscription,
+                });
             }
             Ok(_) => {
                 // Ignore other message types
@@ -1049,11 +1247,15 @@ fn inject_trace_headers_from_context(context: &Context, headers: &mut HeaderMap)
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "opentelemetry")]
     use std::sync::Arc;
+    #[cfg(feature = "opentelemetry")]
+    use std::sync::Arc as TelemetryArc;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use base64::Engine as _;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use futures_util::StreamExt as _;
     #[cfg(feature = "opentelemetry")]
     use opentelemetry::trace::{
         SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState,
@@ -1062,15 +1264,32 @@ mod tests {
     use opentelemetry::{Context, global};
     #[cfg(feature = "opentelemetry")]
     use opentelemetry_sdk::propagation::TraceContextPropagator;
+    use serde_json::json;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::sync::{mpsc, oneshot};
+    use tokio_tungstenite::accept_hdr_async;
+    use tokio_tungstenite::tungstenite::Utf8Bytes;
+    use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
+    use tokio_tungstenite::tungstenite::protocol::CloseFrame;
+    use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+    use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::{
+        Iana, Normal, Policy,
+    };
 
     use super::*;
+    use crate::auth::{AuthSessionStore, MemoryAuthSessionStore};
+
+    const TEST_SYMBOL: &str = "SOL";
+    const REFRESH_TOKEN: &str = "refresh-token";
+    const FRESH_REFRESH_TOKEN: &str = "refresh-token-fresh";
 
     #[test]
     fn connect_request_includes_auth_headers_when_session_is_available() {
         let access_token = test_jwt("ws-jti");
         let session = AuthSession::from_tokens(
             access_token.clone(),
-            Some("refresh-token".to_string()),
+            Some(REFRESH_TOKEN.to_string()),
             URL_SAFE_NO_PAD.encode(b"pop-key"),
             Some(300),
             Some(600),
@@ -1083,11 +1302,11 @@ mod tests {
 
         assert_eq!(
             request.headers().get(AUTHORIZATION).unwrap(),
-            &format!("Bearer {access_token}")
+            &bearer(&access_token)
         );
         assert_eq!(
             request.headers().get(SEC_WEBSOCKET_PROTOCOL).unwrap(),
-            &format!("phoenix-jwt, {access_token}")
+            &ws_protocol(&access_token)
         );
     }
 
@@ -1099,6 +1318,191 @@ mod tests {
 
         assert!(request.headers().get(AUTHORIZATION).is_none());
         assert!(request.headers().get(SEC_WEBSOCKET_PROTOCOL).is_none());
+    }
+
+    #[test]
+    fn process_message_forwards_subscription_status_event() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let subscribers = HashMap::new();
+        let json = br#"{
+            "channel": "subscriptionStatus",
+            "status": "subscribed",
+            "clientId": "client-1",
+            "subscription": {
+                "channel": "traderState",
+                "authority": "ABC123",
+                "traderPdaIndex": 0
+            }
+        }"#;
+
+        PhoenixWSClient::process_message(json, &subscribers, &tx);
+
+        let event = rx.try_recv().expect("subscription event should be sent");
+        assert!(matches!(
+            event,
+            WsSubscriptionEvent::Status {
+                status,
+                subscription: SubscriptionRequest::TraderState(_),
+            } if status == "subscribed"
+        ));
+    }
+
+    #[tokio::test]
+    async fn connect_refreshes_near_expiry_access_before_handshake() {
+        let stale_token = test_jwt_with_exp("stale-ws-jti", future_unix_secs(30));
+        let fresh_token = test_jwt_with_exp("fresh-ws-jti", future_unix_secs(600));
+        let (refresh_url, refresh_auth_rx, refresh_count) =
+            spawn_refresh_server(fresh_token.clone()).await;
+        let (ws_url, mut ws_rx) = spawn_recording_ws_server(None).await;
+        let auth_client = test_auth_client(
+            refresh_url,
+            test_session_store(
+                stale_token.clone(),
+                Some(REFRESH_TOKEN.to_string()),
+                Some(30),
+            ),
+        );
+        let url = Url::parse(&ws_url).expect("ws url should parse");
+
+        let mut stream = PhoenixWSClient::connect(
+            &url,
+            Some(&auth_client),
+            #[cfg(feature = "opentelemetry")]
+            None,
+        )
+        .await
+        .expect("websocket should connect");
+        let _ = stream.close(None).await;
+
+        let observed = timeout_recv(&mut ws_rx).await;
+        assert_eq!(observed.authorization, Some(bearer(&fresh_token)));
+        assert_eq!(observed.protocol, Some(ws_protocol(&fresh_token)));
+        assert_eq!(refresh_count.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(
+            refresh_auth_rx
+                .await
+                .expect("refresh auth should be recorded"),
+            Some(bearer(&stale_token))
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_omits_expired_access_when_refresh_is_unavailable() {
+        let expired_token = test_jwt_with_exp("expired-ws-jti", past_unix_secs(30));
+        let (ws_url, mut ws_rx) = spawn_recording_ws_server(None).await;
+        let auth_client = test_auth_client(
+            "http://127.0.0.1:1",
+            test_session_store(expired_token, None, None),
+        );
+        let url = Url::parse(&ws_url).expect("ws url should parse");
+
+        let mut stream = PhoenixWSClient::connect(
+            &url,
+            Some(&auth_client),
+            #[cfg(feature = "opentelemetry")]
+            None,
+        )
+        .await
+        .expect("websocket should connect anonymously");
+        let _ = stream.close(None).await;
+
+        let observed = timeout_recv(&mut ws_rx).await;
+        assert_eq!(observed.authorization, None);
+        assert_eq!(observed.protocol, None);
+    }
+
+    #[tokio::test]
+    async fn auth_close_refreshes_reconnects_and_resubscribes() {
+        let stale_token = test_jwt_with_exp("stale-close-jti", future_unix_secs(600));
+        let fresh_token = test_jwt_with_exp("fresh-close-jti", future_unix_secs(600));
+        let (refresh_url, _refresh_auth_rx, refresh_count) =
+            spawn_refresh_server(fresh_token.clone()).await;
+        let (ws_url, mut ws_rx) =
+            spawn_auth_close_then_reconnect_ws_server(Iana(4401), "access_token_expired").await;
+        let auth_client = test_auth_client(
+            refresh_url,
+            test_session_store(
+                stale_token.clone(),
+                Some(REFRESH_TOKEN.to_string()),
+                Some(600),
+            ),
+        );
+        let mut client = PhoenixWSClient::new_internal(
+            &ws_url,
+            true,
+            Some(auth_client),
+            #[cfg(feature = "opentelemetry")]
+            None,
+        )
+        .expect("ws client should build");
+        let mut status_rx = client
+            .connection_status_receiver()
+            .expect("status receiver should exist");
+        let (_rx, _handle) = client
+            .subscribe_to_trades(TEST_SYMBOL.to_string())
+            .expect("subscribe should succeed");
+
+        let first = timeout_recv(&mut ws_rx).await;
+        let second = timeout_recv(&mut ws_rx).await;
+        assert_eq!(first.authorization, Some(bearer(&stale_token)));
+        assert!(first.subscription_seen);
+        assert_eq!(second.authorization, Some(bearer(&fresh_token)));
+        assert!(second.subscription_seen);
+        assert_eq!(refresh_count.load(AtomicOrdering::SeqCst), 1);
+        assert_status(&mut status_rx, WsConnectionStatus::Connecting).await;
+        assert_status(&mut status_rx, WsConnectionStatus::Connected).await;
+        assert_status(&mut status_rx, WsConnectionStatus::Connecting).await;
+        assert_status(&mut status_rx, WsConnectionStatus::Connected).await;
+    }
+
+    #[tokio::test]
+    async fn normal_close_does_not_refresh() {
+        let token = test_jwt_with_exp("normal-close-jti", future_unix_secs(600));
+        let (refresh_url, _refresh_auth_rx, refresh_count) =
+            spawn_refresh_server(test_jwt_with_exp("unused-fresh-jti", future_unix_secs(600)))
+                .await;
+        let (ws_url, mut ws_rx) = spawn_close_after_subscription_ws_server(Normal, "normal").await;
+        let auth_client = test_auth_client(
+            refresh_url,
+            test_session_store(token, Some(REFRESH_TOKEN.to_string()), Some(600)),
+        );
+        let mut client = PhoenixWSClient::new_internal(
+            &ws_url,
+            true,
+            Some(auth_client),
+            #[cfg(feature = "opentelemetry")]
+            None,
+        )
+        .expect("ws client should build");
+        let mut status_rx = client
+            .connection_status_receiver()
+            .expect("status receiver should exist");
+        let (_rx, _handle) = client
+            .subscribe_to_trades(TEST_SYMBOL.to_string())
+            .expect("subscribe should succeed");
+
+        let observed = timeout_recv(&mut ws_rx).await;
+        assert!(observed.subscription_seen);
+        assert_status(&mut status_rx, WsConnectionStatus::Connecting).await;
+        assert_status(&mut status_rx, WsConnectionStatus::Connected).await;
+        assert_disconnected_contains(&mut status_rx, "normal").await;
+        assert_eq!(refresh_count.load(AtomicOrdering::SeqCst), 0);
+    }
+
+    #[test]
+    fn recoverable_auth_close_matches_ts_policy() {
+        assert!(PhoenixWSClient::is_recoverable_auth_close(Some(
+            &close_frame(Iana(4401), "any")
+        )));
+        assert!(PhoenixWSClient::is_recoverable_auth_close(Some(
+            &close_frame(Policy, "any")
+        )));
+        assert!(PhoenixWSClient::is_recoverable_auth_close(Some(
+            &close_frame(Normal, "invalid_access_token")
+        )));
+        assert!(!PhoenixWSClient::is_recoverable_auth_close(Some(
+            &close_frame(Normal, "normal")
+        )));
     }
 
     #[cfg(feature = "opentelemetry")]
@@ -1135,7 +1539,7 @@ mod tests {
             TraceState::default(),
         ));
         let provider_context = parent_context.clone();
-        let provider: TraceContextProvider = Arc::new(move || provider_context.clone());
+        let provider: TraceContextProvider = TelemetryArc::new(move || provider_context.clone());
 
         let provided_context =
             trace_parent_context(Some(&provider)).expect("provider should return context");
@@ -1150,8 +1554,289 @@ mod tests {
     }
 
     fn test_jwt(jti: &str) -> String {
+        test_jwt_with_exp(jti, future_unix_secs(600))
+    }
+
+    fn test_jwt_with_exp(jti: &str, exp: u64) -> String {
         let header = URL_SAFE_NO_PAD.encode(r#"{"alg":"none"}"#);
-        let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"jti":"{jti}"}}"#));
+        let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"jti":"{jti}","exp":{exp}}}"#));
         format!("{header}.{payload}.sig")
+    }
+
+    fn test_session_store(
+        access_token: String,
+        refresh_token: Option<String>,
+        expires_in: Option<u64>,
+    ) -> Arc<MemoryAuthSessionStore> {
+        let store = Arc::new(MemoryAuthSessionStore::new());
+        store
+            .store_session(
+                &AuthSession::from_tokens(
+                    access_token,
+                    refresh_token,
+                    URL_SAFE_NO_PAD.encode(b"pop-key"),
+                    expires_in,
+                    Some(600),
+                )
+                .expect("session should parse"),
+            )
+            .expect("session should store");
+        store
+    }
+
+    fn test_auth_client(
+        api_url: impl Into<String>,
+        store: Arc<MemoryAuthSessionStore>,
+    ) -> PhoenixHttpClient {
+        PhoenixHttpClient::builder(api_url)
+            .with_auth_session_store(store)
+            .build()
+            .expect("auth client should build")
+    }
+
+    fn bearer(token: &str) -> String {
+        format!("Bearer {token}")
+    }
+
+    fn ws_protocol(token: &str) -> String {
+        format!("phoenix-jwt, {token}")
+    }
+
+    fn future_unix_secs(offset_secs: u64) -> u64 {
+        SystemTime::now()
+            .checked_add(Duration::from_secs(offset_secs))
+            .and_then(|timestamp| timestamp.duration_since(UNIX_EPOCH).ok())
+            .expect("future timestamp should be after epoch")
+            .as_secs()
+    }
+
+    fn past_unix_secs(offset_secs: u64) -> u64 {
+        SystemTime::now()
+            .checked_sub(Duration::from_secs(offset_secs))
+            .and_then(|timestamp| timestamp.duration_since(UNIX_EPOCH).ok())
+            .expect("past timestamp should be after epoch")
+            .as_secs()
+    }
+
+    fn close_frame(code: CloseCode, reason: &str) -> CloseFrame {
+        CloseFrame {
+            code,
+            reason: Utf8Bytes::from(reason),
+        }
+    }
+
+    #[derive(Debug)]
+    struct WsObservation {
+        authorization: Option<String>,
+        protocol: Option<String>,
+        subscription_seen: bool,
+    }
+
+    async fn spawn_refresh_server(
+        access_token: String,
+    ) -> (String, oneshot::Receiver<Option<String>>, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("refresh listener should bind");
+        let addr = listener.local_addr().expect("refresh addr should exist");
+        let refresh_count = Arc::new(AtomicUsize::new(0));
+        let refresh_count_task = refresh_count.clone();
+        let (auth_tx, auth_rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let mut auth_tx = Some(auth_tx);
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                let access_token = access_token.clone();
+                let mut buffer = vec![0; 8192];
+                let Ok(n) = socket.read(&mut buffer).await else {
+                    return;
+                };
+                let request = String::from_utf8_lossy(&buffer[..n]);
+                let authorization = request.lines().find_map(|line| {
+                    let (name, value) = line.split_once(": ")?;
+                    name.eq_ignore_ascii_case("authorization")
+                        .then(|| value.to_string())
+                });
+                refresh_count_task.fetch_add(1, AtomicOrdering::SeqCst);
+                if let Some(tx) = auth_tx.take() {
+                    let _ = tx.send(authorization);
+                }
+                let body = json!({
+                    "token_type": "Bearer",
+                    "access_token": access_token,
+                    "expires_in": 900,
+                    "refresh_token": FRESH_REFRESH_TOKEN,
+                    "refresh_expires_in": 3600,
+                    "pop_key": URL_SAFE_NO_PAD.encode(b"fresh-pop-key"),
+                })
+                .to_string();
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: \
+                     {}\r\nconnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+            }
+        });
+        (format!("http://{addr}"), auth_rx, refresh_count)
+    }
+
+    async fn spawn_recording_ws_server(
+        close: Option<CloseFrame>,
+    ) -> (String, mpsc::UnboundedReceiver<WsObservation>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("ws listener should bind");
+        let addr = listener.local_addr().expect("ws addr should exist");
+        let (tx, rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await {
+                let tx_headers = tx.clone();
+                let callback = move |request: &Request, mut response: Response| {
+                    let _ = tx_headers.send(observation_from_request(request, false));
+                    select_ws_protocol(request, &mut response);
+                    Ok(response)
+                };
+                if let Ok(mut websocket) = accept_hdr_async(stream, callback).await {
+                    if let Some(frame) = close {
+                        let _ = websocket.close(Some(frame)).await;
+                    } else {
+                        let _ = websocket.next().await;
+                    }
+                }
+            }
+        });
+        (format!("ws://{addr}/v1/ws"), rx)
+    }
+
+    async fn spawn_auth_close_then_reconnect_ws_server(
+        close_code: CloseCode,
+        close_reason: &'static str,
+    ) -> (String, mpsc::UnboundedReceiver<WsObservation>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("ws listener should bind");
+        let addr = listener.local_addr().expect("ws addr should exist");
+        let (tx, rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            handle_ws_connection(
+                &listener,
+                tx.clone(),
+                Some(close_frame(close_code, close_reason)),
+            )
+            .await;
+            handle_ws_connection(&listener, tx, None).await;
+        });
+        (format!("ws://{addr}/v1/ws"), rx)
+    }
+
+    async fn spawn_close_after_subscription_ws_server(
+        close_code: CloseCode,
+        close_reason: &'static str,
+    ) -> (String, mpsc::UnboundedReceiver<WsObservation>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("ws listener should bind");
+        let addr = listener.local_addr().expect("ws addr should exist");
+        let (tx, rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            handle_ws_connection(&listener, tx, Some(close_frame(close_code, close_reason))).await;
+        });
+        (format!("ws://{addr}/v1/ws"), rx)
+    }
+
+    async fn handle_ws_connection(
+        listener: &TcpListener,
+        tx: mpsc::UnboundedSender<WsObservation>,
+        close: Option<CloseFrame>,
+    ) {
+        let Ok((stream, _)) = listener.accept().await else {
+            return;
+        };
+        let (headers_tx, mut headers_rx) = mpsc::unbounded_channel();
+        let callback = move |request: &Request, mut response: Response| {
+            let _ = headers_tx.send(observation_from_request(request, false));
+            select_ws_protocol(request, &mut response);
+            Ok(response)
+        };
+        let Ok(mut websocket) = accept_hdr_async(stream, callback).await else {
+            return;
+        };
+        let Some(mut observation) = headers_rx.recv().await else {
+            return;
+        };
+        observation.subscription_seen = websocket.next().await.is_some();
+        let _ = tx.send(observation);
+        if let Some(frame) = close {
+            let _ = websocket.close(Some(frame)).await;
+        }
+    }
+
+    fn observation_from_request(request: &Request, subscription_seen: bool) -> WsObservation {
+        WsObservation {
+            authorization: request
+                .headers()
+                .get(AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_string),
+            protocol: request
+                .headers()
+                .get(SEC_WEBSOCKET_PROTOCOL)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_string),
+            subscription_seen,
+        }
+    }
+
+    fn select_ws_protocol(request: &Request, response: &mut Response) {
+        let Some(protocol) = request
+            .headers()
+            .get(SEC_WEBSOCKET_PROTOCOL)
+            .and_then(|value| value.to_str().ok())
+        else {
+            return;
+        };
+        if protocol
+            .split(',')
+            .map(str::trim)
+            .any(|entry| entry.eq_ignore_ascii_case("phoenix-jwt"))
+        {
+            response.headers_mut().insert(
+                SEC_WEBSOCKET_PROTOCOL,
+                HeaderValue::from_static("phoenix-jwt"),
+            );
+        }
+    }
+
+    async fn timeout_recv<T>(rx: &mut mpsc::UnboundedReceiver<T>) -> T {
+        tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("channel receive should not time out")
+            .expect("channel should remain open")
+    }
+
+    async fn assert_status(
+        rx: &mut mpsc::UnboundedReceiver<WsConnectionStatus>,
+        expected: WsConnectionStatus,
+    ) {
+        let actual = timeout_recv(rx).await;
+        assert_eq!(actual, expected);
+    }
+
+    async fn assert_disconnected_contains(
+        rx: &mut mpsc::UnboundedReceiver<WsConnectionStatus>,
+        expected_reason: &str,
+    ) {
+        let actual = timeout_recv(rx).await;
+        let WsConnectionStatus::Disconnected(reason) = actual else {
+            panic!("expected disconnected status, got {actual:?}");
+        };
+        assert!(
+            reason.contains(expected_reason),
+            "expected disconnected reason {reason:?} to contain {expected_reason:?}"
+        );
     }
 }

--- a/rust/tests/sdk_localnet_fixture_tests.rs
+++ b/rust/tests/sdk_localnet_fixture_tests.rs
@@ -955,6 +955,7 @@ fn phoenix_metadata_from_fixture(fixture: &SdkLocalnetFixture) -> PhoenixMetadat
                     open_interest_cap_base_lots: 0_u64.into(),
                     max_liquidation_size_base_lots: 0_u64.into(),
                     isolated_only: false,
+                    stats_snapshot: None,
                 },
             )
         })

--- a/rust/types/src/auth.rs
+++ b/rust/types/src/auth.rs
@@ -59,12 +59,6 @@ pub struct WalletTransactionLoginRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-pub struct AdminChallengeRequest {
-    pub key_id: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct ServiceChallengeRequest {
     pub client_id: String,
     pub key_id: Option<String>,
@@ -77,15 +71,6 @@ pub struct ChallengeResponse {
     pub message: String,
     pub expires_at: String,
     pub key_id: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-pub struct AdminLoginRequest {
-    pub key_id: Option<String>,
-    pub nonce: String,
-    pub timestamp: String,
-    pub signature: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/rust/types/src/exchange.rs
+++ b/rust/types/src/exchange.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::types::js_safe_ints::JsSafeU64;
+use crate::types::js_safe_ints::{JsSafeI64, JsSafeU64};
 use crate::types::market::MarketStatus;
 
 // ============================================================================
@@ -136,6 +136,16 @@ pub struct MarketPublicMetadata {
 // Exchange Configuration
 // ============================================================================
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarketStatsSnapshot {
+    pub slot: u64,
+    pub slot_index: u32,
+    pub open_interest_base_lots: JsSafeU64,
+    pub funding_start_interval_timestamp: JsSafeU64,
+    pub cumulative_funding_rate: JsSafeI64,
+}
+
 /// Static market configuration without live data like prices or open interest.
 /// Used by the `/exchange` endpoint to return market parameters.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -165,6 +175,8 @@ pub struct ExchangeMarketConfig {
     pub max_liquidation_size_base_lots: JsSafeU64,
     /// Whether this market only supports isolated margin positions.
     pub isolated_only: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stats_snapshot: Option<MarketStatsSnapshot>,
 }
 
 /// Raw response from the `/exchange` endpoint.
@@ -272,6 +284,7 @@ mod tests {
             open_interest_cap_base_lots: 1_000_000_u64.into(),
             max_liquidation_size_base_lots: 10_000_u64.into(),
             isolated_only: false,
+            stats_snapshot: None,
         };
 
         assert!((config.taker_fee - 0.0005).abs() < 1e-10);
@@ -302,6 +315,7 @@ mod tests {
                 open_interest_cap_base_lots: 1_000_000_u64.into(),
                 max_liquidation_size_base_lots: 10_000_u64.into(),
                 isolated_only: false,
+                stats_snapshot: None,
             },
         );
 

--- a/rust/types/src/exchange_ws.rs
+++ b/rust/types/src/exchange_ws.rs
@@ -453,6 +453,7 @@ impl From<&ExchangeMarketSnapshot> for ExchangeMarketConfig {
             open_interest_cap_base_lots: market.open_interest_cap_base_lots,
             max_liquidation_size_base_lots: market.max_liquidation_size_base_lots,
             isolated_only: market.isolated_only,
+            stats_snapshot: None,
         }
     }
 }

--- a/rust/types/src/js_safe_ints.rs
+++ b/rust/types/src/js_safe_ints.rs
@@ -15,6 +15,88 @@ use std::ops::{AddAssign, Deref, DerefMut};
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, PickFirst, serde_as};
 
+/// Wrapper for signed 64-bit values that must be JSON-safe for consumers
+/// written in JavaScript/TypeScript.
+///
+/// Serializes as a string and can deserialize from either a string or number.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct JsSafeI64(#[serde_as(as = "PickFirst<(DisplayFromStr, _)>")] i64);
+
+impl From<i64> for JsSafeI64 {
+    fn from(value: i64) -> Self {
+        JsSafeI64(value)
+    }
+}
+
+impl From<JsSafeI64> for i64 {
+    fn from(value: JsSafeI64) -> Self {
+        value.0
+    }
+}
+
+impl JsSafeI64 {
+    pub fn into_inner(self) -> i64 {
+        self.0
+    }
+
+    pub fn as_inner(&self) -> i64 {
+        self.0
+    }
+}
+
+impl Deref for JsSafeI64 {
+    type Target = i64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for JsSafeI64 {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl AddAssign for JsSafeI64 {
+    fn add_assign(&mut self, other: Self) {
+        self.0 += other.0;
+    }
+}
+
+impl PartialEq<i64> for JsSafeI64 {
+    fn eq(&self, other: &i64) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<JsSafeI64> for i64 {
+    fn eq(&self, other: &JsSafeI64) -> bool {
+        *self == other.0
+    }
+}
+
+impl PartialOrd<i64> for JsSafeI64 {
+    fn partial_cmp(&self, other: &i64) -> Option<Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
+impl PartialOrd<JsSafeI64> for i64 {
+    fn partial_cmp(&self, other: &JsSafeI64) -> Option<Ordering> {
+        self.partial_cmp(&other.0)
+    }
+}
+
+impl fmt::Display for JsSafeI64 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// Wrapper for unsigned 64-bit values that must be JSON-safe for consumers
 /// written in JavaScript/TypeScript.
 ///
@@ -100,6 +182,27 @@ impl fmt::Display for JsSafeU64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_js_safe_i64_from_string() {
+        let json = r#""-9007199254740993""#;
+        let value: JsSafeI64 = serde_json::from_str(json).unwrap();
+        assert_eq!(value.into_inner(), -9007199254740993_i64);
+    }
+
+    #[test]
+    fn test_js_safe_i64_from_number() {
+        let json = "-12345";
+        let value: JsSafeI64 = serde_json::from_str(json).unwrap();
+        assert_eq!(value.into_inner(), -12345);
+    }
+
+    #[test]
+    fn test_js_safe_i64_serializes_as_string() {
+        let value = JsSafeI64::from(-9007199254740993_i64);
+        let json = serde_json::to_string(&value).unwrap();
+        assert_eq!(json, r#""-9007199254740993""#);
+    }
 
     #[test]
     fn test_js_safe_u64_from_string() {

--- a/rust/types/src/metadata.rs
+++ b/rust/types/src/metadata.rs
@@ -314,6 +314,7 @@ mod tests {
             open_interest_cap_base_lots: 1_000_000_u64.into(),
             max_liquidation_size_base_lots: 10_000_u64.into(),
             isolated_only: false,
+            stats_snapshot: None,
         }
     }
 

--- a/rust/types/src/service_accounts.rs
+++ b/rust/types/src/service_accounts.rs
@@ -11,8 +11,6 @@ pub struct CreateServiceAccountRequest {
     pub description: Option<String>,
     pub client_id: String,
     #[serde(default)]
-    pub role: String,
-    #[serde(default)]
     pub scopes: Vec<String>,
     #[serde(default)]
     pub status: String,
@@ -50,7 +48,6 @@ pub struct ServiceAccountDto {
     pub name: String,
     pub description: Option<String>,
     pub client_id: String,
-    pub role: String,
     pub scopes: Vec<String>,
     pub status: String,
     pub created_at: DateTime<Utc>,

--- a/rust/types/src/ws.rs
+++ b/rust/types/src/ws.rs
@@ -140,6 +140,8 @@ pub enum ServerMessage {
     Candles(CandleData),
     #[serde(rename = "error")]
     Error(ErrorMessage),
+    #[serde(rename = "subscriptionStatus")]
+    SubscriptionStatus(SubscriptionStatusMessage),
     /// Other message types exist but are not used by this SDK.
     #[serde(other)]
     Other,
@@ -151,6 +153,15 @@ pub enum ServerMessage {
 #[serde(tag = "type", rename = "subscriptionConfirmed")]
 pub struct SubscriptionConfirmedMessage {
     pub subscription: SubscriptionRequest,
+}
+
+/// Subscription status message from server.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubscriptionStatusMessage {
+    pub status: String,
+    pub subscription: SubscriptionRequest,
+    pub client_id: String,
 }
 
 /// Subscription error message from server.
@@ -204,6 +215,34 @@ mod tests {
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains("subscribe"));
         assert!(json.contains("traderState"));
+    }
+
+    #[test]
+    fn test_deserialize_subscription_status_message() {
+        let json = r#"{
+            "channel": "subscriptionStatus",
+            "status": "subscribed",
+            "clientId": "client-1",
+            "subscription": {
+                "channel": "traderState",
+                "authority": "ABC123",
+                "traderPdaIndex": 0
+            }
+        }"#;
+
+        let msg: ServerMessage = serde_json::from_str(json).unwrap();
+        let ServerMessage::SubscriptionStatus(status) = msg else {
+            panic!("Expected subscriptionStatus message");
+        };
+        assert_eq!(status.status, "subscribed");
+        assert_eq!(status.client_id, "client-1");
+        assert!(matches!(
+            status.subscription,
+            SubscriptionRequest::TraderState(TraderStateSubscriptionRequest {
+                trader_pda_index: 0,
+                ..
+            })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `fd9d044ad0e76e6bcbef1333b1ebc8648f511b7a`
- Mode: manual
- Synced paths:

- `rise/rust` -> `rust`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `rust/CHANGELOG.md`

### Summary

- **Flight per-order fee override**: `ProxyInstructionParams::builder()` now accepts `.fee_bps_override(bps: u64)` (0–10 000). When set, `create_proxy_instruction_ix` emits the `proxy_instruction_with_fee_override` variant with a different discriminant and a Borsh `Option<u64>` prefix before the inner instruction data. `PhoenixFlightClient` gains a matching `try_wrap_order_instruction_with_fee_bps_override(ix, trader_wallet, fee_bps_override: Option<u64>)` method; the existing `try_wrap_order_instruction` is unchanged and delegates to it with `None`.
- **WebSocket subscription event channel**: `WsSubscriptionEvent` is now a public export. Call `client.subscription_event_receiver()` (once) to receive `Status` and `Error` lifecycle events for every subscription acknowledgement or rejection. New `PhoenixWSClient::new_with_connection_status_and_auth` constructor combines authenticated and connection-status modes.
- **Automatic auth reconnect on WS close**: The client now detects auth-related close codes (4401, 4403, 1008) and reason strings (`access_token_expired`, `invalid_access_token`, etc.), refreshes the session, reconnects, and resubmits active subscriptions transparently.
- **`ExchangeMarketConfig` gains `stats_snapshot: Option<MarketStatsSnapshot>`**: The new field is `#[serde(default)]` so deserialization of existing payloads is unchanged, but Rust struct literal construction must now include `stats_snapshot: None`.
- **New `JsSafeI64` type** added to `phoenix_rise::types::js_safe_ints` (mirrors `JsSafeU64` for signed values; serialises as a decimal string).

### Breaking Changes

- `AdminChallengeRequest` and `AdminLoginRequest` are removed from `phoenix_rise::types::auth`. Code referencing these types will fail to compile.
- `CreateServiceAccountRequest.role` and `ServiceAccountDto.role` fields are removed. Struct construction and pattern matching on these types must be updated.
- `ExchangeMarketConfig` requires a new `stats_snapshot` field for struct literal construction (e.g. in tests). Add `stats_snapshot: None` to any existing struct literals.

### Consumer Notes

- The `fee_bps_override` builder method validates the range at `build()` time and returns `PhoenixIxError::InvalidFeeBpsOverride` for values above 10 000. Pass `None` (or omit the call) to continue using the builder's registered fee.
- `subscription_event_receiver()` takes ownership of the channel and can only be called once per client instance; subsequent calls return `None`.
- `ServerMessage` now has a `SubscriptionStatus(SubscriptionStatusMessage)` variant — match arms with `ServerMessage::Other` that previously caught subscription-status frames will now route through the new variant instead.