### PR TITLE
sync: Rise Rust v0.1.12

### DIFF
--- a/instructions.json
+++ b/instructions.json
@@ -1,7 +1,9 @@
 {
+  "CancelAll": "62bf4bdc732847ed",
   "CancelConditionalOrder": "52681933f83642b8010100",
   "CancelOrdersById": "eacc7e5ede168d180100000000000000e8030000000000000000000000000000",
   "CancelStopLoss": "78c90a660c096f7e00",
+  "CancelUpTo": "1ad1f4fd3bafe3360101020000000000000001e803000000000000",
   "CreateConditionalOrdersAccount": "c906703de70f39f820",
   "DepositFunds": "ca2734d33514fa580100000000000000",
   "EmberDeposit": "f223c68952e1f2b60100000000000000",
@@ -26,6 +28,7 @@
   "SyncParentToChild": "af89d90beb279613",
   "TransferCollateral": "9da33f1bf248fb610100000000000000",
   "TransferCollateralChildToParent": "3364b1738b87f78b",
+  "UncrossCrank": "c4795efd8b2afc930500000000000000",
   "UpdateFee": "e8fdc3f794d449de0100000000000000",
   "WithdrawFunds": "f1241d6fd01f68d90100000000000000"
 }

--- a/programs/close-position-and-withdraw/Cargo.lock
+++ b/programs/close-position-and-withdraw/Cargo.lock
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.6.0",
@@ -2378,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/programs/close-position-and-withdraw/cli/Cargo.lock
+++ b/programs/close-position-and-withdraw/cli/Cargo.lock
@@ -1451,7 +1451,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-trait",
  "base64",
@@ -1617,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/programs/close-position-and-withdraw/deny.toml
+++ b/programs/close-position-and-withdraw/deny.toml
@@ -37,5 +37,6 @@ ignore = [
   "RUSTSEC-2026-0097", # rand advisory accepted for now
   "RUSTSEC-2026-0098", # rustls-webpki URI name constraints issue; transitive via rustls stack
   "RUSTSEC-2026-0099", # rustls-webpki wildcard name constraints issue; transitive via rustls stack
+  "RUSTSEC-2026-0186", # memmap2 0.5.10 forced by Solana 2.x solana-genesis-config; no compatible 0.9.x upgrade available
 ]
 unmaintained = 'workspace'

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -171,3 +171,26 @@ Source Phoenix commit: `fd9d044ad0e76e6bcbef1333b1ebc8648f511b7a`
 - The `fee_bps_override` builder method validates the range at `build()` time and returns `PhoenixIxError::InvalidFeeBpsOverride` for values above 10 000. Pass `None` (or omit the call) to continue using the builder's registered fee.
 - `subscription_event_receiver()` takes ownership of the channel and can only be called once per client instance; subsequent calls return `None`.
 - `ServerMessage` now has a `SubscriptionStatus(SubscriptionStatusMessage)` variant — match arms with `ServerMessage::Other` that previously caught subscription-status frames will now route through the new variant instead.
+
+## v0.1.12 - 2026-06-22
+
+Source Phoenix commit: `a419e23d7d1b2a3e37696d76e85fac7f0a023f5e`
+
+### Summary
+
+- Three new cancellation/maintenance helpers added to `PhoenixTxBuilder`: `build_cancel_all_orders`, `build_cancel_up_to`, and `build_uncross_crank` (the crank is permissionless — no trader signer required).
+- Matching low-level params types and instruction constructors exported from `phoenix_rise_ix`: `CancelAllParams`/`create_cancel_all_ix`, `CancelUpToParams`/`create_cancel_up_to_ix`, `UncrossCrankParams`/`create_uncross_crank_ix`.
+- New granular Cargo features: `sdk`, `types`, and `test-fixture`. The default feature set changed from `[]` to `["sdk"]`.
+- New `test-fixture` feature exposes `phoenix_rise::test_fixture` with `LiteSVM`-backed `SdkLocalnetContext`, fixture deserialization types, and a bundled `default-localnet.json` for in-process localnet tests.
+- `ix` program constants (`PHOENIX_PROGRAM_ID`, `PHOENIX_LOG_AUTHORITY`, `PHOENIX_GLOBAL_CONFIGURATION`) now compile under `target_os = "solana"`, making the `ix` sub-crate usable in on-chain programs.
+
+### Breaking Changes
+
+- **Default features changed from `[]` to `["sdk"]`**: consumers who previously added `phoenix-rise` without `default-features = false` had near-zero transitive deps; they now pull in the full SDK set (`reqwest`, `tokio`, `parking_lot`, etc.). Add `default-features = false` to restore a minimal build.
+- **`solana-keypair` and `ed25519-dalek` re-exports now also require `sdk`**: `PhoenixWalletSessionManager`, `PhoenixSolanaKeypairAuthSigner`, `default_solana_keypair_path`, and `PhoenixEd25519ServiceAuthSigner` are gated on `all(feature = "sdk", feature = "solana-keypair/ed25519-dalek")`. Consumers using `default-features = false` with only those features enabled will see missing-item compile errors; add `features = ["sdk"]` to restore the exports.
+
+### Consumer Notes
+
+- `rust_decimal = []` was previously an empty stub; it now activates `dep:rust_decimal`. The feature was always advertised but did nothing; it now pulls in the crate.
+- `utoipa` and `opentelemetry` features now implicitly enable `types`/`sdk` respectively, so enabling them without `default-features = false` is safe but may add transitive deps if you were relying on those features being lighter.
+- The `test-fixture` feature is intended for test harnesses only; it adds `litesvm 0.7` and `solana-commitment-config` as optional deps and is not covered by the `sdk` default.

--- a/rust/CRATES.md
+++ b/rust/CRATES.md
@@ -9,7 +9,7 @@
 
 ```toml
 [dependencies]
-phoenix-rise = "0.1.10"
+phoenix-rise = "0.1.12"
 ```
 
 Optional features:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common",
  "generic-array",
 ]
 
@@ -193,7 +193,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -204,7 +204,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -448,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "az"
-version = "1.3.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "base64"
@@ -514,17 +514,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.5"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -543,15 +542,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -777,7 +767,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common",
  "inout",
 ]
 
@@ -820,12 +810,6 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
-
-[[package]]
-name = "cmov"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "colorchoice"
@@ -905,9 +889,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.4.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation-sys"
@@ -975,15 +959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,15 +975,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
-]
-
-[[package]]
-name = "ctutils"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
-dependencies = [
- "cmov",
 ]
 
 [[package]]
@@ -1147,19 +1113,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "crypto-common 0.1.7",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
- "ctutils",
 ]
 
 [[package]]
@@ -1290,7 +1245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1368,12 +1323,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1554,16 +1503,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1602,15 +1549,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash 0.8.12",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
 ]
 
 [[package]]
@@ -1720,15 +1658,6 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "hyper"
@@ -1897,12 +1826,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -2090,12 +2013,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -2343,7 +2260,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2393,9 +2310,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
@@ -2622,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-trait",
  "axum",
@@ -2675,7 +2592,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-sdk-cli"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "clap",
  "phoenix-rise",
@@ -2755,16 +2672,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -2881,9 +2788,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -2982,7 +2889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -3279,7 +3186,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5601,10 +5508,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5667,30 +5574,29 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "8ca967379f9d8eb8058d86ed467d81d03e81acd45757e4ca341c24affbe8e8e3"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
- "serde_core",
+ "serde",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "a9108bb380861b07264b950ded55a44a14a4adc68b9f5efd85aafc3aa4d40a68"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "7182799245a7264ce590b349d90338f1c1affad93d2639aed5f8f69c090b334c"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6058,18 +5964,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common",
  "subtle",
 ]
 
@@ -6225,15 +6125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6290,40 +6181,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.13.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver",
 ]
 
 [[package]]
@@ -6386,7 +6243,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6633,88 +6490,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.13.0",
- "prettyplease",
- "syn 2.0.114",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.13.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.13.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,6 +9,7 @@ include = [
   "README.md",
   "sdk/src/**",
   "sdk/examples/**",
+  "test-fixtures/**",
   "ix/src/**",
   "math/src/**",
   "types/src/**",
@@ -20,6 +21,21 @@ readme = "CRATES.md"
 repository = "https://github.com/Ellipsis-Labs/rise-public"
 rust-version = { workspace = true }
 version = { workspace = true }
+
+[workspace]
+members  = ["cli"]
+resolver = "2"
+
+[workspace.package]
+description  = "SDK for interacting with Phoenix"
+edition      = "2021"
+homepage     = "https://docs.phoenix.trade/"
+license      = "MIT"
+publish      = true
+readme       = "CRATES.md"
+repository   = "https://github.com/Ellipsis-Labs/rise"
+rust-version = "1.84.0"
+version      = "0.1.12"
 
 [lib]
 path = "sdk/src/lib.rs"
@@ -35,6 +51,201 @@ path = "sdk/tests/invite_client_tests.rs"
 [[test]]
 name = "http_retry_tests"
 path = "sdk/tests/http_retry_tests.rs"
+
+[features]
+default = ["sdk"]
+ed25519-dalek = ["sdk", "dep:ed25519-dalek"]
+opentelemetry = [
+  "sdk",
+  "dep:opentelemetry",
+  "dep:opentelemetry-http",
+  "dep:tracing-opentelemetry",
+]
+rust_decimal = ["dep:rust_decimal"]
+sdk = [
+  "types",
+  "dep:async-trait",
+  "dep:base64",
+  "dep:bs58",
+  "dep:futures-util",
+  "dep:parking_lot",
+  "dep:rand",
+  "dep:reqwest",
+  "dep:serde_urlencoded",
+  "dep:solana-compute-budget-interface",
+  "dep:solana-rpc-client",
+  "dep:solana-rpc-client-api",
+  "dep:solana-transaction",
+  "dep:solana-transaction-error",
+  "dep:solana-transaction-status-client-types",
+  "dep:tokio-stream",
+]
+solana-keypair = ["dep:solana-keypair", "dep:solana-signer"]
+test-fixture = [
+  "types",
+  "solana-keypair",
+  "dep:base64",
+  "dep:litesvm",
+  "dep:solana-commitment-config",
+  "dep:solana-rpc-client",
+  "dep:solana-transaction",
+]
+types = [
+  "rust_decimal",
+  "dep:chrono",
+  "dep:reqwest",
+  "dep:serde_json",
+  "dep:serde_with",
+  "dep:tokio",
+  "dep:tokio-tungstenite",
+  "dep:tracing",
+  "dep:url",
+]
+utoipa = ["types", "dep:utoipa"]
+
+[package.metadata.cargo-machete]
+ignored = [
+  "borsh",
+  "bytemuck",
+  "fixed",
+  "pastey",
+  "proptest",
+  "rand",
+  "serde_with",
+  "sha2",
+  "sha2-const-stable",
+  "litesvm",
+  "utoipa",
+]
+
+[dependencies]
+async-trait                            = { workspace = true, optional = true }
+base64                                 = { workspace = true, optional = true }
+borsh                                  = { workspace = true }
+bs58                                   = { workspace = true, optional = true }
+bytemuck                               = { workspace = true }
+chrono                                 = { workspace = true, optional = true }
+ed25519-dalek                          = { workspace = true, optional = true }
+fixed                                  = { workspace = true }
+futures-util                           = { workspace = true, optional = true }
+litesvm                                = { version = "0.7", optional = true }
+opentelemetry                          = { workspace = true, optional = true }
+opentelemetry-http                     = { workspace = true, optional = true }
+parking_lot                            = { workspace = true, optional = true }
+pastey                                 = { workspace = true }
+rand                                   = { workspace = true, optional = true }
+reqwest                                = { workspace = true, optional = true }
+rust_decimal                           = { workspace = true, optional = true }
+serde                                  = { workspace = true }
+serde_json                             = { workspace = true, optional = true }
+serde_urlencoded                       = { workspace = true, optional = true }
+serde_with                             = { workspace = true, optional = true }
+sha2                                   = { workspace = true }
+sha2-const-stable                      = { workspace = true }
+solana-commitment-config               = { workspace = true, optional = true }
+solana-compute-budget-interface        = { workspace = true, optional = true }
+solana-instruction                     = { workspace = true }
+solana-keypair                         = { workspace = true, optional = true }
+solana-pubkey                          = { workspace = true }
+solana-rpc-client                      = { workspace = true, optional = true }
+solana-rpc-client-api                  = { workspace = true, optional = true }
+solana-signer                          = { workspace = true, optional = true }
+solana-transaction                     = { workspace = true, optional = true }
+solana-transaction-error               = { workspace = true, optional = true }
+solana-transaction-status-client-types = { workspace = true, optional = true }
+thiserror                              = { workspace = true }
+tokio                                  = { workspace = true, optional = true }
+tokio-stream                           = { version = "0.1", optional = true }
+tokio-tungstenite                      = { workspace = true, optional = true }
+tracing                                = { workspace = true, optional = true }
+tracing-opentelemetry                  = { workspace = true, optional = true }
+url                                    = { workspace = true, optional = true }
+utoipa                                 = { workspace = true, optional = true }
+
+[dev-dependencies]
+axum                            = "0.8"
+litesvm                         = "0.7"
+opentelemetry_sdk               = { workspace = true }
+proptest                        = "1.11.0"
+rand                            = "0.10.1"
+solana-commitment-config        = { workspace = true }
+solana-compute-budget-interface = "~2.2"
+solana-keypair                  = { workspace = true }
+solana-signer                   = { workspace = true }
+solana-transaction              = { workspace = true }
+toml                            = "0.8"
+tracing-subscriber              = { workspace = true }
+
+[workspace.dependencies]
+async-trait = "0.1"
+base64 = "0.22"
+borsh = { version = "1.5", features = ["derive"] }
+bs58 = "0.5"
+bytemuck = { version = "1.21", features = ["derive"] }
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4.5", features = ["derive"] }
+ed25519-dalek = "2"
+fixed = "=1.29.0"
+futures-util = "0.3"
+opentelemetry = { version = "0.31", features = ["trace"] }
+opentelemetry-http = "0.31"
+opentelemetry_sdk = { version = "0.31", features = ["trace"] }
+parking_lot = "0.12"
+pastey = "0.1"
+rand = "0.10"
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "rustls-tls-webpki-roots",
+] }
+rust_decimal = { version = "1.39.0", features = ["serde-str"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_urlencoded = "0.7"
+serde_with = "3.12"
+sha2 = "0.10"
+sha2-const-stable = "0.1"
+solana-commitment-config = { version = "~2.2" }
+solana-compute-budget-interface = "~2.2"
+solana-instruction = { version = "~2.3", default-features = false, features = [
+  "std",
+] }
+solana-keypair = { version = "~2.2" }
+solana-pubkey = { version = "~2.4", features = ["curve25519"] }
+solana-rpc-client = "~2.3"
+solana-rpc-client-api = "~2.3"
+solana-signer = { version = "~2.2" }
+solana-transaction = { version = "~2.2" }
+solana-transaction-error = "~2.2"
+solana-transaction-status-client-types = "~2.3"
+thiserror = "2.0"
+tokio = { version = "1.44", features = [
+  "sync",
+  "rt-multi-thread",
+  "macros",
+  "time",
+  "test-util",
+] }
+tokio-tungstenite = { version = "0.26", default-features = false, features = [
+  "connect",
+  "rustls-tls-webpki-roots",
+] }
+tracing = { version = "0.1", features = ["log"] }
+tracing-opentelemetry = "0.32"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+url = "2.5"
+utoipa = { version = "5.4", features = ["chrono"] }
+
+[profile.ci]
+inherits = "dev"
+# Full debug in CI builds is unnecessary and makes cache artifacts large.
+debug = "line-tables-only"
+
+[lints.rust.unexpected_cfgs]
+check-cfg = ['cfg(target_os, values("solana"))', 'cfg(tokio_unstable)']
+level     = "allow"
+
+[lints.clippy]
+uninlined_format_args = "allow"
 
 [[example]]
 name              = "cancel_all_conditional_orders"
@@ -144,171 +355,3 @@ path = "sdk/examples/subscribe_trades.rs"
 [[example]]
 name = "ws_debug_cli"
 path = "sdk/examples/ws_debug_cli.rs"
-
-[features]
-default = []
-ed25519-dalek = ["dep:ed25519-dalek"]
-opentelemetry = [
-  "dep:opentelemetry",
-  "dep:opentelemetry-http",
-  "dep:tracing-opentelemetry",
-]
-rust_decimal = []
-solana-keypair = ["dep:solana-keypair", "dep:solana-signer"]
-utoipa = ["dep:utoipa"]
-
-[package.metadata.cargo-machete]
-ignored = [
-  "borsh",
-  "bytemuck",
-  "fixed",
-  "pastey",
-  "proptest",
-  "rand",
-  "serde_with",
-  "sha2",
-  "sha2-const-stable",
-  "utoipa",
-]
-
-[dependencies]
-async-trait                            = { workspace = true }
-base64                                 = { workspace = true }
-borsh                                  = { workspace = true }
-bs58                                   = { workspace = true }
-bytemuck                               = { workspace = true }
-chrono                                 = { workspace = true }
-ed25519-dalek                          = { workspace = true, optional = true }
-fixed                                  = { workspace = true }
-futures-util                           = { workspace = true }
-opentelemetry                          = { workspace = true, optional = true }
-opentelemetry-http                     = { workspace = true, optional = true }
-parking_lot                            = { workspace = true }
-pastey                                 = { workspace = true }
-rand                                   = { workspace = true }
-reqwest                                = { workspace = true }
-rust_decimal                           = { workspace = true }
-serde                                  = { workspace = true }
-serde_json                             = { workspace = true }
-serde_urlencoded                       = { workspace = true }
-serde_with                             = { workspace = true }
-sha2                                   = { workspace = true }
-sha2-const-stable                      = { workspace = true }
-solana-compute-budget-interface        = { workspace = true }
-solana-instruction                     = { workspace = true }
-solana-keypair                         = { workspace = true, optional = true }
-solana-pubkey                          = { workspace = true }
-solana-rpc-client                      = { workspace = true }
-solana-rpc-client-api                  = { workspace = true }
-solana-signer                          = { workspace = true, optional = true }
-solana-transaction                     = { workspace = true }
-solana-transaction-error               = { workspace = true }
-solana-transaction-status-client-types = { workspace = true }
-thiserror                              = { workspace = true }
-tokio                                  = { workspace = true }
-tokio-stream                           = "0.1"
-tokio-tungstenite                      = { workspace = true }
-tracing                                = { workspace = true }
-tracing-opentelemetry                  = { workspace = true, optional = true }
-url                                    = { workspace = true }
-utoipa                                 = { workspace = true, optional = true }
-
-[dev-dependencies]
-axum                            = "0.8"
-litesvm                         = "0.7"
-opentelemetry_sdk               = { workspace = true }
-proptest                        = "1.11.0"
-rand                            = "0.10.1"
-solana-commitment-config        = { workspace = true }
-solana-compute-budget-interface = "~2.2"
-solana-keypair                  = { workspace = true }
-solana-signer                   = { workspace = true }
-solana-transaction              = { workspace = true }
-toml                            = "0.8"
-tracing-subscriber              = { workspace = true }
-
-[workspace]
-members  = ["cli"]
-resolver = "2"
-
-[workspace.package]
-description  = "SDK for interacting with Phoenix"
-edition      = "2021"
-homepage     = "https://docs.phoenix.trade/"
-license      = "MIT"
-publish      = true
-readme       = "CRATES.md"
-repository   = "https://github.com/Ellipsis-Labs/rise"
-rust-version = "1.84.0"
-version      = "0.1.11"
-
-[workspace.dependencies]
-async-trait = "0.1"
-base64 = "0.22"
-borsh = { version = "1.5", features = ["derive"] }
-bs58 = "0.5"
-bytemuck = { version = "1.21", features = ["derive"] }
-chrono = { version = "0.4", features = ["serde"] }
-clap = { version = "4.5", features = ["derive"] }
-ed25519-dalek = "2"
-fixed = "=1.29.0"
-futures-util = "0.3"
-opentelemetry = { version = "0.31", features = ["trace"] }
-opentelemetry-http = "0.31"
-opentelemetry_sdk = { version = "0.31", features = ["trace"] }
-parking_lot = "0.12"
-pastey = "0.1"
-rand = "0.10"
-reqwest = { version = "0.12", default-features = false, features = [
-  "json",
-  "rustls-tls-webpki-roots",
-] }
-rust_decimal = { version = "1.39.0", features = ["serde-str"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-serde_urlencoded = "0.7"
-serde_with = "3.12"
-sha2 = "0.10"
-sha2-const-stable = "0.1"
-solana-commitment-config = { version = "~2.2" }
-solana-compute-budget-interface = "~2.2"
-solana-instruction = { version = "~2.3", default-features = false, features = [
-  "std",
-] }
-solana-keypair = { version = "~2.2" }
-solana-pubkey = { version = "~2.4", features = ["curve25519"] }
-solana-rpc-client = "~2.3"
-solana-rpc-client-api = "~2.3"
-solana-signer = { version = "~2.2" }
-solana-transaction = { version = "~2.2" }
-solana-transaction-error = "~2.2"
-solana-transaction-status-client-types = "~2.3"
-thiserror = "2.0"
-tokio = { version = "1.44", features = [
-  "sync",
-  "rt-multi-thread",
-  "macros",
-  "time",
-  "test-util",
-] }
-tokio-tungstenite = { version = "0.26", default-features = false, features = [
-  "connect",
-  "rustls-tls-webpki-roots",
-] }
-tracing = { version = "0.1", features = ["log"] }
-tracing-opentelemetry = "0.32"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-url = "2.5"
-utoipa = { version = "5.4", features = ["chrono"] }
-
-[profile.ci]
-inherits = "dev"
-# Full debug in CI builds is unnecessary and makes cache artifacts large.
-debug = "line-tables-only"
-
-[lints.rust.unexpected_cfgs]
-check-cfg = ['cfg(target_os, values("solana"))', 'cfg(tokio_unstable)']
-level     = "allow"
-
-[lints.clippy]
-uninlined_format_args = "allow"

--- a/rust/README.md
+++ b/rust/README.md
@@ -95,7 +95,9 @@ metadata rather than server-assisted order helpers.
 - Cross-margin order placement: `place_market_order(...)`,
   `place_limit_order(...)`
 - Cancellation helpers: `build_cancel_orders(...)`,
+  `build_cancel_all_orders(...)`, `build_cancel_up_to(...)`,
   `build_cancel_bracket_leg(...)`
+- Maintenance helpers: `build_uncross_crank(...)`
 - Trader and collateral flows: `build_register_trader(...)`,
   `build_deposit_funds(...)`, `build_withdraw_funds(...)`,
   `build_transfer_collateral(...)`, `build_sync_parent_to_child(...)`

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -36,5 +36,6 @@ ignore = [
   "RUSTSEC-2026-0098", # rustls-webpki URI name constraints issue; transitive via rustls stack
   "RUSTSEC-2026-0099", # rustls-webpki wildcard name constraints issue; transitive via rustls stack
   "RUSTSEC-2026-0097", # rand advisory accepted for now
+  "RUSTSEC-2026-0186", # memmap2 0.5.10 forced by Solana 2.x solana-genesis-config; no compatible 0.9.x upgrade available
 ]
 unmaintained = 'workspace'

--- a/rust/ix/examples/build_all_ix.rs
+++ b/rust/ix/examples/build_all_ix.rs
@@ -112,7 +112,60 @@ fn main() {
         results.insert("CancelOrdersById".to_string(), hex_encode(&ix.data));
     }
 
-    // 5. CancelStopLoss
+    // 5. CancelAll
+    {
+        let params = CancelAllParams::builder()
+            .trader(pubkeys[0])
+            .trader_account(pubkeys[1])
+            .perp_asset_map(pubkeys[2])
+            .orderbook(pubkeys[3])
+            .spline_collection(pubkeys[4])
+            .global_trader_index(vec2(5, 6))
+            .active_trader_buffer(vec2(7, 8))
+            .build()
+            .unwrap();
+
+        let ix = create_cancel_all_ix(params).unwrap();
+        results.insert("CancelAll".to_string(), hex_encode(&ix.data));
+    }
+
+    // 6. CancelUpTo
+    {
+        let params = CancelUpToParams::builder()
+            .trader(pubkeys[0])
+            .trader_account(pubkeys[1])
+            .perp_asset_map(pubkeys[2])
+            .orderbook(pubkeys[3])
+            .spline_collection(pubkeys[4])
+            .global_trader_index(vec2(5, 6))
+            .active_trader_buffer(vec2(7, 8))
+            .side(Side::Ask)
+            .num_orders_to_cancel(2)
+            .tick_limit(1000)
+            .build()
+            .unwrap();
+
+        let ix = create_cancel_up_to_ix(params).unwrap();
+        results.insert("CancelUpTo".to_string(), hex_encode(&ix.data));
+    }
+
+    // 7. CancelStopLoss
+    {
+        let params = UncrossCrankParams::builder()
+            .perp_asset_map(pubkeys[2])
+            .orderbook(pubkeys[3])
+            .spline_collection(pubkeys[4])
+            .global_trader_index(vec2(5, 6))
+            .active_trader_buffer(vec2(7, 8))
+            .match_limit(5)
+            .build()
+            .unwrap();
+
+        let ix = create_uncross_crank_ix(params).unwrap();
+        results.insert("UncrossCrank".to_string(), hex_encode(&ix.data));
+    }
+
+    // 7. CancelStopLoss
     {
         let params = CancelStopLossParams::builder()
             .funder(pubkeys[0])

--- a/rust/ix/src/cancel_orders.rs
+++ b/rust/ix/src/cancel_orders.rs
@@ -1,17 +1,301 @@
 //! Cancel orders by ID instruction construction.
 
-use borsh::to_vec;
+use borsh::{BorshSerialize, to_vec};
 use solana_pubkey::Pubkey;
 
 use crate::ix::constants::{
     PHOENIX_GLOBAL_CONFIGURATION, PHOENIX_LOG_AUTHORITY, PHOENIX_PROGRAM_ID,
-    cancel_orders_by_id_discriminant,
+    cancel_all_discriminant, cancel_orders_by_id_discriminant, cancel_up_to_discriminant,
 };
 use crate::ix::error::PhoenixIxError;
-use crate::ix::types::{AccountMeta, CancelId, Instruction};
+use crate::ix::types::{AccountMeta, CancelId, Instruction, Side};
 
 /// Maximum number of orders that can be cancelled in a single instruction.
 pub const MAX_CANCEL_ORDER_IDS: usize = 100;
+
+/// Parameters for cancelling all orders on one market.
+#[derive(Debug, Clone)]
+pub struct CancelAllParams {
+    trader: Pubkey,
+    trader_account: Pubkey,
+    perp_asset_map: Pubkey,
+    orderbook: Pubkey,
+    spline_collection: Pubkey,
+    global_trader_index: Vec<Pubkey>,
+    active_trader_buffer: Vec<Pubkey>,
+}
+
+impl CancelAllParams {
+    /// Start building with the builder pattern.
+    pub fn builder() -> CancelAllParamsBuilder {
+        CancelAllParamsBuilder::new()
+    }
+
+    pub fn trader(&self) -> Pubkey {
+        self.trader
+    }
+
+    pub fn trader_account(&self) -> Pubkey {
+        self.trader_account
+    }
+
+    pub fn perp_asset_map(&self) -> Pubkey {
+        self.perp_asset_map
+    }
+
+    pub fn orderbook(&self) -> Pubkey {
+        self.orderbook
+    }
+
+    pub fn spline_collection(&self) -> Pubkey {
+        self.spline_collection
+    }
+
+    pub fn global_trader_index(&self) -> &[Pubkey] {
+        &self.global_trader_index
+    }
+
+    pub fn active_trader_buffer(&self) -> &[Pubkey] {
+        &self.active_trader_buffer
+    }
+}
+
+/// Builder for `CancelAllParams`.
+#[derive(Default)]
+pub struct CancelAllParamsBuilder {
+    trader: Option<Pubkey>,
+    trader_account: Option<Pubkey>,
+    perp_asset_map: Option<Pubkey>,
+    orderbook: Option<Pubkey>,
+    spline_collection: Option<Pubkey>,
+    global_trader_index: Option<Vec<Pubkey>>,
+    active_trader_buffer: Option<Vec<Pubkey>>,
+}
+
+impl CancelAllParamsBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn trader(mut self, trader: Pubkey) -> Self {
+        self.trader = Some(trader);
+        self
+    }
+
+    pub fn trader_account(mut self, trader_account: Pubkey) -> Self {
+        self.trader_account = Some(trader_account);
+        self
+    }
+
+    pub fn perp_asset_map(mut self, perp_asset_map: Pubkey) -> Self {
+        self.perp_asset_map = Some(perp_asset_map);
+        self
+    }
+
+    pub fn orderbook(mut self, orderbook: Pubkey) -> Self {
+        self.orderbook = Some(orderbook);
+        self
+    }
+
+    pub fn spline_collection(mut self, spline_collection: Pubkey) -> Self {
+        self.spline_collection = Some(spline_collection);
+        self
+    }
+
+    pub fn global_trader_index(mut self, global_trader_index: Vec<Pubkey>) -> Self {
+        self.global_trader_index = Some(global_trader_index);
+        self
+    }
+
+    pub fn active_trader_buffer(mut self, active_trader_buffer: Vec<Pubkey>) -> Self {
+        self.active_trader_buffer = Some(active_trader_buffer);
+        self
+    }
+
+    pub fn build(self) -> Result<CancelAllParams, PhoenixIxError> {
+        Ok(CancelAllParams {
+            trader: self.trader.ok_or(PhoenixIxError::MissingField("trader"))?,
+            trader_account: self
+                .trader_account
+                .ok_or(PhoenixIxError::MissingField("trader_account"))?,
+            perp_asset_map: self
+                .perp_asset_map
+                .ok_or(PhoenixIxError::MissingField("perp_asset_map"))?,
+            orderbook: self
+                .orderbook
+                .ok_or(PhoenixIxError::MissingField("orderbook"))?,
+            spline_collection: self
+                .spline_collection
+                .ok_or(PhoenixIxError::MissingField("spline_collection"))?,
+            global_trader_index: self
+                .global_trader_index
+                .ok_or(PhoenixIxError::MissingField("global_trader_index"))?,
+            active_trader_buffer: self
+                .active_trader_buffer
+                .ok_or(PhoenixIxError::MissingField("active_trader_buffer"))?,
+        })
+    }
+}
+
+/// Parameters for cancelling orders up to a side/limit on one market.
+#[derive(Debug, Clone)]
+pub struct CancelUpToParams {
+    trader: Pubkey,
+    trader_account: Pubkey,
+    perp_asset_map: Pubkey,
+    orderbook: Pubkey,
+    spline_collection: Pubkey,
+    global_trader_index: Vec<Pubkey>,
+    active_trader_buffer: Vec<Pubkey>,
+    side: Side,
+    num_orders_to_cancel: Option<u64>,
+    tick_limit: Option<u64>,
+}
+
+impl CancelUpToParams {
+    /// Start building with the builder pattern.
+    pub fn builder() -> CancelUpToParamsBuilder {
+        CancelUpToParamsBuilder::new()
+    }
+
+    pub fn trader(&self) -> Pubkey {
+        self.trader
+    }
+
+    pub fn trader_account(&self) -> Pubkey {
+        self.trader_account
+    }
+
+    pub fn perp_asset_map(&self) -> Pubkey {
+        self.perp_asset_map
+    }
+
+    pub fn orderbook(&self) -> Pubkey {
+        self.orderbook
+    }
+
+    pub fn spline_collection(&self) -> Pubkey {
+        self.spline_collection
+    }
+
+    pub fn global_trader_index(&self) -> &[Pubkey] {
+        &self.global_trader_index
+    }
+
+    pub fn active_trader_buffer(&self) -> &[Pubkey] {
+        &self.active_trader_buffer
+    }
+
+    pub fn side(&self) -> Side {
+        self.side
+    }
+
+    pub fn num_orders_to_cancel(&self) -> Option<u64> {
+        self.num_orders_to_cancel
+    }
+
+    pub fn tick_limit(&self) -> Option<u64> {
+        self.tick_limit
+    }
+}
+
+/// Builder for `CancelUpToParams`.
+#[derive(Default)]
+pub struct CancelUpToParamsBuilder {
+    trader: Option<Pubkey>,
+    trader_account: Option<Pubkey>,
+    perp_asset_map: Option<Pubkey>,
+    orderbook: Option<Pubkey>,
+    spline_collection: Option<Pubkey>,
+    global_trader_index: Option<Vec<Pubkey>>,
+    active_trader_buffer: Option<Vec<Pubkey>>,
+    side: Option<Side>,
+    num_orders_to_cancel: Option<u64>,
+    tick_limit: Option<u64>,
+}
+
+impl CancelUpToParamsBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn trader(mut self, trader: Pubkey) -> Self {
+        self.trader = Some(trader);
+        self
+    }
+
+    pub fn trader_account(mut self, trader_account: Pubkey) -> Self {
+        self.trader_account = Some(trader_account);
+        self
+    }
+
+    pub fn perp_asset_map(mut self, perp_asset_map: Pubkey) -> Self {
+        self.perp_asset_map = Some(perp_asset_map);
+        self
+    }
+
+    pub fn orderbook(mut self, orderbook: Pubkey) -> Self {
+        self.orderbook = Some(orderbook);
+        self
+    }
+
+    pub fn spline_collection(mut self, spline_collection: Pubkey) -> Self {
+        self.spline_collection = Some(spline_collection);
+        self
+    }
+
+    pub fn global_trader_index(mut self, global_trader_index: Vec<Pubkey>) -> Self {
+        self.global_trader_index = Some(global_trader_index);
+        self
+    }
+
+    pub fn active_trader_buffer(mut self, active_trader_buffer: Vec<Pubkey>) -> Self {
+        self.active_trader_buffer = Some(active_trader_buffer);
+        self
+    }
+
+    pub fn side(mut self, side: Side) -> Self {
+        self.side = Some(side);
+        self
+    }
+
+    pub fn num_orders_to_cancel(mut self, num_orders_to_cancel: u64) -> Self {
+        self.num_orders_to_cancel = Some(num_orders_to_cancel);
+        self
+    }
+
+    pub fn tick_limit(mut self, tick_limit: u64) -> Self {
+        self.tick_limit = Some(tick_limit);
+        self
+    }
+
+    pub fn build(self) -> Result<CancelUpToParams, PhoenixIxError> {
+        Ok(CancelUpToParams {
+            trader: self.trader.ok_or(PhoenixIxError::MissingField("trader"))?,
+            trader_account: self
+                .trader_account
+                .ok_or(PhoenixIxError::MissingField("trader_account"))?,
+            perp_asset_map: self
+                .perp_asset_map
+                .ok_or(PhoenixIxError::MissingField("perp_asset_map"))?,
+            orderbook: self
+                .orderbook
+                .ok_or(PhoenixIxError::MissingField("orderbook"))?,
+            spline_collection: self
+                .spline_collection
+                .ok_or(PhoenixIxError::MissingField("spline_collection"))?,
+            global_trader_index: self
+                .global_trader_index
+                .ok_or(PhoenixIxError::MissingField("global_trader_index"))?,
+            active_trader_buffer: self
+                .active_trader_buffer
+                .ok_or(PhoenixIxError::MissingField("active_trader_buffer"))?,
+            side: self.side.ok_or(PhoenixIxError::MissingField("side"))?,
+            num_orders_to_cancel: self.num_orders_to_cancel,
+            tick_limit: self.tick_limit,
+        })
+    }
+}
 
 /// Parameters for cancelling orders by ID.
 #[derive(Debug, Clone)]
@@ -151,6 +435,60 @@ impl CancelOrdersByIdParamsBuilder {
     }
 }
 
+/// Create a cancel all instruction.
+///
+/// # Arguments
+///
+/// * `params` - The cancel all parameters
+///
+/// # Returns
+///
+/// A Solana instruction ready to be included in a transaction.
+pub fn create_cancel_all_ix(params: CancelAllParams) -> Result<Instruction, PhoenixIxError> {
+    validate_cancel_account_arrays(params.global_trader_index(), params.active_trader_buffer())?;
+
+    Ok(Instruction {
+        program_id: *PHOENIX_PROGRAM_ID,
+        accounts: build_cancel_order_accounts(
+            params.trader(),
+            params.trader_account(),
+            params.perp_asset_map(),
+            params.global_trader_index(),
+            params.active_trader_buffer(),
+            params.orderbook(),
+            params.spline_collection(),
+        ),
+        data: cancel_all_discriminant().to_vec(),
+    })
+}
+
+/// Create a cancel up to instruction.
+///
+/// # Arguments
+///
+/// * `params` - The cancel up to parameters
+///
+/// # Returns
+///
+/// A Solana instruction ready to be included in a transaction.
+pub fn create_cancel_up_to_ix(params: CancelUpToParams) -> Result<Instruction, PhoenixIxError> {
+    validate_cancel_account_arrays(params.global_trader_index(), params.active_trader_buffer())?;
+
+    Ok(Instruction {
+        program_id: *PHOENIX_PROGRAM_ID,
+        accounts: build_cancel_order_accounts(
+            params.trader(),
+            params.trader_account(),
+            params.perp_asset_map(),
+            params.global_trader_index(),
+            params.active_trader_buffer(),
+            params.orderbook(),
+            params.spline_collection(),
+        ),
+        data: encode_cancel_up_to(&params),
+    })
+}
+
 /// Create a cancel orders by ID instruction.
 ///
 /// # Arguments
@@ -183,12 +521,7 @@ pub fn create_cancel_orders_by_id_ix(
 }
 
 fn validate(params: &CancelOrdersByIdParams) -> Result<(), PhoenixIxError> {
-    if params.global_trader_index().is_empty() {
-        return Err(PhoenixIxError::EmptyGlobalTraderIndex);
-    }
-    if params.active_trader_buffer().is_empty() {
-        return Err(PhoenixIxError::EmptyActiveTraderBuffer);
-    }
+    validate_cancel_account_arrays(params.global_trader_index(), params.active_trader_buffer())?;
     if params.order_ids().is_empty() {
         return Err(PhoenixIxError::NoOrderIds);
     }
@@ -196,6 +529,40 @@ fn validate(params: &CancelOrdersByIdParams) -> Result<(), PhoenixIxError> {
         return Err(PhoenixIxError::TooManyOrderIds);
     }
     Ok(())
+}
+
+fn validate_cancel_account_arrays(
+    global_trader_index: &[Pubkey],
+    active_trader_buffer: &[Pubkey],
+) -> Result<(), PhoenixIxError> {
+    if global_trader_index.is_empty() {
+        return Err(PhoenixIxError::EmptyGlobalTraderIndex);
+    }
+    if active_trader_buffer.is_empty() {
+        return Err(PhoenixIxError::EmptyActiveTraderBuffer);
+    }
+    Ok(())
+}
+
+#[derive(BorshSerialize)]
+struct CancelUpToData {
+    side: Side,
+    num_orders_to_cancel: Option<u64>,
+    tick_limit: Option<u64>,
+}
+
+fn encode_cancel_up_to(params: &CancelUpToParams) -> Vec<u8> {
+    let mut data = Vec::new();
+    data.extend_from_slice(&cancel_up_to_discriminant());
+    data.extend_from_slice(
+        &to_vec(&CancelUpToData {
+            side: params.side(),
+            num_orders_to_cancel: params.num_orders_to_cancel(),
+            tick_limit: params.tick_limit(),
+        })
+        .expect("serialization should not fail"),
+    );
+    data
 }
 
 fn encode_cancel_orders(params: &CancelOrdersByIdParams) -> Vec<u8> {
@@ -217,30 +584,50 @@ fn encode_cancel_orders(params: &CancelOrdersByIdParams) -> Vec<u8> {
 }
 
 fn build_accounts(params: &CancelOrdersByIdParams) -> Vec<AccountMeta> {
+    build_cancel_order_accounts(
+        params.trader(),
+        params.trader_account(),
+        params.perp_asset_map(),
+        params.global_trader_index(),
+        params.active_trader_buffer(),
+        params.orderbook(),
+        params.spline_collection(),
+    )
+}
+
+fn build_cancel_order_accounts(
+    trader: Pubkey,
+    trader_account: Pubkey,
+    perp_asset_map: Pubkey,
+    global_trader_index: &[Pubkey],
+    active_trader_buffer: &[Pubkey],
+    orderbook: Pubkey,
+    spline_collection: Pubkey,
+) -> Vec<AccountMeta> {
     let mut accounts = Vec::new();
 
     // LogAccountGroupAccounts (2 accounts)
     accounts.push(AccountMeta::readonly(*PHOENIX_PROGRAM_ID));
     accounts.push(AccountMeta::readonly(*PHOENIX_LOG_AUTHORITY));
 
-    // CancelOrdersByIdInstructionGroupAccounts
+    // CancelOrderInstructionGroupAccounts
     accounts.push(AccountMeta::writable(*PHOENIX_GLOBAL_CONFIGURATION));
-    accounts.push(AccountMeta::readonly_signer(params.trader()));
-    accounts.push(AccountMeta::writable(params.trader_account()));
-    accounts.push(AccountMeta::writable(params.perp_asset_map()));
+    accounts.push(AccountMeta::readonly_signer(trader));
+    accounts.push(AccountMeta::writable(trader_account));
+    accounts.push(AccountMeta::writable(perp_asset_map));
 
     // Global trader index addresses
-    for addr in params.global_trader_index() {
+    for addr in global_trader_index {
         accounts.push(AccountMeta::writable(*addr));
     }
 
     // Active trader buffer addresses
-    for addr in params.active_trader_buffer() {
+    for addr in active_trader_buffer {
         accounts.push(AccountMeta::writable(*addr));
     }
 
-    accounts.push(AccountMeta::writable(params.orderbook()));
-    accounts.push(AccountMeta::writable(params.spline_collection()));
+    accounts.push(AccountMeta::writable(orderbook));
+    accounts.push(AccountMeta::writable(spline_collection));
 
     accounts
 }
@@ -248,6 +635,81 @@ fn build_accounts(params: &CancelOrdersByIdParams) -> Vec<AccountMeta> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_create_cancel_all_ix() {
+        let params = CancelAllParams::builder()
+            .trader(Pubkey::new_unique())
+            .trader_account(Pubkey::new_unique())
+            .perp_asset_map(Pubkey::new_unique())
+            .orderbook(Pubkey::new_unique())
+            .spline_collection(Pubkey::new_unique())
+            .global_trader_index(vec![Pubkey::new_unique()])
+            .active_trader_buffer(vec![Pubkey::new_unique()])
+            .build()
+            .unwrap();
+
+        let ix = create_cancel_all_ix(params).unwrap();
+
+        assert_eq!(ix.program_id, *PHOENIX_PROGRAM_ID);
+        assert_eq!(ix.accounts.len(), 10);
+        assert_eq!(&ix.data[..8], &cancel_all_discriminant());
+        assert_eq!(ix.data.len(), 8);
+    }
+
+    #[test]
+    fn test_create_cancel_up_to_ix() {
+        let params = CancelUpToParams::builder()
+            .trader(Pubkey::new_unique())
+            .trader_account(Pubkey::new_unique())
+            .perp_asset_map(Pubkey::new_unique())
+            .orderbook(Pubkey::new_unique())
+            .spline_collection(Pubkey::new_unique())
+            .global_trader_index(vec![Pubkey::new_unique()])
+            .active_trader_buffer(vec![Pubkey::new_unique()])
+            .side(Side::Ask)
+            .num_orders_to_cancel(2)
+            .tick_limit(1000)
+            .build()
+            .unwrap();
+
+        let ix = create_cancel_up_to_ix(params).unwrap();
+
+        assert_eq!(ix.program_id, *PHOENIX_PROGRAM_ID);
+        assert_eq!(ix.accounts.len(), 10);
+        assert_eq!(&ix.data[..8], &cancel_up_to_discriminant());
+        assert_eq!(ix.data[8], Side::Ask as u8);
+        assert_eq!(ix.data[9], 1);
+        assert_eq!(u64::from_le_bytes(ix.data[10..18].try_into().unwrap()), 2);
+        assert_eq!(ix.data[18], 1);
+        assert_eq!(
+            u64::from_le_bytes(ix.data[19..27].try_into().unwrap()),
+            1000
+        );
+    }
+
+    #[test]
+    fn test_cancel_up_to_allows_open_ended_limits() {
+        let params = CancelUpToParams::builder()
+            .trader(Pubkey::new_unique())
+            .trader_account(Pubkey::new_unique())
+            .perp_asset_map(Pubkey::new_unique())
+            .orderbook(Pubkey::new_unique())
+            .spline_collection(Pubkey::new_unique())
+            .global_trader_index(vec![Pubkey::new_unique()])
+            .active_trader_buffer(vec![Pubkey::new_unique()])
+            .side(Side::Bid)
+            .build()
+            .unwrap();
+
+        let ix = create_cancel_up_to_ix(params).unwrap();
+
+        assert_eq!(&ix.data[..8], &cancel_up_to_discriminant());
+        assert_eq!(ix.data[8], Side::Bid as u8);
+        assert_eq!(ix.data[9], 0);
+        assert_eq!(ix.data[10], 0);
+        assert_eq!(ix.data.len(), 11);
+    }
 
     #[test]
     fn test_create_cancel_orders_ix() {

--- a/rust/ix/src/constants.rs
+++ b/rust/ix/src/constants.rs
@@ -1,5 +1,6 @@
 //! Phoenix program constants and addresses.
 
+#[cfg(not(target_os = "solana"))]
 use std::sync::LazyLock;
 
 use sha2::{Digest, Sha256};
@@ -54,25 +55,42 @@ pub const BETA_PHOENIX_INSTRUCTION_ADDRESSES: PhoenixInstructionAddresses =
 ///
 /// This is resolved once from `PHOENIX_ENV`. Set `PHOENIX_ENV=beta` before
 /// first use to target the beta deployment.
+#[cfg(not(target_os = "solana"))]
 pub static PHOENIX_INSTRUCTION_ADDRESSES: LazyLock<PhoenixInstructionAddresses> =
     LazyLock::new(|| {
         resolve_phoenix_instruction_addresses_for_env(std::env::var("PHOENIX_ENV").ok().as_deref())
     });
 
+#[cfg(target_os = "solana")]
+pub static PHOENIX_INSTRUCTION_ADDRESSES: &PhoenixInstructionAddresses =
+    &PROD_PHOENIX_INSTRUCTION_ADDRESSES;
+
 /// Active Phoenix program ID for the current process.
 ///
 /// This is resolved once from `PHOENIX_ENV`. Set `PHOENIX_ENV=beta` before
 /// first use to target the beta deployment.
+#[cfg(not(target_os = "solana"))]
 pub static PHOENIX_PROGRAM_ID: LazyLock<Pubkey> =
     LazyLock::new(|| phoenix_instruction_addresses().program_id);
 
+#[cfg(target_os = "solana")]
+pub static PHOENIX_PROGRAM_ID: &Pubkey = &PROD_PHOENIX_PROGRAM_ID;
+
 /// Active Phoenix log authority for the current process.
+#[cfg(not(target_os = "solana"))]
 pub static PHOENIX_LOG_AUTHORITY: LazyLock<Pubkey> =
     LazyLock::new(|| phoenix_instruction_addresses().log_authority);
 
+#[cfg(target_os = "solana")]
+pub static PHOENIX_LOG_AUTHORITY: &Pubkey = &PROD_PHOENIX_LOG_AUTHORITY;
+
 /// Active Phoenix global configuration for the current process.
+#[cfg(not(target_os = "solana"))]
 pub static PHOENIX_GLOBAL_CONFIGURATION: LazyLock<Pubkey> =
     LazyLock::new(|| phoenix_instruction_addresses().global_configuration);
+
+#[cfg(target_os = "solana")]
+pub static PHOENIX_GLOBAL_CONFIGURATION: &Pubkey = &PROD_PHOENIX_GLOBAL_CONFIGURATION;
 
 /// Resolve Phoenix instruction addresses for an explicit environment value.
 ///
@@ -158,6 +176,21 @@ pub fn place_market_order_delegated_discriminant() -> [u8; 8] {
 /// Instruction discriminant for cancel_orders_by_id.
 pub fn cancel_orders_by_id_discriminant() -> [u8; 8] {
     compute_discriminant("global:cancel_orders_by_id")
+}
+
+/// Instruction discriminant for cancel_all.
+pub fn cancel_all_discriminant() -> [u8; 8] {
+    compute_discriminant("global:cancel_all")
+}
+
+/// Instruction discriminant for cancel_up_to.
+pub fn cancel_up_to_discriminant() -> [u8; 8] {
+    compute_discriminant("global:cancel_up_to")
+}
+
+/// Instruction discriminant for uncross_crank.
+pub fn uncross_crank_discriminant() -> [u8; 8] {
+    compute_discriminant("global:uncross_crank")
 }
 
 /// Instruction discriminant for deposit_funds.

--- a/rust/ix/src/lib.rs
+++ b/rust/ix/src/lib.rs
@@ -48,9 +48,13 @@ mod spl_approve;
 mod sync_parent_to_child;
 mod transfer_collateral;
 mod types;
+mod uncross_crank;
 mod withdraw_funds;
 
-pub use cancel_orders::{CancelOrdersByIdParams, create_cancel_orders_by_id_ix};
+pub use cancel_orders::{
+    CancelAllParams, CancelOrdersByIdParams, CancelUpToParams, create_cancel_all_ix,
+    create_cancel_orders_by_id_ix, create_cancel_up_to_ix,
+};
 pub use cancel_stop_loss::{CancelStopLossParams, create_cancel_stop_loss_ix};
 pub use conditional_order::{
     CancelConditionalOrderParams, CreateConditionalOrdersAccountParams,
@@ -92,4 +96,5 @@ pub use transfer_collateral::{
     create_transfer_collateral_child_to_parent_ix, create_transfer_collateral_ix,
 };
 pub use types::*;
+pub use uncross_crank::{UncrossCrankParams, create_uncross_crank_ix};
 pub use withdraw_funds::{WithdrawFundsParams, create_withdraw_funds_ix};

--- a/rust/ix/src/uncross_crank.rs
+++ b/rust/ix/src/uncross_crank.rs
@@ -1,0 +1,233 @@
+//! Uncross crank instruction construction.
+
+use borsh::{BorshSerialize, to_vec};
+use solana_pubkey::Pubkey;
+
+use crate::ix::constants::{
+    PHOENIX_GLOBAL_CONFIGURATION, PHOENIX_LOG_AUTHORITY, PHOENIX_PROGRAM_ID,
+    uncross_crank_discriminant,
+};
+use crate::ix::error::PhoenixIxError;
+use crate::ix::types::{AccountMeta, Instruction};
+
+const DEFAULT_MATCH_LIMIT: u64 = 100;
+
+/// Parameters for cranking the orderbook to uncross matched orders.
+#[derive(Debug, Clone)]
+pub struct UncrossCrankParams {
+    perp_asset_map: Pubkey,
+    orderbook: Pubkey,
+    spline_collection: Pubkey,
+    global_trader_index: Vec<Pubkey>,
+    active_trader_buffer: Vec<Pubkey>,
+    match_limit: u64,
+}
+
+impl UncrossCrankParams {
+    /// Start building with the builder pattern.
+    pub fn builder() -> UncrossCrankParamsBuilder {
+        UncrossCrankParamsBuilder::new()
+    }
+
+    pub fn perp_asset_map(&self) -> Pubkey {
+        self.perp_asset_map
+    }
+
+    pub fn orderbook(&self) -> Pubkey {
+        self.orderbook
+    }
+
+    pub fn spline_collection(&self) -> Pubkey {
+        self.spline_collection
+    }
+
+    pub fn global_trader_index(&self) -> &[Pubkey] {
+        &self.global_trader_index
+    }
+
+    pub fn active_trader_buffer(&self) -> &[Pubkey] {
+        &self.active_trader_buffer
+    }
+
+    pub fn match_limit(&self) -> u64 {
+        self.match_limit
+    }
+}
+
+/// Builder for `UncrossCrankParams`.
+#[derive(Default)]
+pub struct UncrossCrankParamsBuilder {
+    perp_asset_map: Option<Pubkey>,
+    orderbook: Option<Pubkey>,
+    spline_collection: Option<Pubkey>,
+    global_trader_index: Option<Vec<Pubkey>>,
+    active_trader_buffer: Option<Vec<Pubkey>>,
+    match_limit: Option<u64>,
+}
+
+impl UncrossCrankParamsBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn perp_asset_map(mut self, perp_asset_map: Pubkey) -> Self {
+        self.perp_asset_map = Some(perp_asset_map);
+        self
+    }
+
+    pub fn orderbook(mut self, orderbook: Pubkey) -> Self {
+        self.orderbook = Some(orderbook);
+        self
+    }
+
+    pub fn spline_collection(mut self, spline_collection: Pubkey) -> Self {
+        self.spline_collection = Some(spline_collection);
+        self
+    }
+
+    pub fn global_trader_index(mut self, global_trader_index: Vec<Pubkey>) -> Self {
+        self.global_trader_index = Some(global_trader_index);
+        self
+    }
+
+    pub fn active_trader_buffer(mut self, active_trader_buffer: Vec<Pubkey>) -> Self {
+        self.active_trader_buffer = Some(active_trader_buffer);
+        self
+    }
+
+    pub fn match_limit(mut self, match_limit: u64) -> Self {
+        self.match_limit = Some(match_limit);
+        self
+    }
+
+    pub fn build(self) -> Result<UncrossCrankParams, PhoenixIxError> {
+        Ok(UncrossCrankParams {
+            perp_asset_map: self
+                .perp_asset_map
+                .ok_or(PhoenixIxError::MissingField("perp_asset_map"))?,
+            orderbook: self
+                .orderbook
+                .ok_or(PhoenixIxError::MissingField("orderbook"))?,
+            spline_collection: self
+                .spline_collection
+                .ok_or(PhoenixIxError::MissingField("spline_collection"))?,
+            global_trader_index: self
+                .global_trader_index
+                .ok_or(PhoenixIxError::MissingField("global_trader_index"))?,
+            active_trader_buffer: self
+                .active_trader_buffer
+                .ok_or(PhoenixIxError::MissingField("active_trader_buffer"))?,
+            match_limit: self.match_limit.unwrap_or(DEFAULT_MATCH_LIMIT),
+        })
+    }
+}
+
+/// Create an uncross crank instruction.
+///
+/// # Arguments
+///
+/// * `params` - The uncross crank parameters
+///
+/// # Returns
+///
+/// A Solana instruction ready to be included in a transaction.
+pub fn create_uncross_crank_ix(params: UncrossCrankParams) -> Result<Instruction, PhoenixIxError> {
+    validate(&params)?;
+
+    Ok(Instruction {
+        program_id: *PHOENIX_PROGRAM_ID,
+        accounts: build_accounts(&params),
+        data: encode_uncross_crank(&params),
+    })
+}
+
+fn validate(params: &UncrossCrankParams) -> Result<(), PhoenixIxError> {
+    if params.global_trader_index().is_empty() {
+        return Err(PhoenixIxError::EmptyGlobalTraderIndex);
+    }
+    if params.active_trader_buffer().is_empty() {
+        return Err(PhoenixIxError::EmptyActiveTraderBuffer);
+    }
+    Ok(())
+}
+
+#[derive(BorshSerialize)]
+struct UncrossCrankData {
+    match_limit: u64,
+}
+
+fn encode_uncross_crank(params: &UncrossCrankParams) -> Vec<u8> {
+    let mut data = Vec::new();
+    data.extend_from_slice(&uncross_crank_discriminant());
+    data.extend_from_slice(
+        &to_vec(&UncrossCrankData {
+            match_limit: params.match_limit(),
+        })
+        .expect("serialization should not fail"),
+    );
+    data
+}
+
+fn build_accounts(params: &UncrossCrankParams) -> Vec<AccountMeta> {
+    let mut accounts = Vec::new();
+
+    // LogAccountGroupAccounts
+    accounts.push(AccountMeta::readonly(*PHOENIX_PROGRAM_ID));
+    accounts.push(AccountMeta::readonly(*PHOENIX_LOG_AUTHORITY));
+
+    // MaintenanceInstructionGroupAccounts
+    accounts.push(AccountMeta::writable(*PHOENIX_GLOBAL_CONFIGURATION));
+    accounts.push(AccountMeta::writable(params.perp_asset_map()));
+
+    for addr in params.global_trader_index() {
+        accounts.push(AccountMeta::writable(*addr));
+    }
+
+    for addr in params.active_trader_buffer() {
+        accounts.push(AccountMeta::writable(*addr));
+    }
+
+    accounts.push(AccountMeta::writable(params.orderbook()));
+    accounts.push(AccountMeta::writable(params.spline_collection()));
+
+    accounts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_uncross_crank_ix() {
+        let params = UncrossCrankParams::builder()
+            .perp_asset_map(Pubkey::new_unique())
+            .orderbook(Pubkey::new_unique())
+            .spline_collection(Pubkey::new_unique())
+            .global_trader_index(vec![Pubkey::new_unique()])
+            .active_trader_buffer(vec![Pubkey::new_unique()])
+            .match_limit(5)
+            .build()
+            .unwrap();
+
+        let ix = create_uncross_crank_ix(params).unwrap();
+
+        assert_eq!(ix.program_id, *PHOENIX_PROGRAM_ID);
+        assert_eq!(ix.accounts.len(), 8);
+        assert_eq!(&ix.data[..8], &uncross_crank_discriminant());
+        assert_eq!(u64::from_le_bytes(ix.data[8..16].try_into().unwrap()), 5);
+    }
+
+    #[test]
+    fn test_uncross_crank_defaults_match_limit() {
+        let params = UncrossCrankParams::builder()
+            .perp_asset_map(Pubkey::new_unique())
+            .orderbook(Pubkey::new_unique())
+            .spline_collection(Pubkey::new_unique())
+            .global_trader_index(vec![Pubkey::new_unique()])
+            .active_trader_buffer(vec![Pubkey::new_unique()])
+            .build()
+            .unwrap();
+
+        assert_eq!(params.match_limit(), DEFAULT_MATCH_LIMIT);
+    }
+}

--- a/rust/sdk/src/lib.rs
+++ b/rust/sdk/src/lib.rs
@@ -41,6 +41,7 @@
 pub mod ix;
 #[path = "../../math/src/lib.rs"]
 pub mod math;
+#[cfg(feature = "types")]
 #[path = "../../types/src/lib.rs"]
 pub mod types;
 
@@ -55,6 +56,7 @@ pub mod phoenix_rise_math {
     };
 }
 
+#[cfg(feature = "types")]
 pub mod phoenix_rise_types {
     pub use crate::types::{
         accounts, auth, candles, client, conversions, core, exchange, exchange_ws, funding,
@@ -64,30 +66,50 @@ pub mod phoenix_rise_types {
     };
 }
 
+#[cfg(feature = "sdk")]
 pub mod accounts;
+#[cfg(feature = "sdk")]
 pub mod api;
+#[cfg(feature = "sdk")]
 mod auth;
+#[cfg(feature = "sdk")]
 mod auth_lifecycle;
+#[cfg(feature = "sdk")]
 mod auth_signers;
+#[cfg(feature = "sdk")]
 mod client;
+#[cfg(feature = "sdk")]
 mod env;
+#[cfg(feature = "sdk")]
 mod exchange_cache;
+#[cfg(feature = "sdk")]
 mod flight_client;
+#[cfg(feature = "sdk")]
 mod hawkeye_client;
+#[cfg(feature = "sdk")]
 mod http_client;
+#[cfg(feature = "sdk")]
 mod order_tickets;
+#[cfg(feature = "test-fixture")]
+pub mod test_fixture;
+#[cfg(feature = "sdk")]
 mod transport;
+#[cfg(feature = "sdk")]
 mod tx_builder;
+#[cfg(feature = "sdk")]
 mod ws_client;
 
 // Re-export main types
+#[cfg(feature = "sdk")]
 pub use accounts::{AccountDataFetcher, PhoenixAccountClient, PhoenixAccountClientError};
+#[cfg(feature = "sdk")]
 pub use api::{
     CandlesClient, CollateralClient, ExchangeClient, FundingClient, InviteClient, MarketsClient,
     OrdersClient, TradersClient, TradesClient,
 };
-#[cfg(feature = "solana-keypair")]
+#[cfg(all(feature = "sdk", feature = "solana-keypair"))]
 pub use auth::PhoenixWalletSessionManager;
+#[cfg(feature = "sdk")]
 pub use auth::{
     AuthError, AuthSession, AuthSessionSnapshot, AuthSessionStore, FileAuthSessionStore,
     MemoryAuthSessionStore, PhoenixAuthSigner, PhoenixHttpAuthConfig, PhoenixMemorySessionManager,
@@ -95,32 +117,44 @@ pub use auth::{
     PhoenixSessionManager, PhoenixWalletNonce, PhoenixWalletNonceRequest,
     PhoenixWalletTransactionChallenge, default_auth_session_store_path, is_auth_recovery_error,
 };
+#[cfg(feature = "sdk")]
 pub use auth_lifecycle::{AuthLifecycleError, AuthLifecycleErrorReason, AuthLifecycleState};
-#[cfg(feature = "ed25519-dalek")]
+#[cfg(all(feature = "sdk", feature = "ed25519-dalek"))]
 pub use auth_signers::PhoenixEd25519ServiceAuthSigner;
+#[cfg(feature = "sdk")]
 pub use auth_signers::{
     PhoenixAuthSignerKind, PhoenixHttpAuthConfigSignerExt, PhoenixHttpClientBuilderSignerExt,
     PhoenixServiceAccountCredential,
 };
-#[cfg(feature = "solana-keypair")]
+#[cfg(all(feature = "sdk", feature = "solana-keypair"))]
 pub use auth_signers::{PhoenixSolanaKeypairAuthSigner, default_solana_keypair_path};
+#[cfg(feature = "sdk")]
 pub use client::PhoenixClient;
+#[cfg(feature = "sdk")]
 pub use env::PhoenixEnv;
+#[cfg(feature = "sdk")]
 pub use exchange_cache::{
     ExchangeCacheApplyError, ExchangeCacheEvent, ExchangeCacheExchangeChangeKind,
     ExchangeCacheMarketChangeKind, ExchangeCacheSnapshotSource, ExchangeInstructionContext,
     PhoenixExchangeCacheStore,
 };
+#[cfg(feature = "sdk")]
 pub use flight_client::PhoenixFlightClient;
+#[cfg(feature = "sdk")]
 pub use hawkeye_client::{HawkeyeSimulation, PhoenixHawkeyeClient, PhoenixHawkeyeClientError};
+#[cfg(feature = "sdk")]
 pub use http_client::{PhoenixHttpClient, PhoenixHttpClientBuilder, RateLimitRetryConfig};
+#[cfg(feature = "sdk")]
 pub use order_tickets::{
     BracketLeg, BracketLegExecution, BracketLegOrders, BracketLegSize, BracketLegTicket,
     DEFAULT_BRACKET_LEG_SLIPPAGE_BPS, LimitOrderTicket, LimitOrderTicketBuilder, MarketOrderTicket,
     MarketOrderTicketBuilder, OrderTicketMetadata,
 };
+#[cfg(feature = "types")]
 pub use rust_decimal::Decimal;
+#[cfg(feature = "sdk")]
 pub use tx_builder::{PhoenixTxBuilder, PhoenixTxBuilderError};
+#[cfg(feature = "sdk")]
 pub use ws_client::{PhoenixWSClient, SubscriptionHandle, WsConnectionStatus, WsSubscriptionEvent};
 
 pub use crate::phoenix_rise_ix::{
@@ -144,6 +178,7 @@ pub use crate::phoenix_rise_ix::{
     phoenix_log_authority, phoenix_program_id, resolve_phoenix_instruction_addresses_for_env,
 };
 // Re-export useful types from the types crate
+#[cfg(feature = "types")]
 pub use crate::phoenix_rise_types::{
     AllMidsData, ApiCandle, AuthoritySet, CROSS_MARGIN_SUBACCOUNT_IDX,
     CancelConditionalOrderRequest, CancelStopLossOrderRequest, CandleData, CandlesQueryParams,
@@ -179,4 +214,5 @@ pub use crate::phoenix_rise_types::{
     UserLiquidationHistoryResponse, UserLiquidationHistoryRole, UserLiquidationHistoryType,
     WalletNonceResponse,
 };
+#[cfg(feature = "types")]
 pub use crate::types::conversions::*;

--- a/rust/sdk/src/test_fixture.rs
+++ b/rust/sdk/src/test_fixture.rs
@@ -1,0 +1,1424 @@
+use std::collections::{HashMap, HashSet};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::thread;
+use std::time::{Duration, Instant, SystemTime};
+
+use base64::Engine;
+use borsh::{BorshSerialize, to_vec};
+use litesvm::LiteSVM;
+use litesvm::types::{FailedTransactionMetadata, TransactionMetadata};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use solana_commitment_config::CommitmentConfig;
+use solana_instruction::{AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_pubkey::Pubkey;
+use solana_rpc_client::rpc_client::RpcClient;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+use crate::types::{
+    AuthoritySetView, ExchangeKeysView, ExchangeMarketConfig, ExchangeRiskFactors, ExchangeView,
+    MarketStatus, PhoenixMetadata,
+};
+
+pub const DEFAULT_SDK_LOCALNET_FIXTURE_JSON: &str =
+    include_str!("../../test-fixtures/default-localnet.json");
+pub const REQUIRED_PROGRAM_ARTIFACT_ENV: &str = "RISE_SDK_LOCALNET_REQUIRE_PROGRAMS";
+pub const PHOENIX_REPO_ROOT_ENV: &str = "PHOENIX_REPO_ROOT";
+pub const ETERNAL_PROGRAM_ENV: &str = "RISE_SDK_LOCALNET_ETERNAL_SO";
+pub const EMBER_PROGRAM_ENV: &str = "RISE_SDK_LOCALNET_EMBER_SO";
+pub const HAWKEYE_PROGRAM_ENV: &str = "RISE_SDK_LOCALNET_HAWKEYE_SO";
+pub const FLIGHT_PROGRAM_ENV: &str = "RISE_SDK_LOCALNET_FLIGHT_SO";
+pub const PHOENIX_MAINNET_BPF_PROGRAMS_ENV: &str = "PHOENIX_MAINNET_BPF_PROGRAMS";
+pub const PHOENIX_MAINNET_BPF_PROGRAM_CACHE_DIR_ENV: &str = "PHOENIX_MAINNET_BPF_PROGRAM_CACHE_DIR";
+pub const PHOENIX_MAINNET_RPC_URL_ENV: &str = "PHOENIX_MAINNET_RPC_URL";
+pub const PHOENIX_RPC_URL_ENV: &str = "PHOENIX_RPC_URL";
+pub const DEFAULT_MAINNET_RPC_URL: &str = "https://api.mainnet-beta.solana.com";
+
+const BPF_LOADER_UPGRADEABLE_ID: Pubkey =
+    solana_pubkey::pubkey!("BPFLoaderUpgradeab1e11111111111111111111111");
+const MAINNET_BPF_CACHE_FINGERPRINT: &str = "mainnet-bpf-programs.fingerprint";
+const MAINNET_BPF_CACHE_LOCK: &str = ".mainnet-bpf-programs.lock";
+const MAINNET_BPF_CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+const MAINNET_BPF_CACHE_WAIT_TIMEOUT: Duration = Duration::from_secs(300);
+const PROGRAMDATA_METADATA_LEN: usize = 45;
+const SPL_TOKEN_MINT_TO_DISCRIMINANT: u8 = 7;
+const FIXTURE_PRICE_EXPONENT: u8 = 3;
+const FIXTURE_ORACLE_UPDATE_TIMESTAMP_BASE: u64 = 1_900_000_000;
+const MICRO_FEE_DENOMINATOR: f64 = 1_000_000.0;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SdkLocalnetFixtureError {
+    #[error("invalid pubkey `{value}`: {reason}")]
+    InvalidPubkey { value: String, reason: String },
+    #[error("invalid base64 data for instruction `{instruction}`: {source}")]
+    InvalidInstructionData {
+        instruction: String,
+        source: base64::DecodeError,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SdkLocalnetFixture {
+    pub schema_version: u32,
+    pub name: String,
+    pub keypair_base_seed: String,
+    pub keypair_derivation: String,
+    pub programs: ProgramAddresses,
+    pub addresses: FixtureAddresses,
+    pub mints: Vec<FixtureMint>,
+    pub signers: Vec<FixtureSigner>,
+    pub markets: Vec<FixtureMarket>,
+    pub actors: Vec<FixtureActor>,
+    pub setup_transactions: Vec<FixtureTransaction>,
+    pub action_templates: Vec<FixtureTransaction>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProgramAddresses {
+    pub phoenix_eternal: String,
+    pub ember: String,
+    pub spl_token: String,
+    pub associated_token: String,
+    pub system: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FixtureAddresses {
+    pub global_config: String,
+    pub log_authority: String,
+    pub perp_asset_map: String,
+    pub withdraw_queue: String,
+    pub global_vault: String,
+    pub global_trader_index: Vec<String>,
+    pub active_trader_buffer: Vec<String>,
+    pub ember_state: String,
+    pub ember_vault: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FixtureMint {
+    pub name: String,
+    pub seed: String,
+    pub pubkey: String,
+    pub decimals: u8,
+    pub role: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FixtureSigner {
+    pub name: String,
+    pub role: String,
+    pub seed: String,
+    pub pubkey: String,
+    pub initial_lamports: u64,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FixtureMarket {
+    pub symbol: String,
+    pub orderbook: String,
+    pub spline: String,
+    pub signer_seed: String,
+    #[serde(default)]
+    pub default_taker_fee_micro: u32,
+    #[serde(default)]
+    pub default_maker_fee_micro: i32,
+    pub base_lot_decimals: i8,
+    pub tick_size_in_quote_lots_per_base_lot: u64,
+    pub initial_mark_price_atoms: u64,
+    pub initial_spot_price_atoms: u64,
+    pub liquidity: FixtureLiquidity,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FixtureLiquidity {
+    pub bids: Vec<FixtureLiquidityLevel>,
+    pub asks: Vec<FixtureLiquidityLevel>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FixtureLiquidityLevel {
+    pub price_usd: String,
+    pub base_quantity: String,
+}
+
+impl FixtureMarket {
+    pub fn price_usd_to_ticks(&self, price_usd: f64, quote_decimals: u8) -> u64 {
+        self.price_to_ticks(FixturePrice::from_usd(price_usd), quote_decimals)
+    }
+
+    pub fn price_to_ticks(&self, price: FixturePrice, quote_decimals: u8) -> u64 {
+        let scaled_value = if price.expo < quote_decimals {
+            let factor = 10_u64
+                .checked_pow((quote_decimals - price.expo) as u32)
+                .expect("price scale factor should not overflow");
+            price
+                .value
+                .checked_mul(factor)
+                .expect("scaled price should not overflow")
+        } else {
+            let factor = 10_u64
+                .checked_pow((price.expo - quote_decimals) as u32)
+                .expect("price scale factor should not overflow");
+            price.value / factor
+        };
+
+        if self.base_lot_decimals >= 0 {
+            let base_lots_per_unit = 10_u64
+                .checked_pow(self.base_lot_decimals as u32)
+                .expect("base-lot scale should not overflow");
+            scaled_value
+                .checked_div(
+                    self.tick_size_in_quote_lots_per_base_lot
+                        .checked_mul(base_lots_per_unit)
+                        .expect("tick denominator should not overflow"),
+                )
+                .expect("tick denominator should not be zero")
+        } else {
+            let base_units_per_lot = 10_u64
+                .checked_pow((-self.base_lot_decimals) as u32)
+                .expect("base-lot scale should not overflow");
+            scaled_value
+                .checked_mul(base_units_per_lot)
+                .expect("tick numerator should not overflow")
+                .checked_div(self.tick_size_in_quote_lots_per_base_lot)
+                .expect("tick denominator should not be zero")
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, BorshSerialize)]
+pub struct FixturePrice {
+    pub value: u64,
+    pub expo: u8,
+}
+
+impl FixturePrice {
+    pub fn new(value: u64, expo: u8) -> Self {
+        assert!(value > 0, "fixture price must be positive");
+        Self { value, expo }
+    }
+
+    pub fn from_usd(price_usd: f64) -> Self {
+        assert!(
+            price_usd.is_finite() && price_usd > 0.0,
+            "fixture USD price must be a positive finite value"
+        );
+        let scale = 10_u64.pow(FIXTURE_PRICE_EXPONENT as u32) as f64;
+        let value = (price_usd * scale).round();
+        assert!(
+            value > 0.0 && value <= u64::MAX as f64,
+            "fixture USD price is out of range"
+        );
+        Self::new(value as u64, FIXTURE_PRICE_EXPONENT)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct FixtureOraclePriceUpdate {
+    pub symbol: String,
+    pub new_exchange_perp_price: Option<FixturePrice>,
+    pub new_exchange_spot_price: FixturePrice,
+}
+
+impl FixtureOraclePriceUpdate {
+    pub fn new(
+        symbol: impl Into<String>,
+        new_exchange_perp_price: Option<FixturePrice>,
+        new_exchange_spot_price: FixturePrice,
+    ) -> Self {
+        Self {
+            symbol: symbol.into(),
+            new_exchange_perp_price,
+            new_exchange_spot_price,
+        }
+    }
+
+    pub fn mark_and_spot(symbol: impl Into<String>, price: FixturePrice) -> Self {
+        Self::new(symbol, Some(price), price)
+    }
+
+    pub fn mark_and_spot_usd(symbol: impl Into<String>, price_usd: f64) -> Self {
+        Self::mark_and_spot(symbol, FixturePrice::from_usd(price_usd))
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FixtureActor {
+    pub name: String,
+    pub signer: String,
+    pub seed: String,
+    pub pubkey: String,
+    pub trader_account: String,
+    pub fake_usdc_token_account: String,
+    pub phoenix_token_account: String,
+    pub subaccount_index: u8,
+    pub initial_usdc_atoms: u64,
+    pub phoenix_deposit_atoms: u64,
+    pub capabilities: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FixtureTransaction {
+    pub name: String,
+    pub description: String,
+    pub signer_seeds: Vec<String>,
+    pub instructions: Vec<SerializedInstruction>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SerializedInstruction {
+    pub name: String,
+    pub program_id: String,
+    pub accounts: Vec<SerializedAccountMeta>,
+    pub data_base64: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SerializedAccountMeta {
+    pub pubkey: String,
+    pub is_signer: bool,
+    pub is_writable: bool,
+}
+
+pub fn default_sdk_localnet_fixture() -> Result<SdkLocalnetFixture, serde_json::Error> {
+    serde_json::from_str(DEFAULT_SDK_LOCALNET_FIXTURE_JSON)
+}
+
+pub fn sdk_localnet_seed_bytes(keypair_base_seed: &str, seed: &str) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(format!("{keypair_base_seed}-{seed}"));
+    hasher.finalize().into()
+}
+
+pub fn default_sdk_localnet_seed_bytes(seed: &str) -> [u8; 32] {
+    sdk_localnet_seed_bytes("rise-sdk-localnet-v1", seed)
+}
+
+pub fn decode_fixture_instruction(
+    instruction: &SerializedInstruction,
+) -> Result<Instruction, SdkLocalnetFixtureError> {
+    let program_id = parse_pubkey(&instruction.program_id)?;
+    let accounts = instruction
+        .accounts
+        .iter()
+        .map(|account| {
+            Ok(AccountMeta {
+                pubkey: parse_pubkey(&account.pubkey)?,
+                is_signer: account.is_signer,
+                is_writable: account.is_writable,
+            })
+        })
+        .collect::<Result<Vec<_>, SdkLocalnetFixtureError>>()?;
+    let data = base64::engine::general_purpose::STANDARD
+        .decode(&instruction.data_base64)
+        .map_err(|source| SdkLocalnetFixtureError::InvalidInstructionData {
+            instruction: instruction.name.clone(),
+            source,
+        })?;
+
+    Ok(Instruction {
+        program_id,
+        accounts,
+        data,
+    })
+}
+
+pub fn parse_pubkey(value: &str) -> Result<Pubkey, SdkLocalnetFixtureError> {
+    Pubkey::from_str(value).map_err(|source| SdkLocalnetFixtureError::InvalidPubkey {
+        value: value.to_string(),
+        reason: source.to_string(),
+    })
+}
+
+pub fn parse_pubkeys(values: &[String]) -> Vec<Pubkey> {
+    values
+        .iter()
+        .map(|value| parse_pubkey(value).expect("fixture pubkey should parse"))
+        .collect()
+}
+
+pub fn phoenix_metadata_from_fixture(fixture: &SdkLocalnetFixture) -> PhoenixMetadata {
+    let payer = fixture
+        .signers
+        .iter()
+        .find(|signer| signer.seed == "payer")
+        .expect("payer signer should exist")
+        .pubkey
+        .clone();
+    let authorities = AuthoritySetView {
+        root_authority: payer.clone(),
+        risk_authority: payer.clone(),
+        market_authority: payer.clone(),
+        oracle_authority: payer.clone(),
+    };
+    let keys = ExchangeKeysView {
+        program_id: None,
+        global_config: fixture.addresses.global_config.clone(),
+        current_authorities: authorities.clone(),
+        pending_authorities: authorities,
+        canonical_mint: fixture
+            .mints
+            .iter()
+            .find(|mint| mint.name == "phoenixCollateral")
+            .map(|mint| mint.pubkey.clone())
+            .unwrap_or_else(|| fixture.addresses.global_vault.clone()),
+        global_vault: fixture.addresses.global_vault.clone(),
+        perp_asset_map: fixture.addresses.perp_asset_map.clone(),
+        global_trader_index: fixture.addresses.global_trader_index.clone(),
+        active_trader_buffer: fixture.addresses.active_trader_buffer.clone(),
+        withdraw_queue: fixture.addresses.withdraw_queue.clone(),
+    };
+    let markets = fixture
+        .markets
+        .iter()
+        .enumerate()
+        .map(|(asset_id, market)| {
+            (
+                market.symbol.clone(),
+                ExchangeMarketConfig {
+                    symbol: market.symbol.clone(),
+                    asset_id: asset_id as u32,
+                    market_status: MarketStatus::Active,
+                    metadata: None,
+                    market_pubkey: market.orderbook.clone(),
+                    spline_pubkey: market.spline.clone(),
+                    tick_size: market.tick_size_in_quote_lots_per_base_lot,
+                    base_lots_decimals: market.base_lot_decimals,
+                    taker_fee: micro_fee_to_rate(market.default_taker_fee_micro),
+                    maker_fee: signed_micro_fee_to_rate(market.default_maker_fee_micro),
+                    leverage_tiers: Vec::new(),
+                    risk_factors: ExchangeRiskFactors::default(),
+                    funding_interval_seconds: 1,
+                    funding_period_seconds: 1,
+                    max_funding_rate_per_interval: 0.0,
+                    open_interest_cap_base_lots: 0_u64.into(),
+                    max_liquidation_size_base_lots: 0_u64.into(),
+                    isolated_only: false,
+                    stats_snapshot: None,
+                },
+            )
+        })
+        .collect();
+
+    PhoenixMetadata::new(ExchangeView { keys, markets })
+}
+
+fn micro_fee_to_rate(value: u32) -> f64 {
+    value as f64 / MICRO_FEE_DENOMINATOR
+}
+
+fn signed_micro_fee_to_rate(value: i32) -> f64 {
+    value as f64 / MICRO_FEE_DENOMINATOR
+}
+
+#[derive(Clone, Debug)]
+pub struct SdkLocalnetProgramPaths {
+    pub phoenix_eternal: PathBuf,
+    pub ember: PathBuf,
+    pub hawkeye: Option<PathBuf>,
+    pub flight: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SdkLocalnetProgram {
+    pub program_id: Pubkey,
+    pub path: PathBuf,
+}
+
+impl SdkLocalnetProgram {
+    pub fn new(program_id: Pubkey, path: impl Into<PathBuf>) -> Self {
+        Self {
+            program_id,
+            path: path.into(),
+        }
+    }
+}
+
+pub struct SdkLocalnetContext {
+    pub fixture: SdkLocalnetFixture,
+    pub svm: LiteSVM,
+    signers_by_seed: HashMap<String, Keypair>,
+    signer_seed_by_pubkey: HashMap<Pubkey, String>,
+    oracle_update_sequence: u64,
+}
+
+impl SdkLocalnetContext {
+    pub fn new(fixture: SdkLocalnetFixture, program_paths: SdkLocalnetProgramPaths) -> Self {
+        Self::new_with_programs(fixture, program_paths, [])
+    }
+
+    pub fn new_with_programs(
+        fixture: SdkLocalnetFixture,
+        program_paths: SdkLocalnetProgramPaths,
+        extra_programs: impl IntoIterator<Item = SdkLocalnetProgram>,
+    ) -> Self {
+        let mut svm = LiteSVM::new();
+
+        if should_load_mainnet_bpf_programs() && !running_in_ci() {
+            load_mainnet_protocol_programs(&mut svm, &fixture);
+        } else {
+            load_program(
+                &mut svm,
+                &fixture.programs.phoenix_eternal,
+                &program_paths.phoenix_eternal,
+            );
+            load_program(&mut svm, &fixture.programs.ember, &program_paths.ember);
+            if let Some(hawkeye) = program_paths.hawkeye.as_ref() {
+                load_program(
+                    &mut svm,
+                    &crate::phoenix_rise_ix::HAWKEYE_PROGRAM_ID.to_string(),
+                    hawkeye,
+                );
+            }
+            if let Some(flight) = program_paths.flight.as_ref() {
+                load_program(
+                    &mut svm,
+                    &crate::phoenix_rise_ix::flight::FLIGHT_PROGRAM_ID.to_string(),
+                    flight,
+                );
+            }
+        }
+
+        for program in extra_programs {
+            load_program(&mut svm, &program.program_id.to_string(), &program.path);
+        }
+
+        let mut signers_by_seed = HashMap::new();
+        let mut signer_seed_by_pubkey = HashMap::new();
+        for signer_config in &fixture.signers {
+            let keypair = Keypair::new_from_array(sdk_localnet_seed_bytes(
+                &fixture.keypair_base_seed,
+                &signer_config.seed,
+            ));
+            assert_eq!(
+                keypair.pubkey(),
+                parse_pubkey(&signer_config.pubkey).expect("fixture pubkey should parse"),
+                "derived signer {} should match fixture pubkey",
+                signer_config.name
+            );
+            signer_seed_by_pubkey.insert(keypair.pubkey(), signer_config.seed.clone());
+            signers_by_seed.insert(signer_config.seed.clone(), keypair);
+        }
+
+        for signer_config in &fixture.signers {
+            if signer_config.initial_lamports == 0 {
+                continue;
+            }
+            let signer = signers_by_seed
+                .get(&signer_config.seed)
+                .expect("signer should exist");
+            svm.airdrop(&signer.pubkey(), signer_config.initial_lamports)
+                .unwrap_or_else(|error| panic!("airdrop:{} failed: {error:?}", signer_config.name));
+        }
+
+        Self {
+            fixture,
+            svm,
+            signers_by_seed,
+            signer_seed_by_pubkey,
+            oracle_update_sequence: 1,
+        }
+    }
+
+    pub fn load_program_from_path(&mut self, program_id: &Pubkey, path: &Path) {
+        let bytes = std::fs::read(path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+        self.svm
+            .add_program(*program_id, &bytes)
+            .unwrap_or_else(|error| panic!("failed to load {}: {error:?}", path.display()));
+    }
+
+    pub fn load_program(&mut self, program: SdkLocalnetProgram) {
+        self.load_program_from_path(&program.program_id, &program.path);
+    }
+
+    pub fn execute_setup(&mut self) {
+        for transaction in self.fixture.setup_transactions.clone() {
+            self.send_fixture_transaction(&transaction.name);
+        }
+    }
+
+    pub fn add_signer(&mut self, seed: &str, initial_lamports: u64) -> Pubkey {
+        let keypair = Keypair::new_from_array(sdk_localnet_seed_bytes(
+            &self.fixture.keypair_base_seed,
+            seed,
+        ));
+        let pubkey = keypair.pubkey();
+        self.signer_seed_by_pubkey.insert(pubkey, seed.to_string());
+        self.signers_by_seed.insert(seed.to_string(), keypair);
+        if initial_lamports > 0 {
+            self.svm
+                .airdrop(&pubkey, initial_lamports)
+                .unwrap_or_else(|error| panic!("airdrop:{seed} failed: {error:?}"));
+        }
+        pubkey
+    }
+
+    pub fn init_flight(&mut self, max_fee_cap_bps: u64) {
+        let global_state = crate::phoenix_rise_ix::flight::get_flight_global_state_address();
+        if self.svm.get_account(&global_state).is_some() {
+            return;
+        }
+        self.send_instructions(
+            vec![flight_init_ix(self.signer_pubkey("payer"), max_fee_cap_bps)],
+            "payer",
+            "flight-init",
+        );
+    }
+
+    pub fn register_flight_builder(&mut self, builder: &FixtureActor, fee_bps: u64) {
+        let ix = crate::phoenix_rise_ix::flight::create_register_builder_ix(
+            crate::phoenix_rise_ix::flight::RegisterBuilderParams::builder()
+                .trader_authority(parse_pubkey(&builder.pubkey).unwrap())
+                .trader_account(parse_pubkey(&builder.trader_account).unwrap())
+                .subaccount_index(builder.subaccount_index)
+                .fee_bps(fee_bps)
+                .build()
+                .unwrap(),
+        )
+        .unwrap()
+        .into();
+        self.send_instructions(vec![ix], &builder.seed, "flight-register-builder");
+    }
+
+    pub fn setup_flight_builder(
+        &mut self,
+        actor_name: &str,
+        max_fee_cap_bps: u64,
+        fee_bps: u64,
+    ) -> FixtureActor {
+        self.init_flight(max_fee_cap_bps);
+        let actor = self.actor(actor_name);
+        self.register_flight_builder(&actor, fee_bps);
+        actor
+    }
+
+    pub fn move_market_price_usd(&mut self, symbol: &str, price_usd: f64) {
+        let price = FixturePrice::from_usd(price_usd);
+        let quote_decimals = self.fixture_mint("fakeUsdc").decimals;
+        let market = self.market(symbol);
+        let price_ticks = market.price_to_ticks(price, quote_decimals);
+
+        self.update_oracle_prices(&[FixtureOraclePriceUpdate::mark_and_spot(symbol, price)]);
+        self.update_spline_price_ticks(symbol, price_ticks);
+    }
+
+    pub fn update_oracle_prices(&mut self, updates: &[FixtureOraclePriceUpdate]) {
+        let update_timestamp = self.next_fixture_oracle_update_timestamp();
+        self.update_oracle_prices_at(update_timestamp, updates);
+    }
+
+    pub fn update_oracle_prices_at(
+        &mut self,
+        update_timestamp: u64,
+        updates: &[FixtureOraclePriceUpdate],
+    ) {
+        assert!(
+            !updates.is_empty(),
+            "fixture oracle price update requires at least one price"
+        );
+        let mut ix = self.fixture_instruction("oracleSetPrices", "updateOraclePrices");
+        ix.data = oracle_price_update_data(update_timestamp, updates);
+        self.send_instructions(vec![ix], "price-oracle", "oracle-update-prices");
+    }
+
+    pub fn update_spline_price_ticks(&mut self, symbol: &str, new_mid_price_ticks: u64) {
+        assert!(
+            new_mid_price_ticks > 0,
+            "fixture spline price must be positive"
+        );
+        let instruction_name = format!("update{}SplinePrice", symbol.to_ascii_uppercase());
+        let mut ix = self.fixture_instruction("splineUpdatePrices", &instruction_name);
+        ix.data = spline_price_update_data(new_mid_price_ticks);
+        self.send_instructions(
+            vec![ix],
+            "spline-trader",
+            &format!("spline-update-{}-price", symbol.to_ascii_lowercase()),
+        );
+    }
+
+    pub fn airdrop_usdc_to_actor(&mut self, actor_name: &str, amount_atoms: u64) {
+        let actor = self.actor(actor_name);
+        self.mint_fake_usdc_to_token_account(
+            parse_pubkey(&actor.fake_usdc_token_account).unwrap(),
+            amount_atoms,
+        );
+    }
+
+    pub fn mint_fake_usdc_to_token_account(&mut self, token_account: Pubkey, amount_atoms: u64) {
+        let mint = self.fixture_mint("fakeUsdc");
+        let mint_pubkey = parse_pubkey(&mint.pubkey).unwrap();
+        let authority = self.signer_pubkey("payer");
+        let mut data = Vec::with_capacity(9);
+        data.push(SPL_TOKEN_MINT_TO_DISCRIMINANT);
+        data.extend_from_slice(&amount_atoms.to_le_bytes());
+
+        self.send_instructions(
+            vec![Instruction {
+                program_id: crate::phoenix_rise_ix::SPL_TOKEN_PROGRAM_ID,
+                accounts: vec![
+                    AccountMeta::new(mint_pubkey, false),
+                    AccountMeta::new(token_account, false),
+                    AccountMeta::new_readonly(authority, true),
+                ],
+                data,
+            }],
+            "payer",
+            "mint-fake-usdc",
+        );
+    }
+
+    pub fn send_fixture_transaction(&mut self, name: &str) {
+        let transaction = self
+            .fixture
+            .setup_transactions
+            .iter()
+            .chain(self.fixture.action_templates.iter())
+            .find(|transaction| transaction.name == name)
+            .unwrap_or_else(|| panic!("missing fixture transaction {name}"))
+            .clone();
+        let fee_payer_seed = transaction
+            .signer_seeds
+            .iter()
+            .find(|seed| seed.as_str() == "payer")
+            .or_else(|| transaction.signer_seeds.first())
+            .expect("fixture transaction should list signer seeds")
+            .clone();
+
+        for instruction in transaction.instructions {
+            self.send_instructions(
+                vec![decode_fixture_instruction(&instruction).unwrap()],
+                &fee_payer_seed,
+                &format!("{}:{}", transaction.name, instruction.name),
+            );
+        }
+    }
+
+    fn fixture_instruction(&self, transaction_name: &str, instruction_name: &str) -> Instruction {
+        let transaction = self
+            .fixture
+            .setup_transactions
+            .iter()
+            .chain(self.fixture.action_templates.iter())
+            .find(|transaction| transaction.name == transaction_name)
+            .unwrap_or_else(|| panic!("missing fixture transaction {transaction_name}"));
+        let instruction = transaction
+            .instructions
+            .iter()
+            .find(|instruction| instruction.name == instruction_name)
+            .unwrap_or_else(|| {
+                panic!("missing fixture instruction {transaction_name}:{instruction_name}")
+            });
+        decode_fixture_instruction(instruction).unwrap()
+    }
+
+    fn next_fixture_oracle_update_timestamp(&mut self) -> u64 {
+        let timestamp = FIXTURE_ORACLE_UPDATE_TIMESTAMP_BASE + self.oracle_update_sequence;
+        self.oracle_update_sequence += 1;
+        timestamp
+    }
+
+    pub fn send_instructions(
+        &mut self,
+        instructions: Vec<Instruction>,
+        fee_payer_seed: &str,
+        label: &str,
+    ) {
+        self.send_instructions_with_metadata(instructions, fee_payer_seed, label);
+    }
+
+    pub fn send_instructions_with_metadata(
+        &mut self,
+        instructions: Vec<Instruction>,
+        fee_payer_seed: &str,
+        label: &str,
+    ) -> TransactionMetadata {
+        self.try_send_instructions_with_metadata(instructions, fee_payer_seed)
+            .unwrap_or_else(|error| {
+                panic!(
+                    "LiteSVM transaction failed for {label}: {:?}\n{}",
+                    error.err,
+                    error.meta.logs.join("\n")
+                )
+            })
+    }
+
+    pub fn try_send_instructions_with_metadata(
+        &mut self,
+        instructions: Vec<Instruction>,
+        fee_payer_seed: &str,
+    ) -> Result<TransactionMetadata, FailedTransactionMetadata> {
+        let fee_payer = self
+            .signers_by_seed
+            .get(fee_payer_seed)
+            .unwrap_or_else(|| panic!("missing fee payer signer {fee_payer_seed}"));
+        let mut signer_pubkeys = HashSet::new();
+        let mut signers = Vec::new();
+        signer_pubkeys.insert(fee_payer.pubkey());
+        signers.push(fee_payer);
+
+        for instruction in &instructions {
+            for account in &instruction.accounts {
+                if !account.is_signer || signer_pubkeys.contains(&account.pubkey) {
+                    continue;
+                }
+                let seed = self
+                    .signer_seed_by_pubkey
+                    .get(&account.pubkey)
+                    .unwrap_or_else(|| panic!("missing signer for {}", account.pubkey));
+                let signer = self
+                    .signers_by_seed
+                    .get(seed)
+                    .unwrap_or_else(|| panic!("missing signer seed {seed}"));
+                signer_pubkeys.insert(account.pubkey);
+                signers.push(signer);
+            }
+        }
+
+        self.svm.expire_blockhash();
+        let tx = Transaction::new_signed_with_payer(
+            &instructions,
+            Some(&fee_payer.pubkey()),
+            &signers,
+            self.svm.latest_blockhash(),
+        );
+        self.svm.send_transaction(tx)
+    }
+
+    pub fn signer_pubkey(&self, seed: &str) -> Pubkey {
+        self.signers_by_seed
+            .get(seed)
+            .unwrap_or_else(|| panic!("missing signer {seed}"))
+            .pubkey()
+    }
+
+    pub fn actor(&self, name: &str) -> FixtureActor {
+        self.fixture
+            .actors
+            .iter()
+            .find(|actor| actor.name == name)
+            .unwrap_or_else(|| panic!("missing actor {name}"))
+            .clone()
+    }
+
+    pub fn actor_pubkey(&self, name: &str) -> Pubkey {
+        parse_pubkey(&self.actor(name).pubkey).expect("actor pubkey should parse")
+    }
+
+    pub fn actor_trader(&self, name: &str) -> Pubkey {
+        parse_pubkey(&self.actor(name).trader_account).expect("actor trader should parse")
+    }
+
+    pub fn fixture_mint(&self, name: &str) -> FixtureMint {
+        self.fixture
+            .mints
+            .iter()
+            .find(|mint| mint.name == name)
+            .unwrap_or_else(|| panic!("missing fixture mint {name}"))
+            .clone()
+    }
+
+    pub fn fake_usdc_mint(&self) -> Pubkey {
+        parse_pubkey(&self.fixture_mint("fakeUsdc").pubkey).expect("fake USDC mint should parse")
+    }
+
+    pub fn phoenix_collateral_mint(&self) -> Pubkey {
+        parse_pubkey(&self.fixture_mint("phoenixCollateral").pubkey)
+            .expect("Phoenix collateral mint should parse")
+    }
+
+    pub fn market(&self, symbol: &str) -> FixtureMarket {
+        self.fixture
+            .markets
+            .iter()
+            .find(|market| market.symbol == symbol)
+            .unwrap_or_else(|| panic!("missing market {symbol}"))
+            .clone()
+    }
+
+    pub fn account_data(&self, address: &Pubkey) -> Vec<u8> {
+        self.svm
+            .get_account(address)
+            .unwrap_or_else(|| panic!("missing account {address}"))
+            .data
+    }
+
+    pub fn token_amount(&self, token_account: &Pubkey) -> u64 {
+        let data = self.account_data(token_account);
+        u64::from_le_bytes(data[64..72].try_into().unwrap())
+    }
+}
+
+pub fn sdk_localnet_vm_required() -> bool {
+    matches!(
+        std::env::var(REQUIRED_PROGRAM_ARTIFACT_ENV).as_deref(),
+        Ok("1") | Ok("true")
+    )
+}
+
+pub fn mainnet_bpf_programs_enabled() -> bool {
+    should_load_mainnet_bpf_programs() && !running_in_ci()
+}
+
+pub fn find_sdk_localnet_program_paths() -> Option<SdkLocalnetProgramPaths> {
+    if mainnet_bpf_programs_enabled() {
+        return Some(SdkLocalnetProgramPaths {
+            phoenix_eternal: PathBuf::new(),
+            ember: PathBuf::new(),
+            hawkeye: None,
+            flight: None,
+        });
+    }
+
+    let explicit = match (
+        std::env::var(ETERNAL_PROGRAM_ENV),
+        std::env::var(EMBER_PROGRAM_ENV),
+        std::env::var(HAWKEYE_PROGRAM_ENV),
+        std::env::var(FLIGHT_PROGRAM_ENV),
+    ) {
+        (Ok(phoenix_eternal), Ok(ember), hawkeye, flight) => Some(SdkLocalnetProgramPaths {
+            phoenix_eternal: PathBuf::from(phoenix_eternal),
+            ember: PathBuf::from(ember),
+            hawkeye: hawkeye.ok().map(PathBuf::from),
+            flight: flight.ok().map(PathBuf::from),
+        }),
+        _ => None,
+    };
+    if explicit.as_ref().is_some_and(program_paths_exist) {
+        return explicit;
+    }
+
+    for root in default_program_roots() {
+        for program_paths in [
+            SdkLocalnetProgramPaths {
+                phoenix_eternal: root.join("programs/target/deploy/phoenix_eternal.so"),
+                ember: root.join("programs/target/deploy/phoenix_ember_program.so"),
+                hawkeye: optional_program_path(
+                    root.join("programs/target/deploy/phoenix_hawkeye.so"),
+                ),
+                flight: optional_program_path(
+                    root.join("programs/target/deploy/phoenix_flight.so"),
+                ),
+            },
+            SdkLocalnetProgramPaths {
+                phoenix_eternal: root.join("target/deploy/phoenix_eternal.so"),
+                ember: root.join("target/deploy/phoenix_ember_program.so"),
+                hawkeye: optional_program_path(root.join("target/deploy/phoenix_hawkeye.so")),
+                flight: optional_program_path(root.join("target/deploy/phoenix_flight.so")),
+            },
+            SdkLocalnetProgramPaths {
+                phoenix_eternal: root.join("programs/eternal/target/deploy/phoenix_eternal.so"),
+                ember: root.join("programs/ember/target/deploy/phoenix_ember_program.so"),
+                hawkeye: optional_program_path(
+                    root.join("programs/phoenix-hawkeye/target/deploy/phoenix_hawkeye.so"),
+                ),
+                flight: optional_program_path(
+                    root.join("programs/flight/target/deploy/phoenix_flight.so"),
+                ),
+            },
+        ] {
+            if program_paths_exist(&program_paths) {
+                return Some(program_paths);
+            }
+        }
+    }
+
+    None
+}
+
+fn default_program_roots() -> Vec<PathBuf> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut roots = vec![
+        manifest_dir.join("../.."),
+        std::env::current_dir().unwrap_or_else(|_| manifest_dir.clone()),
+    ];
+    if let Ok(root) = std::env::var(PHOENIX_REPO_ROOT_ENV) {
+        roots.push(PathBuf::from(root));
+    }
+    roots.sort();
+    roots.dedup();
+    roots
+}
+
+fn program_paths_exist(paths: &SdkLocalnetProgramPaths) -> bool {
+    paths.phoenix_eternal.exists()
+        && paths.ember.exists()
+        && match paths.hawkeye.as_ref() {
+            Some(hawkeye) => hawkeye.exists(),
+            None => true,
+        }
+        && match paths.flight.as_ref() {
+            Some(flight) => flight.exists(),
+            None => true,
+        }
+}
+
+fn optional_program_path(path: PathBuf) -> Option<PathBuf> {
+    path.exists().then_some(path)
+}
+
+fn should_load_mainnet_bpf_programs() -> bool {
+    matches!(
+        std::env::var(PHOENIX_MAINNET_BPF_PROGRAMS_ENV).as_deref(),
+        Ok("1") | Ok("true")
+    )
+}
+
+fn running_in_ci() -> bool {
+    matches!(std::env::var("CI").as_deref(), Ok("1") | Ok("true"))
+}
+
+fn mainnet_rpc_url() -> String {
+    std::env::var(PHOENIX_MAINNET_RPC_URL_ENV)
+        .or_else(|_| std::env::var(PHOENIX_RPC_URL_ENV))
+        .unwrap_or_else(|_| DEFAULT_MAINNET_RPC_URL.to_string())
+}
+
+fn load_mainnet_protocol_programs(svm: &mut LiteSVM, fixture: &SdkLocalnetFixture) {
+    let specs = mainnet_protocol_programs(fixture);
+    let cache_dir = mainnet_bpf_program_cache_dir();
+    ensure_mainnet_program_cache(&cache_dir, &specs);
+
+    for spec in specs {
+        load_program_id(
+            svm,
+            spec.program_id,
+            &mainnet_cached_program_path(&cache_dir, &spec),
+        );
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct MainnetProgramSpec {
+    name: &'static str,
+    program_id: Pubkey,
+    file_name: &'static str,
+}
+
+fn mainnet_protocol_programs(fixture: &SdkLocalnetFixture) -> Vec<MainnetProgramSpec> {
+    vec![
+        MainnetProgramSpec {
+            name: "phoenix-eternal",
+            program_id: parse_pubkey(&fixture.programs.phoenix_eternal)
+                .expect("Phoenix program id should parse"),
+            file_name: "phoenix_eternal-mainnet.so",
+        },
+        MainnetProgramSpec {
+            name: "ember",
+            program_id: parse_pubkey(&fixture.programs.ember)
+                .expect("Ember program id should parse"),
+            file_name: "phoenix_ember_program-mainnet.so",
+        },
+        MainnetProgramSpec {
+            name: "hawkeye",
+            program_id: crate::phoenix_rise_ix::HAWKEYE_PROGRAM_ID,
+            file_name: "phoenix_hawkeye-mainnet.so",
+        },
+        MainnetProgramSpec {
+            name: "flight",
+            program_id: crate::phoenix_rise_ix::flight::FLIGHT_PROGRAM_ID,
+            file_name: "phoenix_flight-mainnet.so",
+        },
+    ]
+}
+
+pub fn mainnet_bpf_program_cache_dir() -> PathBuf {
+    if let Ok(cache_dir) = std::env::var(PHOENIX_MAINNET_BPF_PROGRAM_CACHE_DIR_ENV) {
+        return PathBuf::from(cache_dir);
+    }
+    if let Ok(root) = std::env::var(PHOENIX_REPO_ROOT_ENV) {
+        return PathBuf::from(root).join("target/deploy/.cache");
+    }
+    if let Ok(target_dir) = std::env::var("CARGO_TARGET_DIR") {
+        return PathBuf::from(target_dir).join("deploy/.cache");
+    }
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = manifest_dir.join("../..");
+    if repo_root.join("rise/rust/Cargo.toml").exists() {
+        return repo_root.join("target/deploy/.cache");
+    }
+
+    if let Ok(current_dir) = std::env::current_dir() {
+        if let Some(cargo_root) = find_cargo_target_root(&current_dir) {
+            return cargo_root.join("target/deploy/.cache");
+        }
+    }
+    if let Some(cargo_root) = find_cargo_target_root(&manifest_dir) {
+        return cargo_root.join("target/deploy/.cache");
+    }
+
+    std::env::current_dir()
+        .unwrap_or(manifest_dir)
+        .join("target/deploy/.cache")
+}
+
+fn find_cargo_target_root(start: &Path) -> Option<PathBuf> {
+    let mut current = if start.is_file() {
+        start.parent()?.to_path_buf()
+    } else {
+        start.to_path_buf()
+    };
+    let mut first_cargo_manifest = None;
+
+    loop {
+        if current.join("Cargo.lock").exists() || current.join("target").exists() {
+            return Some(current);
+        }
+        if current.join("Cargo.toml").exists() && first_cargo_manifest.is_none() {
+            first_cargo_manifest = Some(current.clone());
+        }
+        if !current.pop() {
+            break;
+        }
+    }
+
+    first_cargo_manifest
+}
+
+fn ensure_mainnet_program_cache(cache_dir: &Path, specs: &[MainnetProgramSpec]) {
+    fs::create_dir_all(cache_dir).unwrap_or_else(|error| {
+        panic!("create mainnet BPF cache {}: {error}", cache_dir.display())
+    });
+    if mainnet_program_cache_is_fresh(cache_dir, specs) {
+        return;
+    }
+
+    match try_acquire_mainnet_bpf_cache_lock(cache_dir) {
+        Ok(Some(_guard)) => {
+            if !mainnet_program_cache_is_fresh(cache_dir, specs) {
+                fetch_mainnet_program_cache(cache_dir, specs);
+            }
+        }
+        Ok(None) => wait_for_mainnet_program_cache(cache_dir, specs),
+        Err(error) => panic!(
+            "acquire mainnet BPF cache lock in {}: {error}",
+            cache_dir.display()
+        ),
+    }
+}
+
+fn mainnet_program_cache_is_fresh(cache_dir: &Path, specs: &[MainnetProgramSpec]) -> bool {
+    if specs
+        .iter()
+        .any(|spec| !mainnet_cached_program_path(cache_dir, spec).exists())
+    {
+        return false;
+    }
+
+    let fingerprint_path = cache_dir.join(MAINNET_BPF_CACHE_FINGERPRINT);
+    let fingerprint = match fs::read_to_string(&fingerprint_path) {
+        Ok(fingerprint) => fingerprint,
+        Err(_) => return false,
+    };
+    if specs.iter().any(|spec| {
+        !fingerprint.contains(spec.name) || !fingerprint.contains(&spec.program_id.to_string())
+    }) {
+        return false;
+    }
+
+    let modified = match fs::metadata(&fingerprint_path).and_then(|metadata| metadata.modified()) {
+        Ok(modified) => modified,
+        Err(_) => return false,
+    };
+    SystemTime::now()
+        .duration_since(modified)
+        .unwrap_or_default()
+        < MAINNET_BPF_CACHE_TTL
+}
+
+fn wait_for_mainnet_program_cache(cache_dir: &Path, specs: &[MainnetProgramSpec]) {
+    let started = Instant::now();
+    while started.elapsed() < MAINNET_BPF_CACHE_WAIT_TIMEOUT {
+        if mainnet_program_cache_is_fresh(cache_dir, specs) {
+            return;
+        }
+        let lock_path = cache_dir.join(MAINNET_BPF_CACHE_LOCK);
+        if !lock_path.exists() || mainnet_bpf_cache_lock_is_stale(&lock_path) {
+            match try_acquire_mainnet_bpf_cache_lock(cache_dir) {
+                Ok(Some(_guard)) => {
+                    if !mainnet_program_cache_is_fresh(cache_dir, specs) {
+                        fetch_mainnet_program_cache(cache_dir, specs);
+                    }
+                    return;
+                }
+                Ok(None) => {}
+                Err(error) => panic!(
+                    "acquire mainnet BPF cache lock in {}: {error}",
+                    cache_dir.display()
+                ),
+            }
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    panic!(
+        "timed out waiting for mainnet BPF cache in {}",
+        cache_dir.display()
+    );
+}
+
+struct MainnetBpfCacheLock {
+    path: PathBuf,
+}
+
+impl Drop for MainnetBpfCacheLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn try_acquire_mainnet_bpf_cache_lock(
+    cache_dir: &Path,
+) -> std::io::Result<Option<MainnetBpfCacheLock>> {
+    let lock_path = cache_dir.join(MAINNET_BPF_CACHE_LOCK);
+    match OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&lock_path)
+    {
+        Ok(mut file) => {
+            let _ = writeln!(
+                file,
+                "pid={}\nstarted={}",
+                std::process::id(),
+                unix_timestamp()
+            );
+            Ok(Some(MainnetBpfCacheLock { path: lock_path }))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            if mainnet_bpf_cache_lock_is_stale(&lock_path) {
+                let _ = fs::remove_file(&lock_path);
+                return try_acquire_mainnet_bpf_cache_lock(cache_dir);
+            }
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn mainnet_bpf_cache_lock_is_stale(lock_path: &Path) -> bool {
+    fs::metadata(lock_path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+        .is_some_and(|age| age > MAINNET_BPF_CACHE_WAIT_TIMEOUT)
+}
+
+fn fetch_mainnet_program_cache(cache_dir: &Path, specs: &[MainnetProgramSpec]) {
+    let cache_dir = cache_dir.to_path_buf();
+    let specs = specs.to_vec();
+    let handle = thread::Builder::new()
+        .name("rise-mainnet-bpf-fetch".to_string())
+        .spawn(move || fetch_mainnet_program_cache_inner(&cache_dir, &specs))
+        .expect("spawn mainnet BPF fetch thread");
+
+    if let Err(panic) = handle.join() {
+        std::panic::resume_unwind(panic);
+    }
+}
+
+fn fetch_mainnet_program_cache_inner(cache_dir: &Path, specs: &[MainnetProgramSpec]) {
+    let rpc_url = mainnet_rpc_url();
+    let client = RpcClient::new_with_commitment(rpc_url.clone(), CommitmentConfig::confirmed());
+    let mut fingerprint = format!(
+        "fetched_at_unix_secs={}\nrpc_url={rpc_url}\n",
+        unix_timestamp()
+    );
+
+    for spec in specs {
+        let bytes = fetch_mainnet_upgradeable_program_bytes(&client, spec);
+        write_atomic(&mainnet_cached_program_path(cache_dir, spec), &bytes);
+        fingerprint.push_str(&format!(
+            "program={} id={} file={} bytes={}\n",
+            spec.name,
+            spec.program_id,
+            spec.file_name,
+            bytes.len()
+        ));
+    }
+
+    write_atomic(
+        &cache_dir.join(MAINNET_BPF_CACHE_FINGERPRINT),
+        fingerprint.as_bytes(),
+    );
+}
+
+fn fetch_mainnet_upgradeable_program_bytes(
+    client: &RpcClient,
+    spec: &MainnetProgramSpec,
+) -> Vec<u8> {
+    let programdata_address =
+        Pubkey::find_program_address(&[spec.program_id.as_ref()], &BPF_LOADER_UPGRADEABLE_ID).0;
+    let programdata_account = client
+        .get_account(&programdata_address)
+        .unwrap_or_else(|error| {
+            panic!(
+                "fetch mainnet programdata {} for {} ({}): {error}",
+                programdata_address, spec.name, spec.program_id
+            )
+        });
+    if programdata_account.data.len() <= PROGRAMDATA_METADATA_LEN {
+        panic!(
+            "mainnet programdata {} for {} is too small",
+            programdata_address, spec.name
+        );
+    }
+    programdata_account.data[PROGRAMDATA_METADATA_LEN..].to_vec()
+}
+
+fn mainnet_cached_program_path(cache_dir: &Path, spec: &MainnetProgramSpec) -> PathBuf {
+    cache_dir.join(spec.file_name)
+}
+
+fn write_atomic(path: &Path, data: &[u8]) {
+    let file_name = path
+        .file_name()
+        .unwrap_or_else(|| panic!("cache path should have a file name: {}", path.display()))
+        .to_string_lossy();
+    let tmp = path.with_file_name(format!(".{file_name}.tmp-{}", std::process::id()));
+    fs::write(&tmp, data).unwrap_or_else(|error| panic!("write {}: {error}", tmp.display()));
+    fs::rename(&tmp, path)
+        .unwrap_or_else(|error| panic!("rename {} to {}: {error}", tmp.display(), path.display()));
+}
+
+fn unix_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[derive(BorshSerialize)]
+struct FixtureSymbol {
+    symbol_bytes: [u8; 16],
+}
+
+impl FixtureSymbol {
+    fn new(symbol: &str) -> Self {
+        let bytes = symbol.as_bytes();
+        assert!(
+            !bytes.is_empty() && bytes.len() <= 16,
+            "fixture symbol must be between 1 and 16 bytes"
+        );
+        assert!(
+            bytes.iter().all(|byte| byte.is_ascii() && *byte != 0),
+            "fixture symbol must be non-null ASCII"
+        );
+        let mut symbol_bytes = [0_u8; 16];
+        symbol_bytes[..bytes.len()].copy_from_slice(bytes);
+        Self { symbol_bytes }
+    }
+}
+
+#[derive(BorshSerialize)]
+struct SerializedOraclePriceUpdate {
+    perp_asset_id: FixtureSymbol,
+    new_exchange_perp_price: Option<FixturePrice>,
+    new_exchange_spot_price: FixturePrice,
+}
+
+#[derive(BorshSerialize)]
+struct SerializedOraclePriceUpdateFlags {
+    flags: u8,
+}
+
+#[derive(BorshSerialize)]
+struct SerializedOraclePriceUpdateInstruction {
+    update_timestamp: u64,
+    updates: Vec<SerializedOraclePriceUpdate>,
+    flags: SerializedOraclePriceUpdateFlags,
+}
+
+#[derive(BorshSerialize)]
+struct SerializedUpdateSplinePriceParams {
+    new_mid_price: u64,
+    user_update_slot: Option<u64>,
+    refresh_regions: bool,
+}
+
+fn oracle_price_update_data(
+    update_timestamp: u64,
+    updates: &[FixtureOraclePriceUpdate],
+) -> Vec<u8> {
+    let payload = SerializedOraclePriceUpdateInstruction {
+        update_timestamp,
+        updates: updates
+            .iter()
+            .map(|update| SerializedOraclePriceUpdate {
+                perp_asset_id: FixtureSymbol::new(&update.symbol),
+                new_exchange_perp_price: update.new_exchange_perp_price,
+                new_exchange_spot_price: update.new_exchange_spot_price,
+            })
+            .collect(),
+        flags: SerializedOraclePriceUpdateFlags { flags: 0 },
+    };
+    let mut data =
+        crate::phoenix_rise_ix::compute_discriminant("global:update_oracle_prices_with_ordering")
+            .to_vec();
+    data.extend_from_slice(&to_vec(&payload).expect("oracle price update should serialize"));
+    data
+}
+
+fn spline_price_update_data(new_mid_price_ticks: u64) -> Vec<u8> {
+    let payload = SerializedUpdateSplinePriceParams {
+        new_mid_price: new_mid_price_ticks,
+        user_update_slot: None,
+        refresh_regions: true,
+    };
+    let mut data =
+        crate::phoenix_rise_ix::compute_discriminant("global:update_spline_price").to_vec();
+    data.extend_from_slice(&to_vec(&payload).expect("spline price update should serialize"));
+    data
+}
+
+fn flight_init_ix(payer: Pubkey, max_fee_cap_bps: u64) -> Instruction {
+    let mut data = crate::phoenix_rise_ix::compute_discriminant("global:init").to_vec();
+    data.extend_from_slice(&max_fee_cap_bps.to_le_bytes());
+    Instruction {
+        program_id: crate::phoenix_rise_ix::flight::FLIGHT_PROGRAM_ID,
+        accounts: vec![
+            AccountMeta::new(
+                crate::phoenix_rise_ix::flight::get_flight_global_state_address(),
+                false,
+            ),
+            AccountMeta::new_readonly(*crate::phoenix_rise_ix::PHOENIX_PROGRAM_ID, false),
+            AccountMeta::new(payer, true),
+            AccountMeta::new_readonly(crate::phoenix_rise_ix::SYSTEM_PROGRAM_ID, false),
+        ],
+        data,
+    }
+}
+
+fn load_program(svm: &mut LiteSVM, program_id: &str, path: &Path) {
+    load_program_id(
+        svm,
+        parse_pubkey(program_id).expect("program id should parse"),
+        path,
+    );
+}
+
+fn load_program_id(svm: &mut LiteSVM, program_id: Pubkey, path: &Path) {
+    let bytes = std::fs::read(path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+    svm.add_program(program_id, &bytes)
+        .unwrap_or_else(|error| panic!("failed to load {}: {error:?}", path.display()));
+}

--- a/rust/sdk/src/tx_builder.rs
+++ b/rust/sdk/src/tx_builder.rs
@@ -16,19 +16,19 @@ use crate::order_tickets::{
     DEFAULT_BRACKET_LEG_SLIPPAGE_BPS, LimitOrderTicket, MarketOrderTicket, OrderTicketMetadata,
 };
 use crate::phoenix_rise_ix::{
-    CancelId, CancelOrdersByIdParams, CancelStopLossParams, CondensedOrder,
-    CreateConditionalOrdersAccountParams, DepositFundsParams, Direction, EmberDepositParams,
-    EmberWithdrawParams, HawkeyeBboViewAccounts, HawkeyeTraderViewAccounts, IsolatedCollateralFlow,
-    IsolatedLimitOrderParams, IsolatedMarketOrderParams, LimitOrderParams,
+    CancelAllParams, CancelId, CancelOrdersByIdParams, CancelStopLossParams, CancelUpToParams,
+    CondensedOrder, CreateConditionalOrdersAccountParams, DepositFundsParams, Direction,
+    EmberDepositParams, EmberWithdrawParams, HawkeyeBboViewAccounts, HawkeyeTraderViewAccounts,
+    IsolatedCollateralFlow, IsolatedLimitOrderParams, IsolatedMarketOrderParams, LimitOrderParams,
     MarketOrderDelegatedParams, MarketOrderParams, MultiLimitOrderParams, OrderPacket,
     PHOENIX_PROGRAM_ID, PlaceLimitOrderWithConditionalsParams, PlacePositionConditionalOrderParams,
     PlaceStopLossParams, RegisterTraderParams, Side, SplApproveParams, StopLossOrderKind,
     SyncParentToChildParams, TransferCollateralChildToParentParams, TransferCollateralParams,
-    TriggerOrderParams, USDC_MINT, WithdrawFundsParams, client_order_id_to_bytes,
-    create_associated_token_account_idempotent_ix, create_cancel_orders_by_id_ix,
-    create_cancel_stop_loss_ix, create_create_conditional_orders_account_ix,
-    create_deposit_funds_ix, create_ember_deposit_ix, create_ember_withdraw_ix,
-    create_hawkeye_view_bbo_ix, create_hawkeye_view_funding_ix,
+    TriggerOrderParams, USDC_MINT, UncrossCrankParams, WithdrawFundsParams,
+    client_order_id_to_bytes, create_associated_token_account_idempotent_ix, create_cancel_all_ix,
+    create_cancel_orders_by_id_ix, create_cancel_stop_loss_ix, create_cancel_up_to_ix,
+    create_create_conditional_orders_account_ix, create_deposit_funds_ix, create_ember_deposit_ix,
+    create_ember_withdraw_ix, create_hawkeye_view_bbo_ix, create_hawkeye_view_funding_ix,
     create_hawkeye_view_liquidation_price_ix, create_hawkeye_view_margin_for_asset_ix,
     create_hawkeye_view_margin_ix, create_place_limit_order_ix,
     create_place_limit_order_with_conditionals_ix, create_place_market_order_delegated_ix,
@@ -36,8 +36,8 @@ use crate::phoenix_rise_ix::{
     create_place_position_conditional_order_ix, create_place_stop_loss_ix,
     create_register_trader_ix, create_spl_approve_ix, create_sync_parent_to_child_ix,
     create_transfer_collateral_child_to_parent_ix, create_transfer_collateral_ix,
-    create_withdraw_funds_ix, get_associated_token_address, get_conditional_orders_address,
-    get_ember_state_address, get_stop_loss_address,
+    create_uncross_crank_ix, create_withdraw_funds_ix, get_associated_token_address,
+    get_conditional_orders_address, get_ember_state_address, get_stop_loss_address,
 };
 use crate::phoenix_rise_math::{MathError, WrapperNum};
 use crate::phoenix_rise_types::accounts::StopLosses;
@@ -492,6 +492,138 @@ impl<'a> PhoenixTxBuilder<'a> {
             .build()?;
 
         let ix = create_cancel_orders_by_id_ix(params)?;
+        Ok(vec![ix.into()])
+    }
+
+    /// Build a cancel-all instruction for a market.
+    ///
+    /// # Arguments
+    ///
+    /// * `authority` - The trader's wallet address (signer)
+    /// * `trader_pda` - The trader's PDA account
+    /// * `symbol` - Market symbol
+    ///
+    /// # Returns
+    ///
+    /// A vector containing the cancel-all instruction.
+    pub fn build_cancel_all_orders(
+        &self,
+        authority: Pubkey,
+        trader_pda: Pubkey,
+        symbol: &str,
+    ) -> Result<Vec<Instruction>, PhoenixTxBuilderError> {
+        let market = self
+            .metadata
+            .get_market(symbol)
+            .ok_or_else(|| PhoenixTxBuilderError::UnknownSymbol(symbol.to_string()))?;
+
+        let addrs = self.parse_addresses(market)?;
+
+        let params = CancelAllParams::builder()
+            .trader(authority)
+            .trader_account(trader_pda)
+            .perp_asset_map(addrs.perp_asset_map)
+            .orderbook(addrs.orderbook)
+            .spline_collection(addrs.spline_collection)
+            .global_trader_index(addrs.global_trader_index)
+            .active_trader_buffer(addrs.active_trader_buffer)
+            .build()?;
+
+        let ix = create_cancel_all_ix(params)?;
+        Ok(vec![ix.into()])
+    }
+
+    /// Build a cancel-up-to instruction for a market.
+    ///
+    /// `num_orders_to_cancel` and `tick_limit` are optional on-chain limits.
+    /// Pass `None` for either field to leave that side of the cancellation open
+    /// ended.
+    ///
+    /// # Arguments
+    ///
+    /// * `authority` - The trader's wallet address (signer)
+    /// * `trader_pda` - The trader's PDA account
+    /// * `symbol` - Market symbol
+    /// * `side` - Book side to cancel from
+    /// * `num_orders_to_cancel` - Optional maximum number of orders to cancel
+    /// * `tick_limit` - Optional price tick boundary
+    ///
+    /// # Returns
+    ///
+    /// A vector containing the cancel-up-to instruction.
+    pub fn build_cancel_up_to(
+        &self,
+        authority: Pubkey,
+        trader_pda: Pubkey,
+        symbol: &str,
+        side: Side,
+        num_orders_to_cancel: Option<u64>,
+        tick_limit: Option<u64>,
+    ) -> Result<Vec<Instruction>, PhoenixTxBuilderError> {
+        let market = self
+            .metadata
+            .get_market(symbol)
+            .ok_or_else(|| PhoenixTxBuilderError::UnknownSymbol(symbol.to_string()))?;
+
+        let addrs = self.parse_addresses(market)?;
+
+        let mut builder = CancelUpToParams::builder()
+            .trader(authority)
+            .trader_account(trader_pda)
+            .perp_asset_map(addrs.perp_asset_map)
+            .orderbook(addrs.orderbook)
+            .spline_collection(addrs.spline_collection)
+            .global_trader_index(addrs.global_trader_index)
+            .active_trader_buffer(addrs.active_trader_buffer)
+            .side(side);
+        if let Some(num_orders_to_cancel) = num_orders_to_cancel {
+            builder = builder.num_orders_to_cancel(num_orders_to_cancel);
+        }
+        if let Some(tick_limit) = tick_limit {
+            builder = builder.tick_limit(tick_limit);
+        }
+
+        let ix = create_cancel_up_to_ix(builder.build()?)?;
+        Ok(vec![ix.into()])
+    }
+
+    /// Build an uncross-crank instruction for a market.
+    ///
+    /// This is a permissionless maintenance instruction and does not require a
+    /// trader signer. Pass `None` for `match_limit` to use the program SDK
+    /// default.
+    ///
+    /// # Arguments
+    ///
+    /// * `symbol` - Market symbol
+    /// * `match_limit` - Optional maximum number of matches to process
+    ///
+    /// # Returns
+    ///
+    /// A vector containing the uncross-crank instruction.
+    pub fn build_uncross_crank(
+        &self,
+        symbol: &str,
+        match_limit: Option<u64>,
+    ) -> Result<Vec<Instruction>, PhoenixTxBuilderError> {
+        let market = self
+            .metadata
+            .get_market(symbol)
+            .ok_or_else(|| PhoenixTxBuilderError::UnknownSymbol(symbol.to_string()))?;
+
+        let addrs = self.parse_addresses(market)?;
+
+        let mut builder = UncrossCrankParams::builder()
+            .perp_asset_map(addrs.perp_asset_map)
+            .orderbook(addrs.orderbook)
+            .spline_collection(addrs.spline_collection)
+            .global_trader_index(addrs.global_trader_index)
+            .active_trader_buffer(addrs.active_trader_buffer);
+        if let Some(match_limit) = match_limit {
+            builder = builder.match_limit(match_limit);
+        }
+
+        let ix = create_uncross_crank_ix(builder.build()?)?;
         Ok(vec![ix.into()])
     }
 

--- a/rust/test-fixtures/default-localnet.json
+++ b/rust/test-fixtures/default-localnet.json
@@ -1,0 +1,3508 @@
+{
+  "schemaVersion": 1,
+  "name": "rise-sdk-default-localnet",
+  "keypairBaseSeed": "rise-sdk-localnet-v1",
+  "keypairDerivation": "ed25519 keypair_from_seed(sha256(`${keypairBaseSeed}-${seed}`))",
+  "programs": {
+    "phoenixEternal": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+    "ember": "EMBERpYNE6ehWmXymZZS2skiFmCa9V5dp14e1iduM5qy",
+    "splToken": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    "associatedToken": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+    "system": "11111111111111111111111111111111"
+  },
+  "addresses": {
+    "globalConfig": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+    "logAuthority": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+    "perpAssetMap": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+    "withdrawQueue": "E2PdNFupWRyfTersboFbTKroQ7hLvcZtgzNQ81buCDbT",
+    "globalVault": "99DGXmqavGrSBB67bnHySiAoU8u4aQWxCCFGp45XwRnz",
+    "globalTraderIndex": ["HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK"],
+    "activeTraderBuffer": ["2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok"],
+    "emberState": "6ur7v6AXNpnHeEb6xuk7PyezvZ1i5GrgYyWZkNCpzbRz",
+    "emberVault": "FKcEb4TdPDTRuMnQDpSEPQBcrm15S73xiUD6Qf8ZLUkq"
+  },
+  "mints": [
+    {
+      "name": "fakeUsdc",
+      "seed": "usdc",
+      "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+      "decimals": 6,
+      "role": "Ember input mint and fake USDC mint authority"
+    },
+    {
+      "name": "phoenixCollateral",
+      "seed": "phoenix-mint",
+      "pubkey": "3Jht9GbHnD4q4jdMuLs9Z4dBBwCkLjugrEBVh8SE2Bfz",
+      "decimals": 6,
+      "role": "Ember output mint used as Phoenix collateral"
+    }
+  ],
+  "signers": [
+    {
+      "name": "payer",
+      "role": "localnet payer",
+      "seed": "payer",
+      "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+      "initialLamports": 1000000000000
+    },
+    {
+      "name": "fakeUsdcMint",
+      "role": "fake USDC mint",
+      "seed": "usdc",
+      "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+      "initialLamports": 0
+    },
+    {
+      "name": "phoenixMint",
+      "role": "Ember output Phoenix collateral mint",
+      "seed": "phoenix-mint",
+      "pubkey": "3Jht9GbHnD4q4jdMuLs9Z4dBBwCkLjugrEBVh8SE2Bfz",
+      "initialLamports": 0
+    },
+    {
+      "name": "perpAssetMap",
+      "role": "Phoenix perp asset map account",
+      "seed": "perp-asset-map",
+      "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+      "initialLamports": 0
+    },
+    {
+      "name": "withdrawQueue",
+      "role": "Phoenix withdraw queue account",
+      "seed": "withdraw-queue",
+      "pubkey": "E2PdNFupWRyfTersboFbTKroQ7hLvcZtgzNQ81buCDbT",
+      "initialLamports": 0
+    },
+    {
+      "name": "priceOracle",
+      "role": "delegated oracle updater",
+      "seed": "price-oracle",
+      "pubkey": "2XR2pqvh94FtCcc8u9SD18wQmN1D7KQwWcPFUT6BiLa3",
+      "initialLamports": 10000000000
+    },
+    {
+      "name": "orderbookTrader",
+      "role": "maker used by orderbook mock actions",
+      "seed": "orderbook-trader",
+      "pubkey": "5JPFZBK5R517q1DLxtWiD5s72YMw2DZXtHpsRxjPxtxu",
+      "initialLamports": 10000000000
+    },
+    {
+      "name": "splineTrader",
+      "role": "spline owner used by spline mock actions",
+      "seed": "spline-trader",
+      "pubkey": "FNb5zCBYbHUCAjZrwDNkZyiJv5JA7S2Wx52Qu7t3gUfD",
+      "initialLamports": 10000000000
+    },
+    {
+      "name": "taker0",
+      "role": "market-order taker",
+      "seed": "taker-0000",
+      "pubkey": "7isfNVgkf2Wz22DRuB1Yipdk7pLz3wVG8vroJCCQpVKX",
+      "initialLamports": 10000000000
+    },
+    {
+      "name": "taker1",
+      "role": "market-order taker",
+      "seed": "taker-0001",
+      "pubkey": "4aGbsgmMxptuj4tKZLReZjh1obsH4fGaayLYa93qa9aR",
+      "initialLamports": 10000000000
+    },
+    {
+      "name": "stopLossTaker",
+      "role": "stop-loss scenario taker",
+      "seed": "stop-loss-taker-0000",
+      "pubkey": "5N3txRuFnHLDom1YUvzuJBngxFUPMPfwkeGoUdtER7go",
+      "initialLamports": 10000000000
+    },
+    {
+      "name": "stopLossExecutor",
+      "role": "stop-loss trigger executor",
+      "seed": "stop-loss-executor",
+      "pubkey": "Ecjw4GkVLMtJrNEtonJB3yxuuUP8vav1bSQ5zPNTEkzr",
+      "initialLamports": 10000000000
+    },
+    {
+      "name": "btcMarket",
+      "role": "BTC orderbook account",
+      "seed": "market-BTC",
+      "pubkey": "FQKqynzMoUZUzNMhbnaQ9tfAJ212FrRE7C95n9hsrp6D",
+      "initialLamports": 0
+    },
+    {
+      "name": "ethMarket",
+      "role": "ETH orderbook account",
+      "seed": "market-ETH",
+      "pubkey": "2BukCb65F4pPa7RjQbvhdsmR2kUNQoEbJR7QdEmn4fuD",
+      "initialLamports": 0
+    },
+    {
+      "name": "solMarket",
+      "role": "SOL orderbook account",
+      "seed": "market-SOL",
+      "pubkey": "CByKdU5zCv8Z6Wf99nv7AbfXiLk1fCptyhAkq7cTJgAD",
+      "initialLamports": 0
+    }
+  ],
+  "markets": [
+    {
+      "symbol": "BTC",
+      "orderbook": "FQKqynzMoUZUzNMhbnaQ9tfAJ212FrRE7C95n9hsrp6D",
+      "spline": "9J7gqEXKXmMKRuME4bgKeR3udrUPJLeP1R2bxyfGkS51",
+      "signerSeed": "market-BTC",
+      "defaultTakerFeeMicro": 350,
+      "defaultMakerFeeMicro": 50,
+      "baseLotDecimals": 4,
+      "tickSizeInQuoteLotsPerBaseLot": 100,
+      "initialMarkPriceAtoms": 100000000,
+      "initialSpotPriceAtoms": 100000000,
+      "liquidity": {
+        "bids": [
+          {
+            "priceUsd": "99500",
+            "baseQuantity": "0.04"
+          },
+          {
+            "priceUsd": "99000",
+            "baseQuantity": "0.05"
+          }
+        ],
+        "asks": [
+          {
+            "priceUsd": "100500",
+            "baseQuantity": "0.04"
+          },
+          {
+            "priceUsd": "101000",
+            "baseQuantity": "0.05"
+          }
+        ]
+      }
+    },
+    {
+      "symbol": "ETH",
+      "orderbook": "2BukCb65F4pPa7RjQbvhdsmR2kUNQoEbJR7QdEmn4fuD",
+      "spline": "53kr4wExNMU3goZh1eviGzcqQCnjKKJaosVY1P2UUCq7",
+      "signerSeed": "market-ETH",
+      "defaultTakerFeeMicro": 350,
+      "defaultMakerFeeMicro": 50,
+      "baseLotDecimals": 3,
+      "tickSizeInQuoteLotsPerBaseLot": 10,
+      "initialMarkPriceAtoms": 3500000,
+      "initialSpotPriceAtoms": 3500000,
+      "liquidity": {
+        "bids": [
+          {
+            "priceUsd": "3485",
+            "baseQuantity": "1.5"
+          },
+          {
+            "priceUsd": "3475",
+            "baseQuantity": "2.0"
+          }
+        ],
+        "asks": [
+          {
+            "priceUsd": "3515",
+            "baseQuantity": "1.5"
+          },
+          {
+            "priceUsd": "3525",
+            "baseQuantity": "2.0"
+          }
+        ]
+      }
+    },
+    {
+      "symbol": "SOL",
+      "orderbook": "CByKdU5zCv8Z6Wf99nv7AbfXiLk1fCptyhAkq7cTJgAD",
+      "spline": "4NQqRHeBdLx9rcyNUoAfHkFmpk28JDNcAEmdMiTviYsn",
+      "signerSeed": "market-SOL",
+      "defaultTakerFeeMicro": 350,
+      "defaultMakerFeeMicro": 50,
+      "baseLotDecimals": 2,
+      "tickSizeInQuoteLotsPerBaseLot": 10,
+      "initialMarkPriceAtoms": 150000,
+      "initialSpotPriceAtoms": 150000,
+      "liquidity": {
+        "bids": [
+          {
+            "priceUsd": "149.5",
+            "baseQuantity": "40"
+          },
+          {
+            "priceUsd": "149",
+            "baseQuantity": "50"
+          }
+        ],
+        "asks": [
+          {
+            "priceUsd": "150.5",
+            "baseQuantity": "40"
+          },
+          {
+            "priceUsd": "151",
+            "baseQuantity": "50"
+          }
+        ]
+      }
+    }
+  ],
+  "actors": [
+    {
+      "name": "orderbookTrader",
+      "signer": "orderbookTrader",
+      "seed": "orderbook-trader",
+      "pubkey": "5JPFZBK5R517q1DLxtWiD5s72YMw2DZXtHpsRxjPxtxu",
+      "traderAccount": "2YeaRXZYxBbfgWLwVz8oLZ7Sz9MSKQDBwapC4yrCDKra",
+      "fakeUsdcTokenAccount": "9g39VLwJVSZxxGpjJmL3gL15DA9KUW7b9AzFeecm5giT",
+      "phoenixTokenAccount": "H7pLzAA2mXhGi2jG3VNjMSPbtqpMKjmouPzzkT5tc1ST",
+      "subaccountIndex": 0,
+      "initialUsdcAtoms": 25000000000000,
+      "phoenixDepositAtoms": 10000000000000,
+      "capabilities": [
+        "placeLimitOrder",
+        "placeMarketOrder",
+        "riskReducingTrade",
+        "riskIncreasingTrade",
+        "depositCollateral",
+        "withdrawCollateral"
+      ]
+    },
+    {
+      "name": "splineTrader",
+      "signer": "splineTrader",
+      "seed": "spline-trader",
+      "pubkey": "FNb5zCBYbHUCAjZrwDNkZyiJv5JA7S2Wx52Qu7t3gUfD",
+      "traderAccount": "A71SHZp8ju4nbmKQviEXvq4eWKKsivV5JMhRutjS3Dr8",
+      "fakeUsdcTokenAccount": "DMwiCfE53LsZ5wKhjL3h69zrjvmLRQXtoyEo3aYEqXg5",
+      "phoenixTokenAccount": "HBVEpjDHtogU3tjAF3HMky2ZKyE2pu5ZQvCssrw9jS9n",
+      "subaccountIndex": 0,
+      "initialUsdcAtoms": 25000000000000,
+      "phoenixDepositAtoms": 10000000000000,
+      "capabilities": [
+        "placeLimitOrder",
+        "placeMarketOrder",
+        "riskReducingTrade",
+        "riskIncreasingTrade",
+        "depositCollateral",
+        "withdrawCollateral"
+      ]
+    },
+    {
+      "name": "taker0",
+      "signer": "taker0",
+      "seed": "taker-0000",
+      "pubkey": "7isfNVgkf2Wz22DRuB1Yipdk7pLz3wVG8vroJCCQpVKX",
+      "traderAccount": "GHkq1eHeZGi96RmGPZ23e3BDEcdfpPzsPwpYdm17SWgc",
+      "fakeUsdcTokenAccount": "3GZzGngsEc9fLD2C8VJuzE57nULwUJUrA2gLhDHy1bSm",
+      "phoenixTokenAccount": "9jWJtznQEpViojse6fpk5dS8Kuo6KUtujbXDk6DYPUGv",
+      "subaccountIndex": 0,
+      "initialUsdcAtoms": 25000000000000,
+      "phoenixDepositAtoms": 10000000000000,
+      "capabilities": [
+        "placeLimitOrder",
+        "placeMarketOrder",
+        "riskReducingTrade",
+        "riskIncreasingTrade",
+        "depositCollateral",
+        "withdrawCollateral"
+      ]
+    },
+    {
+      "name": "taker1",
+      "signer": "taker1",
+      "seed": "taker-0001",
+      "pubkey": "4aGbsgmMxptuj4tKZLReZjh1obsH4fGaayLYa93qa9aR",
+      "traderAccount": "7U4g5JyoqKTAwTYd7D7iAf4jed8R95yMHJ6aZSDwcKHV",
+      "fakeUsdcTokenAccount": "4Z8qmo7fRKXh5dajhGeDjBPn1npB3cG7bqA2kxPa2CL9",
+      "phoenixTokenAccount": "FfvHTV2AEDWSJXkoCpsTuzgSuvpekpfuoRjRddnmUnkr",
+      "subaccountIndex": 0,
+      "initialUsdcAtoms": 25000000000000,
+      "phoenixDepositAtoms": 10000000000000,
+      "capabilities": [
+        "placeLimitOrder",
+        "placeMarketOrder",
+        "riskReducingTrade",
+        "riskIncreasingTrade",
+        "depositCollateral",
+        "withdrawCollateral"
+      ]
+    },
+    {
+      "name": "stopLossTaker",
+      "signer": "stopLossTaker",
+      "seed": "stop-loss-taker-0000",
+      "pubkey": "5N3txRuFnHLDom1YUvzuJBngxFUPMPfwkeGoUdtER7go",
+      "traderAccount": "7CYKZnzpASyxa2nJYbcdfDani85p8VJXNPLRb7pyd4DS",
+      "fakeUsdcTokenAccount": "RRZmShxBsS2QH9YqAnYjKfZ7QqU5JqqVkyxex137ZEv",
+      "phoenixTokenAccount": "3JGabYoe8dcSjuWF9xH7hJr7CQo2dZzJXJZ8CzDXjBDc",
+      "subaccountIndex": 0,
+      "initialUsdcAtoms": 25000000000000,
+      "phoenixDepositAtoms": 10000000000000,
+      "capabilities": [
+        "placeLimitOrder",
+        "placeMarketOrder",
+        "riskReducingTrade",
+        "riskIncreasingTrade",
+        "depositCollateral",
+        "withdrawCollateral"
+      ]
+    }
+  ],
+  "setupTransactions": [
+    {
+      "name": "createFakeUsdcMint",
+      "description": "Create a deterministic fake USDC SPL mint controlled by the payer.",
+      "signerSeeds": ["payer", "usdc"],
+      "instructions": [
+        {
+          "name": "createFakeUsdcMintAccount",
+          "programId": "11111111111111111111111111111111",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+              "isSigner": true,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "AAAAAGBNFgAAAAAAUgAAAAAAAAAG3fbh12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqQ=="
+        },
+        {
+          "name": "initializeFakeUsdcMint",
+          "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "accounts": [
+            {
+              "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "FAanQmqFfDzviEra9c1ltQ12LmwOUhHDH++ZE7Y5ewI96AA="
+        }
+      ]
+    },
+    {
+      "name": "initializeExchange",
+      "description": "Initialize Ember and Phoenix global exchange state using fake USDC as the Ember input mint.",
+      "signerSeeds": [
+        "payer",
+        "phoenix-mint",
+        "perp-asset-map",
+        "withdraw-queue"
+      ],
+      "instructions": [
+        {
+          "name": "initializeEmber",
+          "programId": "EMBERpYNE6ehWmXymZZS2skiFmCa9V5dp14e1iduM5qy",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "6ur7v6AXNpnHeEb6xuk7PyezvZ1i5GrgYyWZkNCpzbRz",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "3Jht9GbHnD4q4jdMuLs9Z4dBBwCkLjugrEBVh8SE2Bfz",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FKcEb4TdPDTRuMnQDpSEPQBcrm15S73xiUD6Qf8ZLUkq",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "3DvP7Gz6L2Q="
+        },
+        {
+          "name": "createPerpAssetMap",
+          "programId": "11111111111111111111111111111111",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": true,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "AAAAAACx9qACAAAAMMAYAAAAAADOcNb7Vo5D6/yWSpAVbDvpVjsIFwZ8q2lOvIPv3bN+hg=="
+        },
+        {
+          "name": "createWithdrawQueue",
+          "programId": "11111111111111111111111111111111",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "E2PdNFupWRyfTersboFbTKroQ7hLvcZtgzNQ81buCDbT",
+              "isSigner": true,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "AAAAAADjeFgAAAAAkEADAAAAAADOcNb7Vo5D6/yWSpAVbDvpVjsIFwZ8q2lOvIPv3bN+hg=="
+        },
+        {
+          "name": "rebirth",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "99DGXmqavGrSBB67bnHySiAoU8u4aQWxCCFGp45XwRnz",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "3Jht9GbHnD4q4jdMuLs9Z4dBBwCkLjugrEBVh8SE2Bfz",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "E2PdNFupWRyfTersboFbTKroQ7hLvcZtgzNQ81buCDbT",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "j/GaT3Ti/5D+fwIAc9EBAEAAAAAAQHoQ81oAAAAQpdToAAAA"
+        },
+        {
+          "name": "setWithdrawCooldown",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "E2PdNFupWRyfTersboFbTKroQ7hLvcZtgzNQ81buCDbT",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "V9HhhFuX+YQBlgAAAAAAAAAAAA=="
+        },
+        {
+          "name": "updateWithdrawRateLimits",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "E2PdNFupWRyfTersboFbTKroQ7hLvcZtgzNQ81buCDbT",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "u/aSto3YJAEBAEB6EPNaAAABABCl1OgAAAA="
+        },
+        {
+          "name": "fundGlobalTraderIndexHeader",
+          "programId": "11111111111111111111111111111111",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "AgAAAAAyCv4QAAAA"
+        },
+        {
+          "name": "fundActiveTraderBufferHeader",
+          "programId": "11111111111111111111111111111111",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "AgAAAIALC/4QAAAA"
+        }
+      ]
+    },
+    {
+      "name": "initializeMarkets",
+      "description": "Create and activate BTC, ETH, and SOL perpetual markets.",
+      "signerSeeds": ["payer", "market-BTC", "market-ETH", "market-SOL"],
+      "instructions": [
+        {
+          "name": "createBTCOrderbook",
+          "programId": "11111111111111111111111111111111",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FQKqynzMoUZUzNMhbnaQ9tfAJ212FrRE7C95n9hsrp6D",
+              "isSigner": true,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "AAAAAADsvOsBAAAAwBUSAAAAAADOcNb7Vo5D6/yWSpAVbDvpVjsIFwZ8q2lOvIPv3bN+hg=="
+        },
+        {
+          "name": "addBTCMarket",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FQKqynzMoUZUzNMhbnaQ9tfAJ212FrRE7C95n9hsrp6D",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "9J7gqEXKXmMKRuME4bgKeR3udrUPJLeP1R2bxyfGkS51",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "KYm5fkWL/jdCVEMAAAAAAAAAAAAAAAAAoIYBAAAAAAAUAAAAAAAAAFgbAAAAAAAAIKEHAAAAAAAKAAAAAAAAAEAfAAAAAAAAQEIPAAAAAAAFAAAAAAAAACgjAAAAAAAAgJaYAAAAAAACAAAAAAAAABAnAAAAAAAAAABkAAAAAAAAAAReAQAAMgAAABAnAAAAAAAAuAsAAAAAAAAsGogT0AdYG2RFAQAAAAAAoIYBAAAAAABkAAAAAAAAACChBwAAAAAAyAAAAAAAAABAQg8AAAAAACwBAAAAAAAAgJaYAAAAAACQAQAAAAAAAP////8AAAAAdwEAAAAAAADoAwAAAAAAAOgDAAAAAAAAZAAAAAAAAABkAAAAAAAAAGQAAAAAAAAAAQAAAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEB9AEBCgoACgAAAAAAAAAAAAAA"
+        },
+        {
+          "name": "activateBTCMarket",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FQKqynzMoUZUzNMhbnaQ9tfAJ212FrRE7C95n9hsrp6D",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "3X/gKbGRfggB"
+        },
+        {
+          "name": "createETHOrderbook",
+          "programId": "11111111111111111111111111111111",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2BukCb65F4pPa7RjQbvhdsmR2kUNQoEbJR7QdEmn4fuD",
+              "isSigner": true,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "AAAAAADsvOsBAAAAwBUSAAAAAADOcNb7Vo5D6/yWSpAVbDvpVjsIFwZ8q2lOvIPv3bN+hg=="
+        },
+        {
+          "name": "addETHMarket",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2BukCb65F4pPa7RjQbvhdsmR2kUNQoEbJR7QdEmn4fuD",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "53kr4wExNMU3goZh1eviGzcqQCnjKKJaosVY1P2UUCq7",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "KYm5fkWL/jdFVEgAAAAAAAAAAAAAAAAAoIYBAAAAAAAUAAAAAAAAAFgbAAAAAAAAIKEHAAAAAAAKAAAAAAAAAEAfAAAAAAAAQEIPAAAAAAAFAAAAAAAAACgjAAAAAAAAgJaYAAAAAAACAAAAAAAAABAnAAAAAAAAAAAKAAAAAAAAAANeAQAAMgAAABAnAAAAAAAAuAsAAAAAAACIE9AH6AN8FcgUBQAAAAAAoIYBAAAAAABkAAAAAAAAACChBwAAAAAAyAAAAAAAAABAQg8AAAAAACwBAAAAAAAAgJaYAAAAAACQAQAAAAAAAP////8AAAAAdwEAAAAAAADoAwAAAAAAAOgDAAAAAAAAZAAAAAAAAABkAAAAAAAAAGQAAAAAAAAAAQAAAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEB9AEBCgoACgAAAAAAAAAAAAAA"
+        },
+        {
+          "name": "activateETHMarket",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2BukCb65F4pPa7RjQbvhdsmR2kUNQoEbJR7QdEmn4fuD",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "3X/gKbGRfggB"
+        },
+        {
+          "name": "createSOLOrderbook",
+          "programId": "11111111111111111111111111111111",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CByKdU5zCv8Z6Wf99nv7AbfXiLk1fCptyhAkq7cTJgAD",
+              "isSigner": true,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "AAAAAADsvOsBAAAAwBUSAAAAAADOcNb7Vo5D6/yWSpAVbDvpVjsIFwZ8q2lOvIPv3bN+hg=="
+        },
+        {
+          "name": "addSOLMarket",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CByKdU5zCv8Z6Wf99nv7AbfXiLk1fCptyhAkq7cTJgAD",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "4NQqRHeBdLx9rcyNUoAfHkFmpk28JDNcAEmdMiTviYsn",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "KYm5fkWL/jdTT0wAAAAAAAAAAAAAAAAAoIYBAAAAAAAUAAAAAAAAAFgbAAAAAAAAIKEHAAAAAAAKAAAAAAAAAEAfAAAAAAAAQEIPAAAAAAAFAAAAAAAAACgjAAAAAAAAgJaYAAAAAAACAAAAAAAAABAnAAAAAAAAAAAKAAAAAAAAAAJeAQAAMgAAABAnAAAAAAAAuAsAAAAAAACIE9AH6AN8FUBCDwAAAAAAoIYBAAAAAABkAAAAAAAAACChBwAAAAAAyAAAAAAAAABAQg8AAAAAACwBAAAAAAAAgJaYAAAAAACQAQAAAAAAAP////8AAAAAdwEAAAAAAADoAwAAAAAAAOgDAAAAAAAAZAAAAAAAAABkAAAAAAAAAGQAAAAAAAAAAQAAAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEB9AEBCgoACgAAAAAAAAAAAAAA"
+        },
+        {
+          "name": "activateSOLMarket",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CByKdU5zCv8Z6Wf99nv7AbfXiLk1fCptyhAkq7cTJgAD",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "3X/gKbGRfggB"
+        }
+      ]
+    },
+    {
+      "name": "oracleSetPrices",
+      "description": "Create oracle delegation for the price oracle and set deterministic mark/spot prices.",
+      "signerSeeds": ["payer", "price-oracle"],
+      "instructions": [
+        {
+          "name": "createOraclePermission",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "DamWDo1h7UiDiXd7vSTbeiNGdLV9nSLYCnohi3JBTEQS",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2XR2pqvh94FtCcc8u9SD18wQmN1D7KQwWcPFUT6BiLa3",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "vrYapJzdCAA="
+        },
+        {
+          "name": "setOraclePermission",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "DamWDo1h7UiDiXd7vSTbeiNGdLV9nSLYCnohi3JBTEQS",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2XR2pqvh94FtCcc8u9SD18wQmN1D7KQwWcPFUT6BiLa3",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "Rn4pwvW9gAgBAAAAAAAAAAAA"
+        },
+        {
+          "name": "updateOraclePrices",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2XR2pqvh94FtCcc8u9SD18wQmN1D7KQwWcPFUT6BiLa3",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "DamWDo1h7UiDiXd7vSTbeiNGdLV9nSLYCnohi3JBTEQS",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "pAAO+jrGGRgAsz9xAAAAAAMAAABCVEMAAAAAAAAAAAAAAAAAAQDh9QUAAAAAAwDh9QUAAAAAA0VUSAAAAAAAAAAAAAAAAAAB4Gc1AAAAAAAD4Gc1AAAAAAADU09MAAAAAAAAAAAAAAAAAAHwSQIAAAAAAAPwSQIAAAAAAAMA"
+        }
+      ]
+    },
+    {
+      "name": "seedOrderbookTraderCollateral",
+      "description": "Mint fake USDC to orderbookTrader, deposit through Ember, register the Phoenix trader, and enable all trading capabilities.",
+      "signerSeeds": ["payer", "orderbook-trader"],
+      "instructions": [
+        {
+          "name": "createOrderbookTraderFakeUsdcAta",
+          "programId": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "9g39VLwJVSZxxGpjJmL3gL15DA9KUW7b9AzFeecm5giT",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "5JPFZBK5R517q1DLxtWiD5s72YMw2DZXtHpsRxjPxtxu",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "AQ=="
+        },
+        {
+          "name": "mintOrderbookTraderFakeUsdc",
+          "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "accounts": [
+            {
+              "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "9g39VLwJVSZxxGpjJmL3gL15DA9KUW7b9AzFeecm5giT",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "BwCQHsS8FgAA"
+        },
+        {
+          "name": "createOrderbookTraderPhoenixAta",
+          "programId": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "H7pLzAA2mXhGi2jG3VNjMSPbtqpMKjmouPzzkT5tc1ST",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "5JPFZBK5R517q1DLxtWiD5s72YMw2DZXtHpsRxjPxtxu",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "3Jht9GbHnD4q4jdMuLs9Z4dBBwCkLjugrEBVh8SE2Bfz",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "AQ=="
+        },
+        {
+          "name": "emberDepositOrderbookTrader",
+          "programId": "EMBERpYNE6ehWmXymZZS2skiFmCa9V5dp14e1iduM5qy",
+          "accounts": [
+            {
+              "pubkey": "5JPFZBK5R517q1DLxtWiD5s72YMw2DZXtHpsRxjPxtxu",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "6ur7v6AXNpnHeEb6xuk7PyezvZ1i5GrgYyWZkNCpzbRz",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "3Jht9GbHnD4q4jdMuLs9Z4dBBwCkLjugrEBVh8SE2Bfz",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "9g39VLwJVSZxxGpjJmL3gL15DA9KUW7b9AzFeecm5giT",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "H7pLzAA2mXhGi2jG3VNjMSPbtqpMKjmouPzzkT5tc1ST",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FKcEb4TdPDTRuMnQDpSEPQBcrm15S73xiUD6Qf8ZLUkq",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "8iPGiVLh8rYAoHJOGAkAAA=="
+        },
+        {
+          "name": "registerOrderbookTraderTrader",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "5JPFZBK5R517q1DLxtWiD5s72YMw2DZXtHpsRxjPxtxu",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2YeaRXZYxBbfgWLwVz8oLZ7Sz9MSKQDBwapC4yrCDKra",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "S/PgpwEFMyCAAAAAAAAAAAAA"
+        },
+        {
+          "name": "depositOrderbookTraderPhoenixCollateral",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "5JPFZBK5R517q1DLxtWiD5s72YMw2DZXtHpsRxjPxtxu",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "H7pLzAA2mXhGi2jG3VNjMSPbtqpMKjmouPzzkT5tc1ST",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2YeaRXZYxBbfgWLwVz8oLZ7Sz9MSKQDBwapC4yrCDKra",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "99DGXmqavGrSBB67bnHySiAoU8u4aQWxCCFGp45XwRnz",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "yic00zUU+lgAoHJOGAkAAA=="
+        },
+        {
+          "name": "enableOrderbookTraderTraderCapabilities",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2YeaRXZYxBbfgWLwVz8oLZ7Sz9MSKQDBwapC4yrCDKra",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "z6oRFTUjWJcGAAAAAAEBAQMBAgEEAQUB"
+        }
+      ]
+    },
+    {
+      "name": "seedSplineTraderCollateral",
+      "description": "Mint fake USDC to splineTrader, deposit through Ember, register the Phoenix trader, and enable all trading capabilities.",
+      "signerSeeds": ["payer", "spline-trader"],
+      "instructions": [
+        {
+          "name": "createSplineTraderFakeUsdcAta",
+          "programId": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "DMwiCfE53LsZ5wKhjL3h69zrjvmLRQXtoyEo3aYEqXg5",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FNb5zCBYbHUCAjZrwDNkZyiJv5JA7S2Wx52Qu7t3gUfD",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "AQ=="
+        },
+        {
+          "name": "mintSplineTraderFakeUsdc",
+          "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "accounts": [
+            {
+              "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "DMwiCfE53LsZ5wKhjL3h69zrjvmLRQXtoyEo3aYEqXg5",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "BwCQHsS8FgAA"
+        },
+        {
+          "name": "createSplineTraderPhoenixAta",
+          "programId": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "HBVEpjDHtogU3tjAF3HMky2ZKyE2pu5ZQvCssrw9jS9n",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FNb5zCBYbHUCAjZrwDNkZyiJv5JA7S2Wx52Qu7t3gUfD",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "3Jht9GbHnD4q4jdMuLs9Z4dBBwCkLjugrEBVh8SE2Bfz",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "AQ=="
+        },
+        {
+          "name": "emberDepositSplineTrader",
+          "programId": "EMBERpYNE6ehWmXymZZS2skiFmCa9V5dp14e1iduM5qy",
+          "accounts": [
+            {
+              "pubkey": "FNb5zCBYbHUCAjZrwDNkZyiJv5JA7S2Wx52Qu7t3gUfD",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "6ur7v6AXNpnHeEb6xuk7PyezvZ1i5GrgYyWZkNCpzbRz",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "3Jht9GbHnD4q4jdMuLs9Z4dBBwCkLjugrEBVh8SE2Bfz",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "DMwiCfE53LsZ5wKhjL3h69zrjvmLRQXtoyEo3aYEqXg5",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "HBVEpjDHtogU3tjAF3HMky2ZKyE2pu5ZQvCssrw9jS9n",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FKcEb4TdPDTRuMnQDpSEPQBcrm15S73xiUD6Qf8ZLUkq",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "8iPGiVLh8rYAoHJOGAkAAA=="
+        },
+        {
+          "name": "registerSplineTraderTrader",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FNb5zCBYbHUCAjZrwDNkZyiJv5JA7S2Wx52Qu7t3gUfD",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "A71SHZp8ju4nbmKQviEXvq4eWKKsivV5JMhRutjS3Dr8",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "S/PgpwEFMyCAAAAAAAAAAAAA"
+        },
+        {
+          "name": "depositSplineTraderPhoenixCollateral",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FNb5zCBYbHUCAjZrwDNkZyiJv5JA7S2Wx52Qu7t3gUfD",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "HBVEpjDHtogU3tjAF3HMky2ZKyE2pu5ZQvCssrw9jS9n",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "A71SHZp8ju4nbmKQviEXvq4eWKKsivV5JMhRutjS3Dr8",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "99DGXmqavGrSBB67bnHySiAoU8u4aQWxCCFGp45XwRnz",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "yic00zUU+lgAoHJOGAkAAA=="
+        },
+        {
+          "name": "enableSplineTraderTraderCapabilities",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "A71SHZp8ju4nbmKQviEXvq4eWKKsivV5JMhRutjS3Dr8",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "z6oRFTUjWJcGAAAAAAEBAQMBAgEEAQUB"
+        }
+      ]
+    },
+    {
+      "name": "seedTaker0Collateral",
+      "description": "Mint fake USDC to taker0, deposit through Ember, register the Phoenix trader, and enable all trading capabilities.",
+      "signerSeeds": ["payer", "taker-0000"],
+      "instructions": [
+        {
+          "name": "createTaker0FakeUsdcAta",
+          "programId": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "3GZzGngsEc9fLD2C8VJuzE57nULwUJUrA2gLhDHy1bSm",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "7isfNVgkf2Wz22DRuB1Yipdk7pLz3wVG8vroJCCQpVKX",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "AQ=="
+        },
+        {
+          "name": "mintTaker0FakeUsdc",
+          "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "accounts": [
+            {
+              "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "3GZzGngsEc9fLD2C8VJuzE57nULwUJUrA2gLhDHy1bSm",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "BwCQHsS8FgAA"
+        },
+        {
+          "name": "createTaker0PhoenixAta",
+          "programId": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "9jWJtznQEpViojse6fpk5dS8Kuo6KUtujbXDk6DYPUGv",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "7isfNVgkf2Wz22DRuB1Yipdk7pLz3wVG8vroJCCQpVKX",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "3Jht9GbHnD4q4jdMuLs9Z4dBBwCkLjugrEBVh8SE2Bfz",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "AQ=="
+        },
+        {
+          "name": "emberDepositTaker0",
+          "programId": "EMBERpYNE6ehWmXymZZS2skiFmCa9V5dp14e1iduM5qy",
+          "accounts": [
+            {
+              "pubkey": "7isfNVgkf2Wz22DRuB1Yipdk7pLz3wVG8vroJCCQpVKX",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "6ur7v6AXNpnHeEb6xuk7PyezvZ1i5GrgYyWZkNCpzbRz",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "3Jht9GbHnD4q4jdMuLs9Z4dBBwCkLjugrEBVh8SE2Bfz",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "3GZzGngsEc9fLD2C8VJuzE57nULwUJUrA2gLhDHy1bSm",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "9jWJtznQEpViojse6fpk5dS8Kuo6KUtujbXDk6DYPUGv",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FKcEb4TdPDTRuMnQDpSEPQBcrm15S73xiUD6Qf8ZLUkq",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "8iPGiVLh8rYAoHJOGAkAAA=="
+        },
+        {
+          "name": "registerTaker0Trader",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "7isfNVgkf2Wz22DRuB1Yipdk7pLz3wVG8vroJCCQpVKX",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GHkq1eHeZGi96RmGPZ23e3BDEcdfpPzsPwpYdm17SWgc",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "S/PgpwEFMyCAAAAAAAAAAAAA"
+        },
+        {
+          "name": "depositTaker0PhoenixCollateral",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "7isfNVgkf2Wz22DRuB1Yipdk7pLz3wVG8vroJCCQpVKX",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "9jWJtznQEpViojse6fpk5dS8Kuo6KUtujbXDk6DYPUGv",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "GHkq1eHeZGi96RmGPZ23e3BDEcdfpPzsPwpYdm17SWgc",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "99DGXmqavGrSBB67bnHySiAoU8u4aQWxCCFGp45XwRnz",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "yic00zUU+lgAoHJOGAkAAA=="
+        },
+        {
+          "name": "enableTaker0TraderCapabilities",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "GHkq1eHeZGi96RmGPZ23e3BDEcdfpPzsPwpYdm17SWgc",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "z6oRFTUjWJcGAAAAAAEBAQMBAgEEAQUB"
+        }
+      ]
+    },
+    {
+      "name": "seedTaker1Collateral",
+      "description": "Mint fake USDC to taker1, deposit through Ember, register the Phoenix trader, and enable all trading capabilities.",
+      "signerSeeds": ["payer", "taker-0001"],
+      "instructions": [
+        {
+          "name": "createTaker1FakeUsdcAta",
+          "programId": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "4Z8qmo7fRKXh5dajhGeDjBPn1npB3cG7bqA2kxPa2CL9",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "4aGbsgmMxptuj4tKZLReZjh1obsH4fGaayLYa93qa9aR",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "AQ=="
+        },
+        {
+          "name": "mintTaker1FakeUsdc",
+          "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "accounts": [
+            {
+              "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "4Z8qmo7fRKXh5dajhGeDjBPn1npB3cG7bqA2kxPa2CL9",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "BwCQHsS8FgAA"
+        },
+        {
+          "name": "createTaker1PhoenixAta",
+          "programId": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FfvHTV2AEDWSJXkoCpsTuzgSuvpekpfuoRjRddnmUnkr",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "4aGbsgmMxptuj4tKZLReZjh1obsH4fGaayLYa93qa9aR",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "3Jht9GbHnD4q4jdMuLs9Z4dBBwCkLjugrEBVh8SE2Bfz",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "AQ=="
+        },
+        {
+          "name": "emberDepositTaker1",
+          "programId": "EMBERpYNE6ehWmXymZZS2skiFmCa9V5dp14e1iduM5qy",
+          "accounts": [
+            {
+              "pubkey": "4aGbsgmMxptuj4tKZLReZjh1obsH4fGaayLYa93qa9aR",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "6ur7v6AXNpnHeEb6xuk7PyezvZ1i5GrgYyWZkNCpzbRz",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "3Jht9GbHnD4q4jdMuLs9Z4dBBwCkLjugrEBVh8SE2Bfz",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "4Z8qmo7fRKXh5dajhGeDjBPn1npB3cG7bqA2kxPa2CL9",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FfvHTV2AEDWSJXkoCpsTuzgSuvpekpfuoRjRddnmUnkr",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FKcEb4TdPDTRuMnQDpSEPQBcrm15S73xiUD6Qf8ZLUkq",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "8iPGiVLh8rYAoHJOGAkAAA=="
+        },
+        {
+          "name": "registerTaker1Trader",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "4aGbsgmMxptuj4tKZLReZjh1obsH4fGaayLYa93qa9aR",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "7U4g5JyoqKTAwTYd7D7iAf4jed8R95yMHJ6aZSDwcKHV",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "S/PgpwEFMyCAAAAAAAAAAAAA"
+        },
+        {
+          "name": "depositTaker1PhoenixCollateral",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "4aGbsgmMxptuj4tKZLReZjh1obsH4fGaayLYa93qa9aR",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "FfvHTV2AEDWSJXkoCpsTuzgSuvpekpfuoRjRddnmUnkr",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "7U4g5JyoqKTAwTYd7D7iAf4jed8R95yMHJ6aZSDwcKHV",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "99DGXmqavGrSBB67bnHySiAoU8u4aQWxCCFGp45XwRnz",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "yic00zUU+lgAoHJOGAkAAA=="
+        },
+        {
+          "name": "enableTaker1TraderCapabilities",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "7U4g5JyoqKTAwTYd7D7iAf4jed8R95yMHJ6aZSDwcKHV",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "z6oRFTUjWJcGAAAAAAEBAQMBAgEEAQUB"
+        }
+      ]
+    },
+    {
+      "name": "seedStopLossTakerCollateral",
+      "description": "Mint fake USDC to stopLossTaker, deposit through Ember, register the Phoenix trader, and enable all trading capabilities.",
+      "signerSeeds": ["payer", "stop-loss-taker-0000"],
+      "instructions": [
+        {
+          "name": "createStopLossTakerFakeUsdcAta",
+          "programId": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "RRZmShxBsS2QH9YqAnYjKfZ7QqU5JqqVkyxex137ZEv",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "5N3txRuFnHLDom1YUvzuJBngxFUPMPfwkeGoUdtER7go",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "AQ=="
+        },
+        {
+          "name": "mintStopLossTakerFakeUsdc",
+          "programId": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          "accounts": [
+            {
+              "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "RRZmShxBsS2QH9YqAnYjKfZ7QqU5JqqVkyxex137ZEv",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "BwCQHsS8FgAA"
+        },
+        {
+          "name": "createStopLossTakerPhoenixAta",
+          "programId": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+          "accounts": [
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "3JGabYoe8dcSjuWF9xH7hJr7CQo2dZzJXJZ8CzDXjBDc",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "5N3txRuFnHLDom1YUvzuJBngxFUPMPfwkeGoUdtER7go",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "3Jht9GbHnD4q4jdMuLs9Z4dBBwCkLjugrEBVh8SE2Bfz",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "AQ=="
+        },
+        {
+          "name": "emberDepositStopLossTaker",
+          "programId": "EMBERpYNE6ehWmXymZZS2skiFmCa9V5dp14e1iduM5qy",
+          "accounts": [
+            {
+              "pubkey": "5N3txRuFnHLDom1YUvzuJBngxFUPMPfwkeGoUdtER7go",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "6ur7v6AXNpnHeEb6xuk7PyezvZ1i5GrgYyWZkNCpzbRz",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CN3tY5cGA7CwgEZsgdTW7FaLXkK9NkdtDbb9ix6U11vT",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "3Jht9GbHnD4q4jdMuLs9Z4dBBwCkLjugrEBVh8SE2Bfz",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "RRZmShxBsS2QH9YqAnYjKfZ7QqU5JqqVkyxex137ZEv",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "3JGabYoe8dcSjuWF9xH7hJr7CQo2dZzJXJZ8CzDXjBDc",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FKcEb4TdPDTRuMnQDpSEPQBcrm15S73xiUD6Qf8ZLUkq",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "8iPGiVLh8rYAoHJOGAkAAA=="
+        },
+        {
+          "name": "registerStopLossTakerTrader",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "5N3txRuFnHLDom1YUvzuJBngxFUPMPfwkeGoUdtER7go",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "7CYKZnzpASyxa2nJYbcdfDani85p8VJXNPLRb7pyd4DS",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "S/PgpwEFMyCAAAAAAAAAAAAA"
+        },
+        {
+          "name": "depositStopLossTakerPhoenixCollateral",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "5N3txRuFnHLDom1YUvzuJBngxFUPMPfwkeGoUdtER7go",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "3JGabYoe8dcSjuWF9xH7hJr7CQo2dZzJXJZ8CzDXjBDc",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "7CYKZnzpASyxa2nJYbcdfDani85p8VJXNPLRb7pyd4DS",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "99DGXmqavGrSBB67bnHySiAoU8u4aQWxCCFGp45XwRnz",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "yic00zUU+lgAoHJOGAkAAA=="
+        },
+        {
+          "name": "enableStopLossTakerTraderCapabilities",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "7CYKZnzpASyxa2nJYbcdfDani85p8VJXNPLRb7pyd4DS",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "z6oRFTUjWJcGAAAAAAEBAQMBAgEEAQUB"
+        }
+      ]
+    },
+    {
+      "name": "registerSplines",
+      "description": "Register the spline trader as spline owner for each market.",
+      "signerSeeds": ["payer"],
+      "instructions": [
+        {
+          "name": "registerBTCSpline",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "9J7gqEXKXmMKRuME4bgKeR3udrUPJLeP1R2bxyfGkS51",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FQKqynzMoUZUzNMhbnaQ9tfAJ212FrRE7C95n9hsrp6D",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "A71SHZp8ju4nbmKQviEXvq4eWKKsivV5JMhRutjS3Dr8",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "HrCgT/x18To="
+        },
+        {
+          "name": "registerETHSpline",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "53kr4wExNMU3goZh1eviGzcqQCnjKKJaosVY1P2UUCq7",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2BukCb65F4pPa7RjQbvhdsmR2kUNQoEbJR7QdEmn4fuD",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "A71SHZp8ju4nbmKQviEXvq4eWKKsivV5JMhRutjS3Dr8",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "HrCgT/x18To="
+        },
+        {
+          "name": "registerSOLSpline",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CFupopDymBDnia6zh8vRxY6oKJp8WPaKahv4ooFebyEw",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "4NQqRHeBdLx9rcyNUoAfHkFmpk28JDNcAEmdMiTviYsn",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CByKdU5zCv8Z6Wf99nv7AbfXiLk1fCptyhAkq7cTJgAD",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "A71SHZp8ju4nbmKQviEXvq4eWKKsivV5JMhRutjS3Dr8",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": false,
+              "isWritable": false
+            }
+          ],
+          "dataBase64": "HrCgT/x18To="
+        }
+      ]
+    },
+    {
+      "name": "orderbookPlaceLevels",
+      "description": "Place deterministic maker bid/ask levels from the orderbook trader.",
+      "signerSeeds": ["orderbook-trader"],
+      "instructions": [
+        {
+          "name": "placeBTCMakerLevels",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "5JPFZBK5R517q1DLxtWiD5s72YMw2DZXtHpsRxjPxtxu",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2YeaRXZYxBbfgWLwVz8oLZ7Sz9MSKQDBwapC4yrCDKra",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FQKqynzMoUZUzNMhbnaQ9tfAJ212FrRE7C95n9hsrp6D",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "9J7gqEXKXmMKRuME4bgKeR3udrUPJLeP1R2bxyfGkS51",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "7NDdrI3igVQCAAAArIQBAAAAAACQAQAAAAAAAAC4ggEAAAAAAPQBAAAAAAAAAAIAAACUiAEAAAAAAJABAAAAAAAAAIiKAQAAAAAA9AEAAAAAAAAAAAA="
+        },
+        {
+          "name": "placeETHMakerLevels",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "5JPFZBK5R517q1DLxtWiD5s72YMw2DZXtHpsRxjPxtxu",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2YeaRXZYxBbfgWLwVz8oLZ7Sz9MSKQDBwapC4yrCDKra",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2BukCb65F4pPa7RjQbvhdsmR2kUNQoEbJR7QdEmn4fuD",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "53kr4wExNMU3goZh1eviGzcqQCnjKKJaosVY1P2UUCq7",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "7NDdrI3igVQCAAAAVFEFAAAAAADcBQAAAAAAAABsTQUAAAAAANAHAAAAAAAAAAIAAAAMXQUAAAAAANwFAAAAAAAAAPRgBQAAAAAA0AcAAAAAAAAAAAA="
+        },
+        {
+          "name": "placeSOLMakerLevels",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "5JPFZBK5R517q1DLxtWiD5s72YMw2DZXtHpsRxjPxtxu",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2YeaRXZYxBbfgWLwVz8oLZ7Sz9MSKQDBwapC4yrCDKra",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CByKdU5zCv8Z6Wf99nv7AbfXiLk1fCptyhAkq7cTJgAD",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "4NQqRHeBdLx9rcyNUoAfHkFmpk28JDNcAEmdMiTviYsn",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "7NDdrI3igVQCAAAA/EcCAAAAAACgDwAAAAAAAAAIRgIAAAAAAIgTAAAAAAAAAAIAAADkSwIAAAAAAKAPAAAAAAAAANhNAgAAAAAAiBMAAAAAAAAAAAA="
+        }
+      ]
+    }
+  ],
+  "actionTemplates": [
+    {
+      "name": "oracleSetPrices",
+      "description": "Update deterministic mark/spot prices with the delegated price oracle.",
+      "signerSeeds": ["price-oracle"],
+      "instructions": [
+        {
+          "name": "updateOraclePrices",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2XR2pqvh94FtCcc8u9SD18wQmN1D7KQwWcPFUT6BiLa3",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "DamWDo1h7UiDiXd7vSTbeiNGdLV9nSLYCnohi3JBTEQS",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "pAAO+jrGGRgAsz9xAAAAAAMAAABCVEMAAAAAAAAAAAAAAAAAAQDh9QUAAAAAAwDh9QUAAAAAA0VUSAAAAAAAAAAAAAAAAAAB4Gc1AAAAAAAD4Gc1AAAAAAADU09MAAAAAAAAAAAAAAAAAAHwSQIAAAAAAAPwSQIAAAAAAAMA"
+        }
+      ]
+    },
+    {
+      "name": "orderbookPlaceLevels",
+      "description": "Place deterministic maker bid/ask levels from the orderbook trader.",
+      "signerSeeds": ["orderbook-trader"],
+      "instructions": [
+        {
+          "name": "placeBTCMakerLevels",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "5JPFZBK5R517q1DLxtWiD5s72YMw2DZXtHpsRxjPxtxu",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2YeaRXZYxBbfgWLwVz8oLZ7Sz9MSKQDBwapC4yrCDKra",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FQKqynzMoUZUzNMhbnaQ9tfAJ212FrRE7C95n9hsrp6D",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "9J7gqEXKXmMKRuME4bgKeR3udrUPJLeP1R2bxyfGkS51",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "7NDdrI3igVQCAAAArIQBAAAAAACQAQAAAAAAAAC4ggEAAAAAAPQBAAAAAAAAAAIAAACUiAEAAAAAAJABAAAAAAAAAIiKAQAAAAAA9AEAAAAAAAAAAAA="
+        },
+        {
+          "name": "placeETHMakerLevels",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "5JPFZBK5R517q1DLxtWiD5s72YMw2DZXtHpsRxjPxtxu",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2YeaRXZYxBbfgWLwVz8oLZ7Sz9MSKQDBwapC4yrCDKra",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2BukCb65F4pPa7RjQbvhdsmR2kUNQoEbJR7QdEmn4fuD",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "53kr4wExNMU3goZh1eviGzcqQCnjKKJaosVY1P2UUCq7",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "7NDdrI3igVQCAAAAVFEFAAAAAADcBQAAAAAAAABsTQUAAAAAANAHAAAAAAAAAAIAAAAMXQUAAAAAANwFAAAAAAAAAPRgBQAAAAAA0AcAAAAAAAAAAAA="
+        },
+        {
+          "name": "placeSOLMakerLevels",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "5JPFZBK5R517q1DLxtWiD5s72YMw2DZXtHpsRxjPxtxu",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2YeaRXZYxBbfgWLwVz8oLZ7Sz9MSKQDBwapC4yrCDKra",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CByKdU5zCv8Z6Wf99nv7AbfXiLk1fCptyhAkq7cTJgAD",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "4NQqRHeBdLx9rcyNUoAfHkFmpk28JDNcAEmdMiTviYsn",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "7NDdrI3igVQCAAAA/EcCAAAAAACgDwAAAAAAAAAIRgIAAAAAAIgTAAAAAAAAAAIAAADkSwIAAAAAAKAPAAAAAAAAANhNAgAAAAAAiBMAAAAAAAAAAAA="
+        }
+      ]
+    },
+    {
+      "name": "orderbookCancelLevels",
+      "description": "Cancel all maker levels owned by the orderbook trader.",
+      "signerSeeds": ["orderbook-trader"],
+      "instructions": [
+        {
+          "name": "cancelBTCMakerLevels",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "5JPFZBK5R517q1DLxtWiD5s72YMw2DZXtHpsRxjPxtxu",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2YeaRXZYxBbfgWLwVz8oLZ7Sz9MSKQDBwapC4yrCDKra",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "FQKqynzMoUZUzNMhbnaQ9tfAJ212FrRE7C95n9hsrp6D",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "9J7gqEXKXmMKRuME4bgKeR3udrUPJLeP1R2bxyfGkS51",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "Yr9L3HMoR+0="
+        },
+        {
+          "name": "cancelETHMakerLevels",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "5JPFZBK5R517q1DLxtWiD5s72YMw2DZXtHpsRxjPxtxu",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2YeaRXZYxBbfgWLwVz8oLZ7Sz9MSKQDBwapC4yrCDKra",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2BukCb65F4pPa7RjQbvhdsmR2kUNQoEbJR7QdEmn4fuD",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "53kr4wExNMU3goZh1eviGzcqQCnjKKJaosVY1P2UUCq7",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "Yr9L3HMoR+0="
+        },
+        {
+          "name": "cancelSOLMakerLevels",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2zskx2iyCvb6Stg7RBZkt1f6MrF4dpYtMG3yMvKwqtUZ",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "5JPFZBK5R517q1DLxtWiD5s72YMw2DZXtHpsRxjPxtxu",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "2YeaRXZYxBbfgWLwVz8oLZ7Sz9MSKQDBwapC4yrCDKra",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2yLiFHyZiTj6339LJfn8PJfZPNpxdtDsq6iXi8A7Xt67",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "HCrPXLByGqRh2szQi3gj7oRdRVBNi1gccAyn4CQCT3HK",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "2U32rSzzrQS3eVmGHsnbw5kcqKF3wQXpHGd3hMq5YJok",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "CByKdU5zCv8Z6Wf99nv7AbfXiLk1fCptyhAkq7cTJgAD",
+              "isSigner": false,
+              "isWritable": true
+            },
+            {
+              "pubkey": "4NQqRHeBdLx9rcyNUoAfHkFmpk28JDNcAEmdMiTviYsn",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "Yr9L3HMoR+0="
+        }
+      ]
+    },
+    {
+      "name": "splineUpdatePrices",
+      "description": "Update deterministic spline prices for each market.",
+      "signerSeeds": ["spline-trader"],
+      "instructions": [
+        {
+          "name": "updateBTCSplinePrice",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "FNb5zCBYbHUCAjZrwDNkZyiJv5JA7S2Wx52Qu7t3gUfD",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "A71SHZp8ju4nbmKQviEXvq4eWKKsivV5JMhRutjS3Dr8",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "9J7gqEXKXmMKRuME4bgKeR3udrUPJLeP1R2bxyfGkS51",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "LZvINCXWu4yghgEAAAAAAAAB"
+        },
+        {
+          "name": "updateETHSplinePrice",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "FNb5zCBYbHUCAjZrwDNkZyiJv5JA7S2Wx52Qu7t3gUfD",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "A71SHZp8ju4nbmKQviEXvq4eWKKsivV5JMhRutjS3Dr8",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "53kr4wExNMU3goZh1eviGzcqQCnjKKJaosVY1P2UUCq7",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "LZvINCXWu4wwVwUAAAAAAAAB"
+        },
+        {
+          "name": "updateSOLSplinePrice",
+          "programId": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+          "accounts": [
+            {
+              "pubkey": "EtrnLzgbS7nMMy5fbD42kXiUzGg8XQzJ972Xtk1cjWih",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "GdxfTLSsdSY37G6fZoYtdGDSfgFnbT2EmRpuePZxWShS",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "FNb5zCBYbHUCAjZrwDNkZyiJv5JA7S2Wx52Qu7t3gUfD",
+              "isSigner": true,
+              "isWritable": false
+            },
+            {
+              "pubkey": "A71SHZp8ju4nbmKQviEXvq4eWKKsivV5JMhRutjS3Dr8",
+              "isSigner": false,
+              "isWritable": false
+            },
+            {
+              "pubkey": "4NQqRHeBdLx9rcyNUoAfHkFmpk28JDNcAEmdMiTviYsn",
+              "isSigner": false,
+              "isWritable": true
+            }
+          ],
+          "dataBase64": "LZvINCXWu4zwSQIAAAAAAAAB"
+        }
+      ]
+    }
+  ]
+}

--- a/rust/tests/sdk_localnet_fixture_tests.rs
+++ b/rust/tests/sdk_localnet_fixture_tests.rs
@@ -48,6 +48,9 @@ const STOP_LOSS_PERMISSION: u64 = 1 << 2;
 const TRADER_ONBOARDING_PERMISSION: u64 = 1 << 4;
 const ORACLE_UPDATE_TIMESTAMP: u64 = 1_900_000_001;
 const ORACLE_PRICE_EXPO: u8 = 3;
+const MAINNET_DEFAULT_TAKER_FEE_MICRO: u32 = 350;
+const MAINNET_DEFAULT_MAKER_FEE_MICRO: i32 = 50;
+const MICRO_FEE_DENOMINATOR: f64 = 1_000_000.0;
 const TRADER_CAPABILITY_HOT: u32 = 1 << 0;
 const TRADER_CAPABILITY_FROZEN: u32 = (1 << 1) | (1 << 2);
 const TRADER_CAPABILITY_COLD: u32 = (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4) | (1 << 5);
@@ -63,6 +66,18 @@ fn default_sdk_localnet_fixture_loads_and_decodes() {
     assert!(!fixture.addresses.perp_asset_map.is_empty());
     assert!(!fixture.addresses.withdraw_queue.is_empty());
     assert_eq!(fixture.markets.len(), 3);
+    assert!(
+        fixture
+            .markets
+            .iter()
+            .all(|market| market.default_taker_fee_micro == MAINNET_DEFAULT_TAKER_FEE_MICRO)
+    );
+    assert!(
+        fixture
+            .markets
+            .iter()
+            .all(|market| market.default_maker_fee_micro == MAINNET_DEFAULT_MAKER_FEE_MICRO)
+    );
     assert_eq!(fixture.actors.len(), 5);
     assert!(
         fixture
@@ -107,7 +122,7 @@ fn default_sdk_localnet_fixture_loads_and_decodes() {
 fn packaged_fixture_copy_matches_root_fixture() {
     assert_eq!(
         DEFAULT_SDK_LOCALNET_FIXTURE_JSON, ROOT_SDK_LOCALNET_FIXTURE_JSON,
-        "the Rust test harness should read rise/test-fixtures/default-localnet.json"
+        "the packaged Rust fixture should match rise/test-fixtures/default-localnet.json"
     );
 }
 
@@ -945,8 +960,8 @@ fn phoenix_metadata_from_fixture(fixture: &SdkLocalnetFixture) -> PhoenixMetadat
                     spline_pubkey: market.spline.clone(),
                     tick_size: market.tick_size_in_quote_lots_per_base_lot,
                     base_lots_decimals: market.base_lot_decimals,
-                    taker_fee: 0.0,
-                    maker_fee: 0.0,
+                    taker_fee: micro_fee_to_rate(market.default_taker_fee_micro),
+                    maker_fee: signed_micro_fee_to_rate(market.default_maker_fee_micro),
                     leverage_tiers: Vec::new(),
                     risk_factors: ExchangeRiskFactors::default(),
                     funding_interval_seconds: 1,
@@ -962,6 +977,14 @@ fn phoenix_metadata_from_fixture(fixture: &SdkLocalnetFixture) -> PhoenixMetadat
         .collect();
 
     PhoenixMetadata::new(ExchangeView { keys, markets })
+}
+
+fn micro_fee_to_rate(value: u32) -> f64 {
+    value as f64 / MICRO_FEE_DENOMINATOR
+}
+
+fn signed_micro_fee_to_rate(value: i32) -> f64 {
+    value as f64 / MICRO_FEE_DENOMINATOR
 }
 
 fn price_to_ticks(builder: &PhoenixTxBuilder<'_>, symbol: &str, price: f64) -> u64 {

--- a/rust/tests/test_harness/mod.rs
+++ b/rust/tests/test_harness/mod.rs
@@ -1,15 +1,34 @@
 #![allow(dead_code)]
 
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use base64::Engine;
+use litesvm::LiteSVM;
+use litesvm::types::{FailedTransactionMetadata, TransactionMetadata};
+use phoenix_rise::types::{
+    AuthoritySetView, ExchangeKeysView, ExchangeMarketConfig, ExchangeRiskFactors, ExchangeView,
+    MarketStatus, PhoenixMetadata,
+};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use solana_instruction::{AccountMeta, Instruction};
+use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
 
 pub const DEFAULT_SDK_LOCALNET_FIXTURE_JSON: &str =
-    include_str!("../../../test-fixtures/default-localnet.json");
+    include_str!("../../test-fixtures/default-localnet.json");
+pub const REQUIRED_PROGRAM_ARTIFACT_ENV: &str = "RISE_SDK_LOCALNET_REQUIRE_PROGRAMS";
+pub const PHOENIX_REPO_ROOT_ENV: &str = "PHOENIX_REPO_ROOT";
+pub const ETERNAL_PROGRAM_ENV: &str = "RISE_SDK_LOCALNET_ETERNAL_SO";
+pub const EMBER_PROGRAM_ENV: &str = "RISE_SDK_LOCALNET_EMBER_SO";
+pub const HAWKEYE_PROGRAM_ENV: &str = "RISE_SDK_LOCALNET_HAWKEYE_SO";
+pub const FLIGHT_PROGRAM_ENV: &str = "RISE_SDK_LOCALNET_FLIGHT_SO";
+
+const MICRO_FEE_DENOMINATOR: f64 = 1_000_000.0;
 
 #[derive(Debug, thiserror::Error)]
 pub enum SdkLocalnetFixtureError {
@@ -90,6 +109,10 @@ pub struct FixtureMarket {
     pub orderbook: String,
     pub spline: String,
     pub signer_seed: String,
+    #[serde(default)]
+    pub default_taker_fee_micro: u32,
+    #[serde(default)]
+    pub default_maker_fee_micro: i32,
     pub base_lot_decimals: i8,
     pub tick_size_in_quote_lots_per_base_lot: u64,
     pub initial_mark_price_atoms: u64,
@@ -196,9 +219,434 @@ pub fn decode_fixture_instruction(
     })
 }
 
-fn parse_pubkey(value: &str) -> Result<Pubkey, SdkLocalnetFixtureError> {
+pub fn parse_pubkey(value: &str) -> Result<Pubkey, SdkLocalnetFixtureError> {
     Pubkey::from_str(value).map_err(|source| SdkLocalnetFixtureError::InvalidPubkey {
         value: value.to_string(),
         reason: source.to_string(),
     })
+}
+
+pub fn parse_pubkeys(values: &[String]) -> Vec<Pubkey> {
+    values
+        .iter()
+        .map(|value| parse_pubkey(value).expect("fixture pubkey should parse"))
+        .collect()
+}
+
+pub fn phoenix_metadata_from_fixture(fixture: &SdkLocalnetFixture) -> PhoenixMetadata {
+    let payer = fixture
+        .signers
+        .iter()
+        .find(|signer| signer.seed == "payer")
+        .expect("payer signer should exist")
+        .pubkey
+        .clone();
+    let authorities = AuthoritySetView {
+        root_authority: payer.clone(),
+        risk_authority: payer.clone(),
+        market_authority: payer.clone(),
+        oracle_authority: payer.clone(),
+    };
+    let keys = ExchangeKeysView {
+        program_id: None,
+        global_config: fixture.addresses.global_config.clone(),
+        current_authorities: authorities.clone(),
+        pending_authorities: authorities,
+        canonical_mint: fixture
+            .mints
+            .iter()
+            .find(|mint| mint.name == "phoenixCollateral")
+            .map(|mint| mint.pubkey.clone())
+            .unwrap_or_else(|| fixture.addresses.global_vault.clone()),
+        global_vault: fixture.addresses.global_vault.clone(),
+        perp_asset_map: fixture.addresses.perp_asset_map.clone(),
+        global_trader_index: fixture.addresses.global_trader_index.clone(),
+        active_trader_buffer: fixture.addresses.active_trader_buffer.clone(),
+        withdraw_queue: fixture.addresses.withdraw_queue.clone(),
+    };
+    let markets = fixture
+        .markets
+        .iter()
+        .enumerate()
+        .map(|(asset_id, market)| {
+            (
+                market.symbol.clone(),
+                ExchangeMarketConfig {
+                    symbol: market.symbol.clone(),
+                    asset_id: asset_id as u32,
+                    market_status: MarketStatus::Active,
+                    metadata: None,
+                    market_pubkey: market.orderbook.clone(),
+                    spline_pubkey: market.spline.clone(),
+                    tick_size: market.tick_size_in_quote_lots_per_base_lot,
+                    base_lots_decimals: market.base_lot_decimals,
+                    taker_fee: micro_fee_to_rate(market.default_taker_fee_micro),
+                    maker_fee: signed_micro_fee_to_rate(market.default_maker_fee_micro),
+                    leverage_tiers: Vec::new(),
+                    risk_factors: ExchangeRiskFactors::default(),
+                    funding_interval_seconds: 1,
+                    funding_period_seconds: 1,
+                    max_funding_rate_per_interval: 0.0,
+                    open_interest_cap_base_lots: 0_u64.into(),
+                    max_liquidation_size_base_lots: 0_u64.into(),
+                    isolated_only: false,
+                    stats_snapshot: None,
+                },
+            )
+        })
+        .collect();
+
+    PhoenixMetadata::new(ExchangeView { keys, markets })
+}
+
+fn micro_fee_to_rate(value: u32) -> f64 {
+    value as f64 / MICRO_FEE_DENOMINATOR
+}
+
+fn signed_micro_fee_to_rate(value: i32) -> f64 {
+    value as f64 / MICRO_FEE_DENOMINATOR
+}
+
+#[derive(Clone, Debug)]
+pub struct SdkLocalnetProgramPaths {
+    pub phoenix_eternal: PathBuf,
+    pub ember: PathBuf,
+    pub hawkeye: Option<PathBuf>,
+    pub flight: Option<PathBuf>,
+}
+
+pub struct SdkLocalnetContext {
+    pub fixture: SdkLocalnetFixture,
+    pub svm: LiteSVM,
+    signers_by_seed: HashMap<String, Keypair>,
+    signer_seed_by_pubkey: HashMap<Pubkey, String>,
+}
+
+impl SdkLocalnetContext {
+    pub fn new(fixture: SdkLocalnetFixture, program_paths: SdkLocalnetProgramPaths) -> Self {
+        let mut svm = LiteSVM::new();
+        load_program(
+            &mut svm,
+            &fixture.programs.phoenix_eternal,
+            &program_paths.phoenix_eternal,
+        );
+        load_program(&mut svm, &fixture.programs.ember, &program_paths.ember);
+        if let Some(hawkeye) = program_paths.hawkeye.as_ref() {
+            load_program(
+                &mut svm,
+                &phoenix_rise::HAWKEYE_PROGRAM_ID.to_string(),
+                hawkeye,
+            );
+        }
+        if let Some(flight) = program_paths.flight.as_ref() {
+            load_program(
+                &mut svm,
+                &phoenix_rise::phoenix_rise_ix::flight::FLIGHT_PROGRAM_ID.to_string(),
+                flight,
+            );
+        }
+
+        let mut signers_by_seed = HashMap::new();
+        let mut signer_seed_by_pubkey = HashMap::new();
+        for signer_config in &fixture.signers {
+            let keypair = Keypair::new_from_array(sdk_localnet_seed_bytes(
+                &fixture.keypair_base_seed,
+                &signer_config.seed,
+            ));
+            assert_eq!(
+                keypair.pubkey(),
+                parse_pubkey(&signer_config.pubkey).expect("fixture pubkey should parse"),
+                "derived signer {} should match fixture pubkey",
+                signer_config.name
+            );
+            signer_seed_by_pubkey.insert(keypair.pubkey(), signer_config.seed.clone());
+            signers_by_seed.insert(signer_config.seed.clone(), keypair);
+        }
+
+        for signer_config in &fixture.signers {
+            if signer_config.initial_lamports == 0 {
+                continue;
+            }
+            let signer = signers_by_seed
+                .get(&signer_config.seed)
+                .expect("signer should exist");
+            svm.airdrop(&signer.pubkey(), signer_config.initial_lamports)
+                .unwrap_or_else(|error| panic!("airdrop:{} failed: {error:?}", signer_config.name));
+        }
+
+        Self {
+            fixture,
+            svm,
+            signers_by_seed,
+            signer_seed_by_pubkey,
+        }
+    }
+
+    pub fn load_program_from_path(&mut self, program_id: &Pubkey, path: &Path) {
+        let bytes = std::fs::read(path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+        self.svm
+            .add_program(*program_id, &bytes)
+            .unwrap_or_else(|error| panic!("failed to load {}: {error:?}", path.display()));
+    }
+
+    pub fn execute_setup(&mut self) {
+        for transaction in self.fixture.setup_transactions.clone() {
+            self.send_fixture_transaction(&transaction.name);
+        }
+    }
+
+    pub fn add_signer(&mut self, seed: &str, initial_lamports: u64) -> Pubkey {
+        let keypair = Keypair::new_from_array(sdk_localnet_seed_bytes(
+            &self.fixture.keypair_base_seed,
+            seed,
+        ));
+        let pubkey = keypair.pubkey();
+        self.signer_seed_by_pubkey.insert(pubkey, seed.to_string());
+        self.signers_by_seed.insert(seed.to_string(), keypair);
+        if initial_lamports > 0 {
+            self.svm
+                .airdrop(&pubkey, initial_lamports)
+                .unwrap_or_else(|error| panic!("airdrop:{seed} failed: {error:?}"));
+        }
+        pubkey
+    }
+
+    pub fn send_fixture_transaction(&mut self, name: &str) {
+        let transaction = self
+            .fixture
+            .setup_transactions
+            .iter()
+            .chain(self.fixture.action_templates.iter())
+            .find(|transaction| transaction.name == name)
+            .unwrap_or_else(|| panic!("missing fixture transaction {name}"))
+            .clone();
+        let fee_payer_seed = transaction
+            .signer_seeds
+            .iter()
+            .find(|seed| seed.as_str() == "payer")
+            .or_else(|| transaction.signer_seeds.first())
+            .expect("fixture transaction should list signer seeds")
+            .clone();
+
+        for instruction in transaction.instructions {
+            self.send_instructions(
+                vec![decode_fixture_instruction(&instruction).unwrap()],
+                &fee_payer_seed,
+                &format!("{}:{}", transaction.name, instruction.name),
+            );
+        }
+    }
+
+    pub fn send_instructions(
+        &mut self,
+        instructions: Vec<Instruction>,
+        fee_payer_seed: &str,
+        label: &str,
+    ) {
+        self.send_instructions_with_metadata(instructions, fee_payer_seed, label);
+    }
+
+    pub fn send_instructions_with_metadata(
+        &mut self,
+        instructions: Vec<Instruction>,
+        fee_payer_seed: &str,
+        label: &str,
+    ) -> TransactionMetadata {
+        self.try_send_instructions_with_metadata(instructions, fee_payer_seed)
+            .unwrap_or_else(|error| {
+                panic!(
+                    "LiteSVM transaction failed for {label}: {:?}\n{}",
+                    error.err,
+                    error.meta.logs.join("\n")
+                )
+            })
+    }
+
+    pub fn try_send_instructions_with_metadata(
+        &mut self,
+        instructions: Vec<Instruction>,
+        fee_payer_seed: &str,
+    ) -> Result<TransactionMetadata, FailedTransactionMetadata> {
+        let fee_payer = self
+            .signers_by_seed
+            .get(fee_payer_seed)
+            .unwrap_or_else(|| panic!("missing fee payer signer {fee_payer_seed}"));
+        let mut signer_pubkeys = HashSet::new();
+        let mut signers = Vec::new();
+        signer_pubkeys.insert(fee_payer.pubkey());
+        signers.push(fee_payer);
+
+        for instruction in &instructions {
+            for account in &instruction.accounts {
+                if !account.is_signer || signer_pubkeys.contains(&account.pubkey) {
+                    continue;
+                }
+                let seed = self
+                    .signer_seed_by_pubkey
+                    .get(&account.pubkey)
+                    .unwrap_or_else(|| panic!("missing signer for {}", account.pubkey));
+                let signer = self
+                    .signers_by_seed
+                    .get(seed)
+                    .unwrap_or_else(|| panic!("missing signer seed {seed}"));
+                signer_pubkeys.insert(account.pubkey);
+                signers.push(signer);
+            }
+        }
+
+        self.svm.expire_blockhash();
+        let tx = Transaction::new_signed_with_payer(
+            &instructions,
+            Some(&fee_payer.pubkey()),
+            &signers,
+            self.svm.latest_blockhash(),
+        );
+        self.svm.send_transaction(tx)
+    }
+
+    pub fn signer_pubkey(&self, seed: &str) -> Pubkey {
+        self.signers_by_seed
+            .get(seed)
+            .unwrap_or_else(|| panic!("missing signer {seed}"))
+            .pubkey()
+    }
+
+    pub fn actor(&self, name: &str) -> FixtureActor {
+        self.fixture
+            .actors
+            .iter()
+            .find(|actor| actor.name == name)
+            .unwrap_or_else(|| panic!("missing actor {name}"))
+            .clone()
+    }
+
+    pub fn actor_pubkey(&self, name: &str) -> Pubkey {
+        parse_pubkey(&self.actor(name).pubkey).expect("actor pubkey should parse")
+    }
+
+    pub fn actor_trader(&self, name: &str) -> Pubkey {
+        parse_pubkey(&self.actor(name).trader_account).expect("actor trader should parse")
+    }
+
+    pub fn market(&self, symbol: &str) -> FixtureMarket {
+        self.fixture
+            .markets
+            .iter()
+            .find(|market| market.symbol == symbol)
+            .unwrap_or_else(|| panic!("missing market {symbol}"))
+            .clone()
+    }
+
+    pub fn account_data(&self, address: &Pubkey) -> Vec<u8> {
+        self.svm
+            .get_account(address)
+            .unwrap_or_else(|| panic!("missing account {address}"))
+            .data
+    }
+}
+
+pub fn sdk_localnet_vm_required() -> bool {
+    matches!(
+        std::env::var(REQUIRED_PROGRAM_ARTIFACT_ENV).as_deref(),
+        Ok("1") | Ok("true")
+    )
+}
+
+pub fn find_sdk_localnet_program_paths() -> Option<SdkLocalnetProgramPaths> {
+    let explicit = match (
+        std::env::var(ETERNAL_PROGRAM_ENV),
+        std::env::var(EMBER_PROGRAM_ENV),
+        std::env::var(HAWKEYE_PROGRAM_ENV),
+        std::env::var(FLIGHT_PROGRAM_ENV),
+    ) {
+        (Ok(phoenix_eternal), Ok(ember), hawkeye, flight) => Some(SdkLocalnetProgramPaths {
+            phoenix_eternal: PathBuf::from(phoenix_eternal),
+            ember: PathBuf::from(ember),
+            hawkeye: hawkeye.ok().map(PathBuf::from),
+            flight: flight.ok().map(PathBuf::from),
+        }),
+        _ => None,
+    };
+    if explicit.as_ref().is_some_and(program_paths_exist) {
+        return explicit;
+    }
+
+    for root in default_program_roots() {
+        for program_paths in [
+            SdkLocalnetProgramPaths {
+                phoenix_eternal: root.join("programs/target/deploy/phoenix_eternal.so"),
+                ember: root.join("programs/target/deploy/phoenix_ember_program.so"),
+                hawkeye: optional_program_path(
+                    root.join("programs/target/deploy/phoenix_hawkeye.so"),
+                ),
+                flight: optional_program_path(
+                    root.join("programs/target/deploy/phoenix_flight.so"),
+                ),
+            },
+            SdkLocalnetProgramPaths {
+                phoenix_eternal: root.join("target/deploy/phoenix_eternal.so"),
+                ember: root.join("target/deploy/phoenix_ember_program.so"),
+                hawkeye: optional_program_path(root.join("target/deploy/phoenix_hawkeye.so")),
+                flight: optional_program_path(root.join("target/deploy/phoenix_flight.so")),
+            },
+            SdkLocalnetProgramPaths {
+                phoenix_eternal: root.join("programs/eternal/target/deploy/phoenix_eternal.so"),
+                ember: root.join("programs/ember/target/deploy/phoenix_ember_program.so"),
+                hawkeye: optional_program_path(
+                    root.join("programs/phoenix-hawkeye/target/deploy/phoenix_hawkeye.so"),
+                ),
+                flight: optional_program_path(
+                    root.join("programs/flight/target/deploy/phoenix_flight.so"),
+                ),
+            },
+        ] {
+            if program_paths_exist(&program_paths) {
+                return Some(program_paths);
+            }
+        }
+    }
+
+    None
+}
+
+fn default_program_roots() -> Vec<PathBuf> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut roots = vec![
+        manifest_dir.join("../.."),
+        std::env::current_dir().unwrap_or_else(|_| manifest_dir.clone()),
+    ];
+    if let Ok(root) = std::env::var(PHOENIX_REPO_ROOT_ENV) {
+        roots.push(PathBuf::from(root));
+    }
+    roots.sort();
+    roots.dedup();
+    roots
+}
+
+fn program_paths_exist(paths: &SdkLocalnetProgramPaths) -> bool {
+    paths.phoenix_eternal.exists()
+        && paths.ember.exists()
+        && match paths.hawkeye.as_ref() {
+            Some(hawkeye) => hawkeye.exists(),
+            None => true,
+        }
+        && match paths.flight.as_ref() {
+            Some(flight) => flight.exists(),
+            None => true,
+        }
+}
+
+fn optional_program_path(path: PathBuf) -> Option<PathBuf> {
+    path.exists().then_some(path)
+}
+
+fn load_program(svm: &mut LiteSVM, program_id: &str, path: &Path) {
+    let bytes = std::fs::read(path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+    svm.add_program(
+        parse_pubkey(program_id).expect("program id should parse"),
+        &bytes,
+    )
+    .unwrap_or_else(|error| panic!("failed to load {}: {error:?}", path.display()));
 }


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `a419e23d7d1b2a3e37696d76e85fac7f0a023f5e`
- Mode: automatic
- Synced paths:

- `rise/rust` -> `rust`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/programs` -> `programs`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `rust/CHANGELOG.md`

### Summary

- Three new cancellation/maintenance helpers added to `PhoenixTxBuilder`: `build_cancel_all_orders`, `build_cancel_up_to`, and `build_uncross_crank` (the crank is permissionless — no trader signer required).
- Matching low-level params types and instruction constructors exported from `phoenix_rise_ix`: `CancelAllParams`/`create_cancel_all_ix`, `CancelUpToParams`/`create_cancel_up_to_ix`, `UncrossCrankParams`/`create_uncross_crank_ix`.
- New granular Cargo features: `sdk`, `types`, and `test-fixture`. The default feature set changed from `[]` to `["sdk"]`.
- New `test-fixture` feature exposes `phoenix_rise::test_fixture` with `LiteSVM`-backed `SdkLocalnetContext`, fixture deserialization types, and a bundled `default-localnet.json` for in-process localnet tests.
- `ix` program constants (`PHOENIX_PROGRAM_ID`, `PHOENIX_LOG_AUTHORITY`, `PHOENIX_GLOBAL_CONFIGURATION`) now compile under `target_os = "solana"`, making the `ix` sub-crate usable in on-chain programs.

### Breaking Changes

- **Default features changed from `[]` to `["sdk"]`**: consumers who previously added `phoenix-rise` without `default-features = false` had near-zero transitive deps; they now pull in the full SDK set (`reqwest`, `tokio`, `parking_lot`, etc.). Add `default-features = false` to restore a minimal build.
- **`solana-keypair` and `ed25519-dalek` re-exports now also require `sdk`**: `PhoenixWalletSessionManager`, `PhoenixSolanaKeypairAuthSigner`, `default_solana_keypair_path`, and `PhoenixEd25519ServiceAuthSigner` are gated on `all(feature = "sdk", feature = "solana-keypair/ed25519-dalek")`. Consumers using `default-features = false` with only those features enabled will see missing-item compile errors; add `features = ["sdk"]` to restore the exports.

### Consumer Notes

- `rust_decimal = []` was previously an empty stub; it now activates `dep:rust_decimal`. The feature was always advertised but did nothing; it now pulls in the crate.
- `utoipa` and `opentelemetry` features now implicitly enable `types`/`sdk` respectively, so enabling them without `default-features = false` is safe but may add transitive deps if you were relying on those features being lighter.
- The `test-fixture` feature is intended for test harnesses only; it adds `litesvm 0.7` and `solana-commitment-config` as optional deps and is not covered by the `sdk` default.