### PR TITLE
sync: Rise TypeScript v0.4.52

### DIFF
--- a/programs/close-position-and-withdraw/Cargo.lock
+++ b/programs/close-position-and-withdraw/Cargo.lock
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.15"
+version = "0.1.13"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.6.0",

--- a/programs/close-position-and-withdraw/cli/Cargo.lock
+++ b/programs/close-position-and-withdraw/cli/Cargo.lock
@@ -1451,7 +1451,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.15"
+version = "0.1.13"
 dependencies = [
  "async-trait",
  "base64",

--- a/programs/trader-onboarder/Cargo.lock
+++ b/programs/trader-onboarder/Cargo.lock
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.15"
+version = "0.1.13"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.6.0",

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -476,3 +476,23 @@ Source Phoenix commit: `f437eb2cee153f012a3ab34e799623d34defb07f`
 - The `buildActivateReferralTxRequest` convenience method on `V1InviteClient` makes parallel HTTP calls for the permission account and exchange snapshot; pass pre-fetched `permission` and/or `exchangeAccounts` in the params object to skip those fetches.
 - The `signTransaction` callback in `BuildActivateReferralTxRequestParams` accepts a Kit `Transaction`, a base64 string, raw `Uint8Array`/`ArrayBuffer`, or any object with a `serialize()` method — covering both `@solana/kit` and legacy `@solana/web3.js` `VersionedTransaction` adapters.
 - `rentPayer` on `BuildReferralActivationTransactionParams` is deprecated: the tx-based activation flow no longer creates trader accounts on-chain. Register the trader before calling this flow.
+
+## v0.4.52 - 2026-06-25
+
+Source Phoenix commit: `f9c0326d728b06047d21c64915a6a72f8bcb1afb`
+
+### Summary
+
+- Added `withdrawalsAvailable: boolean` to `ExchangeStatusView`, `ExchangeStateSnapshot`, `ExchangeStatusChangedOp`, and `ExchangeStatusPayload` — reflects whether the exchange withdraw queue is open for withdrawals (requires exchange to be active and withdraw throttle budget to be non-zero).
+- RPC snapshot loading now fetches the withdraw queue header in parallel, using it to populate `withdrawalsAvailable`; a fetch failure is treated as available (`true`).
+- `exchangeUpdated` events in the cache store now include `withdrawalsAvailable`, and a change in its value triggers a `"status"` exchange change notification.
+- Wire adapters normalize the snake_case alias `withdrawals_available` from the server to `withdrawalsAvailable`, defaulting to `true` when the field is absent (backward-compatible with older server payloads).
+
+### Breaking Changes
+
+- `ExchangeStatusView`, `ExchangeStateSnapshot`, `ExchangeStatusChangedOp`, and `ExchangeStatusPayload` each gain a required `withdrawalsAvailable: boolean` field. Consumers who construct or assert on these types directly (e.g., in tests or typed fixtures) must add this field. Wire-parsed values from the server default to `true` when the field is missing, so runtime parsing is non-breaking.
+
+### Consumer Notes
+
+- Read `snapshot.exchange.withdrawalsAvailable` or `status.withdrawalsAvailable` to determine whether withdrawals are currently permitted before initiating a withdrawal flow.
+- No action needed for pure subscribers: existing server messages without `withdrawalsAvailable` are handled transparently with a `true` default.

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/rise",
-  "version": "0.4.51",
+  "version": "0.4.52",
   "packageManager": "bun@1.3.13",
   "repository": {
     "type": "git",

--- a/ts/src/api/exchange/types.ts
+++ b/ts/src/api/exchange/types.ts
@@ -61,12 +61,14 @@ export const ExchangeKeysSchema: z.ZodType<ExchangeKeys> = z.object({
 export interface ExchangeStatusView {
   active: boolean;
   gated: boolean;
+  withdrawalsAvailable: boolean;
 }
 
 export const ExchangeStatusViewSchema: z.ZodType<ExchangeStatusView> = z.object(
   {
     active: z.boolean(),
     gated: z.boolean(),
+    withdrawalsAvailable: z.boolean().default(true),
   }
 );
 
@@ -447,6 +449,7 @@ export interface ExchangeStateSnapshot {
   exchangeStatusFeatures: string[];
   active: boolean;
   gated: boolean;
+  withdrawalsAvailable: boolean;
 }
 
 export const ExchangeStateSnapshotSchema: z.ZodType<ExchangeStateSnapshot> =
@@ -465,6 +468,7 @@ export const ExchangeStateSnapshotSchema: z.ZodType<ExchangeStateSnapshot> =
     exchangeStatusFeatures: z.array(z.string()),
     active: z.boolean(),
     gated: z.boolean(),
+    withdrawalsAvailable: z.boolean().default(true),
   });
 
 export interface ExchangeMarketSnapshot {

--- a/ts/src/exchange-cache/_metadataShared.ts
+++ b/ts/src/exchange-cache/_metadataShared.ts
@@ -1,9 +1,14 @@
 import {
   decodeGlobalConfiguration,
   decodePerpAssetMap,
+  fetchWithdrawQueueHeader,
   fetchOrderbookHeader,
 } from "@/accounts";
-import type { GlobalConfiguration, PerpAssetMetadata } from "@/accounts";
+import type {
+  GlobalConfiguration,
+  PerpAssetMetadata,
+  WithdrawQueueHeader,
+} from "@/accounts";
 import type { AccountFetcherClient } from "@/accounts/fetcherFactory";
 import type {
   ExchangeMarketSnapshot,
@@ -103,11 +108,15 @@ const toMarketStatus = (status: number): string => {
 
 const toExchangeStateSnapshot = (
   globalConfiguration: GlobalConfiguration,
+  withdrawQueueHeader: WithdrawQueueHeader | null,
   globalTraderIndex: string[],
   activeTraderBuffer: string[],
   programId: PhoenixProgramAddress
 ): ExchangeStateSnapshot => {
   const exchangeStatusBits = globalConfiguration.exchangeStatus;
+  const active =
+    (exchangeStatusBits & 0b1000_0000) !== 0 &&
+    (exchangeStatusBits & 0b0000_0001) !== 0;
   return {
     programId,
     globalConfig: globalConfiguration.accountKey,
@@ -130,12 +139,14 @@ const toExchangeStateSnapshot = (
     withdrawQueue: globalConfiguration.withdrawQueueKey,
     exchangeStatusBits,
     exchangeStatusFeatures: toExchangeStatusFeatures(exchangeStatusBits),
-    active:
-      (exchangeStatusBits & 0b1000_0000) !== 0 &&
-      (exchangeStatusBits & 0b0000_0001) !== 0,
+    active,
     gated:
       (exchangeStatusBits & 0b1000_0000) !== 0 &&
       (exchangeStatusBits & 0b0000_0010) !== 0,
+    withdrawalsAvailable:
+      active &&
+      (withdrawQueueHeader === null ||
+        withdrawQueueHeader.withdrawThrottle.maxBudget !== 0n),
   };
 };
 
@@ -563,21 +574,26 @@ export const loadRpcSnapshot = async (
     ]),
   };
 
-  const [globalTraderIndex, activeTraderBuffer, markets] = await Promise.all([
-    getGlobalTraderIndexAddresses(helperClientWithCache),
-    getActiveTraderBufferAddresses(helperClientWithCache),
-    Promise.all(
-      perpAssetMap.metadata.entries.map(({ key, value }) =>
-        toMarketSnapshot(
-          value,
-          key,
-          fetcher,
-          pdaClient,
-          globalConfiguration.quoteDecimals
+  const [withdrawQueueHeader, globalTraderIndex, activeTraderBuffer, markets] =
+    await Promise.all([
+      fetchWithdrawQueueHeader({
+        client: helperClientWithCache,
+        address: globalConfiguration.withdrawQueueKey,
+      }).catch(() => null),
+      getGlobalTraderIndexAddresses(helperClientWithCache),
+      getActiveTraderBufferAddresses(helperClientWithCache),
+      Promise.all(
+        perpAssetMap.metadata.entries.map(({ key, value }) =>
+          toMarketSnapshot(
+            value,
+            key,
+            fetcher,
+            pdaClient,
+            globalConfiguration.quoteDecimals
+          )
         )
-      )
-    ),
-  ]);
+      ),
+    ]);
 
   return {
     version: 1,
@@ -585,6 +601,7 @@ export const loadRpcSnapshot = async (
     slotIndex: 0,
     exchange: toExchangeStateSnapshot(
       globalConfiguration,
+      withdrawQueueHeader,
       globalTraderIndex,
       activeTraderBuffer,
       phoenixProgramAddress
@@ -600,7 +617,8 @@ const determineExchangeChange = (
   if (
     previous.exchangeStatusBits !== next.exchangeStatusBits ||
     previous.active !== next.active ||
-    previous.gated !== next.gated
+    previous.gated !== next.gated ||
+    previous.withdrawalsAvailable !== next.withdrawalsAvailable
   ) {
     return "status";
   }

--- a/ts/src/exchange-cache/store.ts
+++ b/ts/src/exchange-cache/store.ts
@@ -563,6 +563,7 @@ class PhoenixExchangeCacheStoreImpl implements PhoenixExchangeCacheStore {
             exchangeStatusFeatures: [...op.newFeatures],
             active: op.active,
             gated: op.gated,
+            withdrawalsAvailable: op.withdrawalsAvailable,
           };
           events.push({
             type: "exchangeUpdated",

--- a/ts/src/ws/adapters/exchange-status/wire.ts
+++ b/ts/src/ws/adapters/exchange-status/wire.ts
@@ -5,6 +5,7 @@ export interface ExchangeStatusPayload {
   previousExchangeStatusBits: number;
   active: boolean;
   gated: boolean;
+  withdrawalsAvailable: boolean;
   authority: string;
   [key: string]: unknown;
 }
@@ -41,6 +42,7 @@ const ExchangeStatusPayloadSchema: z.ZodType<ExchangeStatusPayload> = z
       }),
     active: z.boolean(),
     gated: z.boolean(),
+    withdrawalsAvailable: z.boolean().default(true),
     authority: z.string(),
   })
   .passthrough();

--- a/ts/src/ws/adapters/exchange/wire.ts
+++ b/ts/src/ws/adapters/exchange/wire.ts
@@ -33,6 +33,7 @@ export interface ExchangeStatusChangedOp {
   disabledFeatures: string[];
   active: boolean;
   gated: boolean;
+  withdrawalsAvailable: boolean;
 }
 
 export interface MarketAddedOp {
@@ -327,6 +328,9 @@ const normalizeExchangeDeltaOp = (value: unknown): unknown => {
       if (op.disabledFeatures === undefined) {
         op.disabledFeatures = op.disabled_features;
       }
+      if (op.withdrawalsAvailable === undefined) {
+        op.withdrawalsAvailable = op.withdrawals_available ?? true;
+      }
       return op;
     case "marketStatusChanged":
       if (op.previousMarketStatus === undefined) {
@@ -398,6 +402,7 @@ const ExchangeStatusChangedOpSchema = z.object({
   disabledFeatures: z.array(z.string()),
   active: z.boolean(),
   gated: z.boolean(),
+  withdrawalsAvailable: z.boolean().default(true),
 });
 
 const ExchangeKeysUpdatedOpSchema = z.object({

--- a/ts/tests/client-exchange-subscriptions.test.ts
+++ b/ts/tests/client-exchange-subscriptions.test.ts
@@ -52,6 +52,7 @@ const buildSnapshot = (): ExchangeSnapshotView => ({
     exchangeStatusFeatures: ["initialized", "active"],
     active: true,
     gated: false,
+    withdrawalsAvailable: true,
   },
   markets: [
     {

--- a/ts/tests/exchange-adapter.test.ts
+++ b/ts/tests/exchange-adapter.test.ts
@@ -75,6 +75,7 @@ const buildSnapshotPayload = () => ({
     exchangeStatusFeatures: ["initialized", "active"],
     active: true,
     gated: false,
+    withdrawalsAvailable: true,
   },
   markets: [
     {
@@ -181,6 +182,38 @@ describe("exchange adapter", () => {
     abort.abort();
   });
 
+  it("defaults missing withdrawalsAvailable in snapshot frames to true", async () => {
+    const { ws, subscriptions } = createFakeWs();
+    const adapter = createExchangeAdapter(ws);
+    const abort = new AbortController();
+    const iterator = adapter(abort.signal)[Symbol.asyncIterator]();
+    const nextMessage = iterator.next();
+    const [subscription] = [...subscriptions.values()];
+
+    const payload = buildSnapshotPayload();
+    delete (payload.exchange as { withdrawalsAvailable?: boolean })
+      .withdrawalsAvailable;
+
+    subscription?.onMessage({
+      channel: "exchange",
+      messageType: "snapshot",
+      ...payload,
+    });
+
+    const result = await nextMessage;
+    if (result.done) {
+      throw new Error("expected exchange snapshot");
+    }
+
+    expect(result.value.messageType).toBe("snapshot");
+    if (result.value.messageType !== "snapshot") {
+      throw new Error("expected snapshot message");
+    }
+    expect(result.value.exchange.withdrawalsAvailable).toBe(true);
+
+    abort.abort();
+  });
+
   it("normalizes snake_case delta op fields from the exchange stream", async () => {
     const { ws, subscriptions } = createFakeWs();
     const adapter = createExchangeAdapter(ws);
@@ -256,6 +289,7 @@ describe("exchange adapter", () => {
       disabledFeatures: [],
       active: true,
       gated: false,
+      withdrawalsAvailable: true,
     });
     expect(result.value.ops[1]).toMatchObject({
       kind: "marketStatusChanged",

--- a/ts/tests/exchange-cache.test.ts
+++ b/ts/tests/exchange-cache.test.ts
@@ -58,6 +58,7 @@ const buildSnapshot = (
     exchangeStatusFeatures: ["initialized", "active"],
     active: true,
     gated: false,
+    withdrawalsAvailable: true,
   },
   markets: [
     {

--- a/ts/tests/exchange-metadata-client.test.ts
+++ b/ts/tests/exchange-metadata-client.test.ts
@@ -63,6 +63,7 @@ const buildSnapshot = (): ExchangeSnapshotView => ({
     exchangeStatusFeatures: ["initialized", "active"],
     active: true,
     gated: false,
+    withdrawalsAvailable: true,
   },
   markets: [
     {
@@ -462,7 +463,7 @@ describe("exchange metadata client integration", () => {
     expect(snapshot.slot).toBe(415023825n);
     expect(snapshot.slotIndex).toBe(0);
     expect(snapshot.markets.length).toBeGreaterThan(0);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(fetchOrderbookHeaderSpy).toHaveBeenCalled();
     expect(getGlobalTraderIndexAddressesSpy).toHaveBeenCalledOnce();
     expect(getActiveTraderBufferAddressesSpy).toHaveBeenCalledOnce();

--- a/ts/tests/exchange-selectors.test.ts
+++ b/ts/tests/exchange-selectors.test.ts
@@ -150,6 +150,7 @@ const createExchangeStoreState = (
         exchangeStatusFeatures: ["initialized", "active"],
         active: true,
         gated: false,
+        withdrawalsAvailable: true,
       },
       markets: [...markets],
     },

--- a/ts/tests/market-data.test.ts
+++ b/ts/tests/market-data.test.ts
@@ -37,6 +37,7 @@ const buildSnapshot = (): ExchangeSnapshotView => ({
     exchangeStatusFeatures: ["initialized", "active"],
     active: true,
     gated: false,
+    withdrawalsAvailable: true,
   },
   markets: [
     {

--- a/ts/tests/public-client-routes.test.ts
+++ b/ts/tests/public-client-routes.test.ts
@@ -339,9 +339,9 @@ describe("public client route mapping", () => {
     const markets = new V1MarketsClient(transport);
 
     await exchange.getExchange();
-    await exchange.getSnapshot();
+    const snapshot = await exchange.getSnapshot();
     await exchange.getMarket("SOL");
-    await exchange.getStatus();
+    const status = await exchange.getStatus();
     await exchange.getKeys();
     await exchange.getMarkets();
     await markets.getMarkets();
@@ -351,6 +351,9 @@ describe("public client route mapping", () => {
     await markets.getNextMarketCalendarTransition("XAU");
     await markets.getCommodityMarketCalendar();
     await markets.getMarketCalendar("XAU");
+
+    expect(snapshot.exchange.withdrawalsAvailable).toBe(true);
+    expect(status.withdrawalsAvailable).toBe(true);
 
     expect(records).toEqual([
       {


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `f9c0326d728b06047d21c64915a6a72f8bcb1afb`
- Mode: manual
- Synced paths:

- `rise/ts` -> `ts`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/programs` -> `programs`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `ts/CHANGELOG.md`

### Summary

- Added `withdrawalsAvailable: boolean` to `ExchangeStatusView`, `ExchangeStateSnapshot`, `ExchangeStatusChangedOp`, and `ExchangeStatusPayload` — reflects whether the exchange withdraw queue is open for withdrawals (requires exchange to be active and withdraw throttle budget to be non-zero).
- RPC snapshot loading now fetches the withdraw queue header in parallel, using it to populate `withdrawalsAvailable`; a fetch failure is treated as available (`true`).
- `exchangeUpdated` events in the cache store now include `withdrawalsAvailable`, and a change in its value triggers a `"status"` exchange change notification.
- Wire adapters normalize the snake_case alias `withdrawals_available` from the server to `withdrawalsAvailable`, defaulting to `true` when the field is absent (backward-compatible with older server payloads).

### Breaking Changes

- `ExchangeStatusView`, `ExchangeStateSnapshot`, `ExchangeStatusChangedOp`, and `ExchangeStatusPayload` each gain a required `withdrawalsAvailable: boolean` field. Consumers who construct or assert on these types directly (e.g., in tests or typed fixtures) must add this field. Wire-parsed values from the server default to `true` when the field is missing, so runtime parsing is non-breaking.

### Consumer Notes

- Read `snapshot.exchange.withdrawalsAvailable` or `status.withdrawalsAvailable` to determine whether withdrawals are currently permitted before initiating a withdrawal flow.
- No action needed for pure subscribers: existing server messages without `withdrawalsAvailable` are handled transparently with a `true` default.