### PR TITLE
sync: Rise Rust v0.1.14

### DIFF
--- a/programs/close-position-and-withdraw/Cargo.lock
+++ b/programs/close-position-and-withdraw/Cargo.lock
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.6.0",

--- a/programs/close-position-and-withdraw/cli/Cargo.lock
+++ b/programs/close-position-and-withdraw/cli/Cargo.lock
@@ -1451,7 +1451,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "async-trait",
  "base64",

--- a/programs/trader-onboarder/Cargo.lock
+++ b/programs/trader-onboarder/Cargo.lock
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.6.0",

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -215,3 +215,26 @@ Source Phoenix commit: `d1ccda811fc68e0cbf1fbf5d3e6d0235d508c3db`
 - Update your `Cargo.toml` to `phoenix-rise = "0.1.13"`.
 - Delegated onboarding flows that previously required manual capability bitmask construction can now use the exported `TRADER_CAPABILITY_*` constants and `is_trader_ready` to check readiness without hardcoding bit values.
 - The new `permission` instruction builders (`create_permission_ix`, `set_permission_delegated_ix`) are needed for integrators who programmatically manage delegated trader-onboarding budgets; see the `delegated_trader_management_onboarding` example for the end-to-end flow.
+
+## v0.1.14 - 2026-06-24
+
+Source Phoenix commit: `f2a0ac7b66eae85ef8ddb3f21ff68ce6f7063754`
+
+### Summary
+
+- Added two new unauthenticated referral activation endpoints to `InviteClient`: `get_referral_activation_permission()` (`GET /v1/referral/activation-permission`) and `activate_referral_tx()` (`POST /v1/referral/activate-tx`), enabling a wallet-side transaction-signing flow for referral activation.
+- New public types `ActivateReferralTxRequest`, `ActivateReferralTxResponse`, and `ReferralActivationPermissionResponse` are re-exported from the crate root under the `sdk` feature flag.
+- Added `ExchangeStatusView` struct (fields: `active`, `gated`, `withdrawals_available`) and a corresponding `ExchangeClient::get_status()` method (`GET /exchange/status`).
+- Added `withdrawals_available: bool` field to `ExchangeStateSnapshot` and the `ExchangeStatusChanged` variant of `ExchangeDeltaOp`; both default to `true` when the field is absent from the wire payload (backward-compatible deserialization).
+- Added a `referral_activation_tx` example (requires `solana-keypair` feature) demonstrating the full end-to-end activate-tx wallet integration flow.
+
+### Breaking Changes
+
+- None identified in the synced diff.
+
+### Consumer Notes
+
+- If you pattern-match on `ExchangeDeltaOp::ExchangeStatusChanged`, you must now bind or ignore the new `withdrawals_available` field; omitting it is a compile error.
+- `ExchangeStateSnapshot` gains a `withdrawals_available` field; struct literal construction (if any) must be updated to include it.
+- `ExchangeStatusView` is a new type exported from `phoenix_rise_types`; no migration needed unless a local type of the same name exists.
+- The `activate_referral_tx` flow requires the trader account to exist on-chain before calling `/v1/referral/activate-tx`; use `--register-if-missing` (or call `register_trader` first) if the account may not exist yet.

--- a/rust/CRATES.md
+++ b/rust/CRATES.md
@@ -9,7 +9,7 @@
 
 ```toml
 [dependencies]
-phoenix-rise = "0.1.13"
+phoenix-rise = "0.1.14"
 ```
 
 Optional features:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2539,11 +2539,12 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "async-trait",
  "axum",
  "base64 0.22.1",
+ "bincode",
  "borsh 1.6.0",
  "bs58",
  "bytemuck",
@@ -2592,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-sdk-cli"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "clap",
  "phoenix-rise",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,7 +17,7 @@ publish = true
 readme = "CRATES.md"
 repository = "https://github.com/Ellipsis-Labs/rise-public"
 rust-version = "1.84.0"
-version = "0.1.13"
+version = "0.1.14"
 
 [[example]]
 name              = "cancel_all_conditional_orders"
@@ -57,6 +57,10 @@ required-features = ["solana-keypair"]
 
 [[example]]
 name              = "onboard_trader_delegated"
+required-features = ["solana-keypair"]
+
+[[example]]
+name              = "referral_activation_tx"
 required-features = ["solana-keypair"]
 
 [[example]]
@@ -135,6 +139,7 @@ utoipa = { version = "5.4", features = ["chrono"], optional = true }
 
 [dev-dependencies]
 axum                            = "0.8"
+bincode                         = "1.3.3"
 litesvm                         = "0.7"
 opentelemetry_sdk               = { version = "0.31", features = ["trace"] }
 proptest                        = "1.11.0"
@@ -160,7 +165,7 @@ publish      = true
 readme       = "CRATES.md"
 repository   = "https://github.com/Ellipsis-Labs/rise-public"
 rust-version = "1.89.0"
-version      = "0.1.13"
+version      = "0.1.14"
 
 [workspace.dependencies]
 clap = { version = "4.5", features = ["derive"] }

--- a/rust/examples/referral_activation_tx.rs
+++ b/rust/examples/referral_activation_tx.rs
@@ -1,0 +1,436 @@
+//! Example: activate a referral with the public activate-tx flow.
+//!
+//! This flow mirrors a wallet integration:
+//!
+//! 1. Fetch `/v1/referral/activation-permission`.
+//! 2. Build the delegated onboarding/capability transaction.
+//! 3. Sign it with the trader authority.
+//! 4. Submit it to `/v1/referral/activate-tx`; the API adds the onboarder
+//!    signature, submits the transaction, and waits for activation.
+//! 5. Wait 5s, then fetch and print the trader account from RPC.
+//!
+//! The activate-tx endpoint does not create the trader account. Pass
+//! `--register-if-missing` to register the trader first with the same keypair.
+//!
+//! Run with:
+//!   PHOENIX_ENV=beta \
+//!   cargo run -p phoenix-rise --example referral_activation_tx \
+//!     --features solana-keypair -- <REFERRAL_CODE> \
+//!     --api-url http://127.0.0.1:8080 \
+//!     --rpc-url <RPC_URL> \
+//!     --trader-keypair-path ~/.config/solana/id.json \
+//!     --register-if-missing
+
+use std::str::FromStr;
+use std::time::Duration;
+use std::{env, process};
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use phoenix_rise::accounts::{Permission, Trader};
+use phoenix_rise::phoenix_rise_ix::{
+    OnboardTraderDelegatedParams, RegisterTraderParams, TRADER_ONBOARDING_PERMISSION,
+    create_onboard_trader_delegated_ix, create_register_trader_ix,
+};
+use phoenix_rise::{ActivateReferralTxRequest, PhoenixHttpClient, PhoenixMetadata, TraderKey};
+use solana_commitment_config::CommitmentConfig;
+use solana_keypair::read_keypair_file;
+use solana_pubkey::Pubkey;
+use solana_rpc_client::nonblocking::rpc_client::RpcClient;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+use solana_transaction::versioned::VersionedTransaction;
+
+const DEFAULT_API_URL: &str = "https://perp-api.phoenix.trade";
+const DEFAULT_RPC_URL: &str = "https://api.mainnet-beta.solana.com";
+const DEFAULT_MAX_POSITIONS: u64 = 128;
+const DEFAULT_POST_SUBMIT_WAIT_SECONDS: u64 = 5;
+const USAGE: &str = r#"Usage:
+  cargo run -p phoenix-rise --example referral_activation_tx --features solana-keypair -- <REFERRAL_CODE> [options]
+
+Options:
+  --api-url <url>                       Phoenix API URL
+  --rpc-url <url>                       Solana RPC URL
+  --trader-keypair-path <path>          Trader authority keypair path
+  --trader-pda-index <n>                Trader PDA index (default: 0)
+  --trader-subaccount-index <n>         Trader subaccount index (default: 0; activate-tx currently supports 0 only)
+  --register-if-missing                 Create the trader account first if it is missing
+  --max-positions <n>                   Max positions for --register-if-missing (default: 128)
+  --post-submit-wait-seconds <n>        Seconds to wait before printing the RPC trader account (default: 5)
+  -h, --help                            Show this help
+
+Environment:
+  PHOENIX_API_URL
+  PHOENIX_RPC_URL / SOLANA_RPC_URL
+  TRADER_KEYPAIR_PATH / KEYPAIR_PATH
+  PHOENIX_ENV=beta                      Use beta Phoenix instruction addresses
+"#;
+
+struct CliArgs {
+    referral_code: String,
+    api_url: String,
+    rpc_url: String,
+    trader_keypair_path: String,
+    trader_pda_index: u8,
+    trader_subaccount_index: u8,
+    register_if_missing: bool,
+    max_positions: u64,
+    post_submit_wait: Duration,
+}
+
+fn fail(message: &str) -> ! {
+    eprintln!("{message}");
+    eprintln!();
+    eprintln!("{USAGE}");
+    process::exit(1);
+}
+
+fn default_keypair_path() -> String {
+    let home = env::var("HOME").expect("HOME environment variable not set");
+    format!("{home}/.config/solana/id.json")
+}
+
+fn parse_u8(value: &str, flag: &str) -> u8 {
+    value
+        .parse::<u8>()
+        .unwrap_or_else(|_| fail(&format!("Invalid value for {flag}: {value}")))
+}
+
+fn parse_u64(value: &str, flag: &str) -> u64 {
+    value
+        .parse::<u64>()
+        .unwrap_or_else(|_| fail(&format!("Invalid value for {flag}: {value}")))
+}
+
+fn parse_max_positions(value: &str) -> u64 {
+    let max_positions = parse_u64(value, "--max-positions");
+    if max_positions == 0 || max_positions > DEFAULT_MAX_POSITIONS {
+        fail("--max-positions must be between 1 and 128");
+    }
+    max_positions
+}
+
+fn parse_args(argv: Vec<String>) -> CliArgs {
+    let mut api_url = env::var("PHOENIX_API_URL").unwrap_or_else(|_| DEFAULT_API_URL.to_string());
+    let mut rpc_url = env::var("PHOENIX_RPC_URL")
+        .or_else(|_| env::var("SOLANA_RPC_URL"))
+        .unwrap_or_else(|_| DEFAULT_RPC_URL.to_string());
+    let mut trader_keypair_path = env::var("TRADER_KEYPAIR_PATH")
+        .or_else(|_| env::var("KEYPAIR_PATH"))
+        .unwrap_or_else(|_| default_keypair_path());
+    let mut trader_pda_index = 0;
+    let mut trader_subaccount_index = 0;
+    let mut register_if_missing = false;
+    let mut max_positions = DEFAULT_MAX_POSITIONS;
+    let mut post_submit_wait = Duration::from_secs(DEFAULT_POST_SUBMIT_WAIT_SECONDS);
+    let mut referral_code = None::<String>;
+
+    let mut args = argv.into_iter().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--api-url" => {
+                api_url = args
+                    .next()
+                    .unwrap_or_else(|| fail("Missing value for --api-url"));
+            }
+            "--rpc-url" => {
+                rpc_url = args
+                    .next()
+                    .unwrap_or_else(|| fail("Missing value for --rpc-url"));
+            }
+            "--trader-keypair-path" => {
+                trader_keypair_path = args
+                    .next()
+                    .unwrap_or_else(|| fail("Missing value for --trader-keypair-path"));
+            }
+            "--trader-pda-index" => {
+                let value = args
+                    .next()
+                    .unwrap_or_else(|| fail("Missing value for --trader-pda-index"));
+                trader_pda_index = parse_u8(&value, "--trader-pda-index");
+            }
+            "--trader-subaccount-index" => {
+                let value = args
+                    .next()
+                    .unwrap_or_else(|| fail("Missing value for --trader-subaccount-index"));
+                trader_subaccount_index = parse_u8(&value, "--trader-subaccount-index");
+            }
+            "--register-if-missing" => {
+                register_if_missing = true;
+            }
+            "--max-positions" => {
+                let value = args
+                    .next()
+                    .unwrap_or_else(|| fail("Missing value for --max-positions"));
+                max_positions = parse_max_positions(&value);
+            }
+            "--post-submit-wait-seconds" => {
+                let value = args
+                    .next()
+                    .unwrap_or_else(|| fail("Missing value for --post-submit-wait-seconds"));
+                post_submit_wait =
+                    Duration::from_secs(parse_u64(&value, "--post-submit-wait-seconds"));
+            }
+            "-h" | "--help" => {
+                println!("{USAGE}");
+                process::exit(0);
+            }
+            value if value.starts_with('-') => fail(&format!("Unknown argument: {value}")),
+            value => {
+                if referral_code.is_some() {
+                    fail(&format!("Unexpected positional argument: {value}"));
+                }
+                referral_code = Some(value.to_string());
+            }
+        }
+    }
+
+    if trader_subaccount_index != 0 {
+        fail("--trader-subaccount-index must be 0 for /v1/referral/activate-tx");
+    }
+
+    CliArgs {
+        referral_code: referral_code
+            .unwrap_or_else(|| fail("Expected exactly one positional argument: <REFERRAL_CODE>")),
+        api_url,
+        rpc_url,
+        trader_keypair_path,
+        trader_pda_index,
+        trader_subaccount_index,
+        register_if_missing,
+        max_positions,
+        post_submit_wait,
+    }
+}
+
+async fn fetch_trader(
+    rpc: &RpcClient,
+    trader_account: &Pubkey,
+) -> Result<Option<Trader>, Box<dyn std::error::Error>> {
+    let Some(account) = rpc
+        .get_account_with_commitment(trader_account, CommitmentConfig::confirmed())
+        .await?
+        .value
+    else {
+        return Ok(None);
+    };
+    Ok(Some(Trader::try_from_account_bytes(&account.data)?))
+}
+
+async fn register_trader_if_missing(
+    rpc: &RpcClient,
+    trader_keypair: &solana_keypair::Keypair,
+    trader: &TraderKey,
+    max_positions: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if fetch_trader(rpc, &trader.pda()).await?.is_some() {
+        println!("Trader account already exists; skipping registration.");
+        return Ok(());
+    }
+
+    let register_params = RegisterTraderParams::builder()
+        .payer(trader_keypair.pubkey())
+        .trader(trader.authority())
+        .trader_account(trader.pda())
+        .max_positions(max_positions)
+        .trader_pda_index(trader.pda_index)
+        .subaccount_index(trader.subaccount_index)
+        .build()?;
+    let instruction: solana_instruction::Instruction =
+        create_register_trader_ix(register_params)?.into();
+    let blockhash = rpc.get_latest_blockhash().await?;
+    let tx = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&trader_keypair.pubkey()),
+        &[trader_keypair],
+        blockhash,
+    );
+    let signature = rpc.send_and_confirm_transaction(&tx).await?;
+    println!("Registered trader account.");
+    println!("Register signature: {signature}");
+    Ok(())
+}
+
+async fn fetch_permission_account(
+    rpc: &RpcClient,
+    permission_account: &Pubkey,
+) -> Result<Permission, Box<dyn std::error::Error>> {
+    let account = rpc
+        .get_account_with_commitment(permission_account, CommitmentConfig::confirmed())
+        .await?
+        .value
+        .ok_or_else(|| format!("Permission account does not exist: {permission_account}"))?;
+    Ok(Permission::try_from_account_bytes(&account.data)?)
+}
+
+fn validate_permission(
+    permission: &Permission,
+    expected_risk_authority: Pubkey,
+    expected_onboarder: Pubkey,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if permission.permission_authority != expected_risk_authority {
+        return Err(format!(
+            "Permission authority mismatch: expected {expected_risk_authority}, got {}",
+            permission.permission_authority
+        )
+        .into());
+    }
+    if permission.delegated_key != expected_onboarder {
+        return Err(format!(
+            "Permission delegated key mismatch: expected {expected_onboarder}, got {}",
+            permission.delegated_key
+        )
+        .into());
+    }
+    if permission.permission & TRADER_ONBOARDING_PERMISSION != TRADER_ONBOARDING_PERMISSION {
+        return Err("Permission account is missing trader-onboarding permission".into());
+    }
+    if permission.allowed_signer_actions == 0 {
+        return Err("Permission account has no remaining signer actions".into());
+    }
+    Ok(())
+}
+
+fn parse_pubkey(value: &str, field: &str) -> Result<Pubkey, Box<dyn std::error::Error>> {
+    Pubkey::from_str(value).map_err(|error| format!("Invalid {field}: {error}").into())
+}
+
+async fn build_signed_activation_transaction_base64(
+    trader_keypair: &solana_keypair::Keypair,
+    trader: &TraderKey,
+    trader_onboarder: Pubkey,
+    permission_account: Pubkey,
+    global_trader_index: Vec<Pubkey>,
+    active_trader_buffer: Vec<Pubkey>,
+    rpc: &RpcClient,
+) -> Result<(String, String), Box<dyn std::error::Error>> {
+    let onboard_params = OnboardTraderDelegatedParams::builder()
+        .authority(trader_onboarder)
+        .permission_account(permission_account)
+        .trader_account(trader.pda())
+        .global_trader_index(global_trader_index)
+        .active_trader_buffer(active_trader_buffer)
+        .build()?;
+    let instruction: solana_instruction::Instruction =
+        create_onboard_trader_delegated_ix(onboard_params)?.into();
+
+    let mut tx = Transaction::new_with_payer(&[instruction], Some(&trader_keypair.pubkey()));
+    let recent_blockhash = rpc.get_latest_blockhash().await?;
+    tx.try_partial_sign(&[trader_keypair], recent_blockhash)?;
+    let versioned = VersionedTransaction::from(tx);
+    let bytes = bincode::serialize(&versioned)?;
+    Ok((BASE64_STANDARD.encode(bytes), recent_blockhash.to_string()))
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let argv: Vec<String> = env::args().collect();
+    if argv.len() == 1 {
+        println!("{USAGE}");
+        return Ok(());
+    }
+
+    let args = parse_args(argv);
+    let trader_keypair = read_keypair_file(&args.trader_keypair_path)
+        .map_err(|error| format!("Failed to read trader keypair: {error}"))?;
+    let trader = TraderKey::new_with_idx(
+        trader_keypair.pubkey(),
+        args.trader_pda_index,
+        args.trader_subaccount_index,
+    );
+    let rpc = RpcClient::new_with_commitment(args.rpc_url.clone(), CommitmentConfig::confirmed());
+    let http = PhoenixHttpClient::new_public(args.api_url.clone())?;
+
+    println!("API URL:             {}", args.api_url);
+    println!("RPC URL:             {}", args.rpc_url);
+    println!("Trader authority:    {}", trader.authority());
+    println!("Trader account:      {}", trader.pda());
+    println!("Referral code:       {}", args.referral_code);
+
+    if args.register_if_missing {
+        register_trader_if_missing(&rpc, &trader_keypair, &trader, args.max_positions).await?;
+    } else if fetch_trader(&rpc, &trader.pda()).await?.is_none() {
+        return Err(
+            "Trader account is missing. Re-run with --register-if-missing or register it first."
+                .into(),
+        );
+    }
+
+    println!("\nFetching referral activation permission...");
+    let permission_response = http.invite().get_referral_activation_permission().await?;
+    let trader_onboarder = parse_pubkey(&permission_response.trader_onboarder, "trader_onboarder")?;
+    let risk_authority = parse_pubkey(&permission_response.risk_authority, "risk_authority")?;
+    let permission_account = parse_pubkey(
+        &permission_response.permission_account,
+        "permission_account",
+    )?;
+    println!("Trader onboarder:    {trader_onboarder}");
+    println!("Risk authority:      {risk_authority}");
+    println!("Permission account:  {permission_account}");
+
+    let permission = fetch_permission_account(&rpc, &permission_account).await?;
+    validate_permission(&permission, risk_authority, trader_onboarder)?;
+    println!("Permission bits:     {}", permission.permission);
+    println!("Signer actions left: {}", permission.allowed_signer_actions);
+
+    println!("\nFetching exchange metadata...");
+    let exchange = http.get_exchange().await?.into();
+    let metadata = PhoenixMetadata::new(exchange);
+    let keys = metadata.keys();
+    let global_trader_index = keys
+        .global_trader_index
+        .iter()
+        .map(|value| parse_pubkey(value, "global_trader_index"))
+        .collect::<Result<Vec<_>, _>>()?;
+    let active_trader_buffer = keys
+        .active_trader_buffer
+        .iter()
+        .map(|value| parse_pubkey(value, "active_trader_buffer"))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let (transaction, recent_blockhash) = build_signed_activation_transaction_base64(
+        &trader_keypair,
+        &trader,
+        trader_onboarder,
+        permission_account,
+        global_trader_index,
+        active_trader_buffer,
+        &rpc,
+    )
+    .await?;
+
+    println!("\nSubmitting /v1/referral/activate-tx...");
+    let response = http
+        .invite()
+        .activate_referral_tx(&ActivateReferralTxRequest {
+            referral_code: args.referral_code,
+            trader_authority: trader.authority().to_string(),
+            trader_pda_index: Some(args.trader_pda_index),
+            trader_subaccount_index: Some(args.trader_subaccount_index),
+            recent_blockhash,
+            transaction,
+        })
+        .await?;
+    println!("Activation status:   {}", response.status);
+    println!("Response trader PDA: {}", response.trader_pda);
+    if let Some(signature) = response.signature {
+        println!("Activation sig:      {signature}");
+    }
+
+    println!(
+        "\nWaiting {}s before fetching trader account from RPC...",
+        args.post_submit_wait.as_secs()
+    );
+    tokio::time::sleep(args.post_submit_wait).await;
+
+    let trader_account = fetch_trader(&rpc, &trader.pda()).await?.ok_or_else(|| {
+        format!(
+            "Trader account still missing after activation: {}",
+            trader.pda()
+        )
+    })?;
+    println!("\nRPC trader account:");
+    println!("{trader_account:#?}");
+
+    Ok(())
+}

--- a/rust/src/api/exchange.rs
+++ b/rust/src/api/exchange.rs
@@ -1,6 +1,6 @@
 use crate::http_client::HttpClientInner;
 use crate::phoenix_rise_types::{
-    ExchangeKeysView, ExchangeResponse, ExchangeSnapshotView, PhoenixHttpError,
+    ExchangeKeysView, ExchangeResponse, ExchangeSnapshotView, ExchangeStatusView, PhoenixHttpError,
 };
 
 pub struct ExchangeClient<'a> {
@@ -18,5 +18,9 @@ impl ExchangeClient<'_> {
 
     pub async fn get_snapshot(&self) -> Result<ExchangeSnapshotView, PhoenixHttpError> {
         self.http.get_json("/v1/exchange/snapshot").await
+    }
+
+    pub async fn get_status(&self) -> Result<ExchangeStatusView, PhoenixHttpError> {
+        self.http.get_json("/exchange/status").await
     }
 }

--- a/rust/src/api/invite.rs
+++ b/rust/src/api/invite.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use solana_pubkey::Pubkey;
 
 use crate::http_client::HttpClientInner;
@@ -51,6 +51,23 @@ impl InviteClient<'_> {
             .map_err(with_referral_activation_auth_context)?;
         Ok(response.trader_pda)
     }
+
+    pub async fn get_referral_activation_permission(
+        &self,
+    ) -> Result<ReferralActivationPermissionResponse, PhoenixHttpError> {
+        self.http
+            .get_json("/v1/referral/activation-permission")
+            .await
+    }
+
+    pub async fn activate_referral_tx(
+        &self,
+        request: &ActivateReferralTxRequest,
+    ) -> Result<ActivateReferralTxResponse, PhoenixHttpError> {
+        self.http
+            .post_json("/v1/referral/activate-tx", request)
+            .await
+    }
 }
 
 fn with_referral_activation_auth_context(error: PhoenixHttpError) -> PhoenixHttpError {
@@ -97,7 +114,35 @@ struct ActivateReferralRequest<'a> {
     referral_code: &'a str,
 }
 
-#[derive(serde::Deserialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ActivateReferralTxRequest {
+    pub referral_code: String,
+    pub trader_authority: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trader_pda_index: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trader_subaccount_index: Option<u8>,
+    pub recent_blockhash: String,
+    pub transaction: String,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct ActivateReferralTxResponse {
+    #[serde(default)]
+    pub signature: Option<String>,
+    pub trader_pda: String,
+    pub referral_code: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct ReferralActivationPermissionResponse {
+    pub trader_onboarder: String,
+    pub risk_authority: String,
+    pub permission_account: String,
+}
+
+#[derive(Deserialize)]
 struct ActivateInviteResponse {
     trader_pda: String,
 }

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -12,7 +12,10 @@ pub use candles::CandlesClient;
 pub use collateral::CollateralClient;
 pub use exchange::ExchangeClient;
 pub use funding::FundingClient;
-pub use invite::InviteClient;
+pub use invite::{
+    ActivateReferralTxRequest, ActivateReferralTxResponse, InviteClient,
+    ReferralActivationPermissionResponse,
+};
 pub use markets::MarketsClient;
 pub use orders::OrdersClient;
 pub use traders::TradersClient;

--- a/rust/src/exchange_cache.rs
+++ b/rust/src/exchange_cache.rs
@@ -210,12 +210,14 @@ impl PhoenixExchangeCacheStore {
                     new_features,
                     active,
                     gated,
+                    withdrawals_available,
                     ..
                 } => {
                     next_snapshot.exchange.exchange_status_bits = *new_bits;
                     next_snapshot.exchange.exchange_status_features = new_features.clone();
                     next_snapshot.exchange.active = *active;
                     next_snapshot.exchange.gated = *gated;
+                    next_snapshot.exchange.withdrawals_available = *withdrawals_available;
                     events.push(ExchangeCacheEvent::ExchangeUpdated {
                         change: ExchangeCacheExchangeChangeKind::Status,
                         slot: delta.slot,
@@ -534,6 +536,7 @@ mod tests {
                 exchange_status_features: vec!["initialized".to_string(), "active".to_string()],
                 active: true,
                 gated: false,
+                withdrawals_available: true,
             },
             markets: vec![ExchangeMarketSnapshot {
                 symbol: "SOL-PERP".to_string(),

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -101,8 +101,9 @@ mod ws_client;
 pub use accounts::{AccountDataFetcher, PhoenixAccountClient, PhoenixAccountClientError};
 #[cfg(feature = "sdk")]
 pub use api::{
-    CandlesClient, CollateralClient, ExchangeClient, FundingClient, InviteClient, MarketsClient,
-    OrdersClient, TradersClient, TradesClient,
+    ActivateReferralTxRequest, ActivateReferralTxResponse, CandlesClient, CollateralClient,
+    ExchangeClient, FundingClient, InviteClient, MarketsClient, OrdersClient,
+    ReferralActivationPermissionResponse, TradersClient, TradesClient,
 };
 #[cfg(all(feature = "sdk", feature = "solana-keypair"))]
 pub use auth::PhoenixWalletSessionManager;

--- a/rust/src/types/exchange.rs
+++ b/rust/src/types/exchange.rs
@@ -188,6 +188,20 @@ pub struct ExchangeResponse {
     pub markets: Vec<ExchangeMarketConfig>,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ExchangeStatusView {
+    pub active: bool,
+    pub gated: bool,
+    #[serde(default = "default_withdrawals_available")]
+    pub withdrawals_available: bool,
+}
+
+// TODO: remove me when the migrations are finished
+fn default_withdrawals_available() -> bool {
+    true
+}
+
 /// Exchange configuration containing keys and market configs.
 ///
 /// This struct is populated by querying the Phoenix API for exchange keys
@@ -224,6 +238,17 @@ impl From<ExchangeResponse> for ExchangeView {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn exchange_status_defaults_missing_withdrawals_available_to_true() {
+        let view: ExchangeStatusView = serde_json::from_value(serde_json::json!({
+            "active": true,
+            "gated": false,
+        }))
+        .unwrap();
+
+        assert!(view.withdrawals_available);
+    }
 
     #[test]
     fn test_deserialize_exchange_keys_view() {

--- a/rust/src/types/exchange_ws.rs
+++ b/rust/src/types/exchange_ws.rs
@@ -129,6 +129,8 @@ pub struct ExchangeStateSnapshot {
     pub exchange_status_features: Vec<String>,
     pub active: bool,
     pub gated: bool,
+    #[serde(default = "default_withdrawals_available")]
+    pub withdrawals_available: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -310,6 +312,8 @@ pub enum ExchangeDeltaOp {
         disabled_features: Vec<String>,
         active: bool,
         gated: bool,
+        #[serde(default = "default_withdrawals_available")]
+        withdrawals_available: bool,
     },
     MarketAdded {
         market: ExchangeMarketSnapshot,
@@ -462,6 +466,11 @@ fn clamp_u64_to_u32(value: u64) -> u32 {
     value.min(u32::MAX as u64) as u32
 }
 
+// TODO: remove me when the migrations are finished
+fn default_withdrawals_available() -> bool {
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -520,6 +529,7 @@ mod tests {
                 exchange_status_features: vec!["active".to_string()],
                 active: true,
                 gated: false,
+                withdrawals_available: true,
             },
             markets: vec![ExchangeMarketSnapshot {
                 symbol: "SOL-PERP".to_string(),
@@ -581,6 +591,61 @@ mod tests {
                 .funding_config
                 .max_funding_rate_per_interval,
             2_500
+        );
+    }
+
+    #[test]
+    fn exchange_snapshot_defaults_missing_withdrawals_available_to_true() {
+        let mut value = serde_json::to_value(snapshot()).unwrap();
+        value
+            .get_mut("exchange")
+            .and_then(serde_json::Value::as_object_mut)
+            .unwrap()
+            .remove("withdrawalsAvailable");
+
+        let decoded: ExchangeSnapshotView = serde_json::from_value(value).unwrap();
+
+        assert!(decoded.exchange.withdrawals_available);
+    }
+
+    #[test]
+    fn exchange_status_delta_defaults_missing_withdrawals_available_to_true() {
+        let value = serde_json::json!({
+            "channel": "exchange",
+            "version": 1,
+            "sequenceNumber": 11,
+            "slot": 43,
+            "slotIndex": 0,
+            "ops": [
+                {
+                    "kind": "exchangeStatusChanged",
+                    "previous_bits": 128,
+                    "new_bits": 129,
+                    "previous_features": ["initialized"],
+                    "new_features": ["initialized", "active"],
+                    "enabled_features": ["active"],
+                    "disabled_features": [],
+                    "active": true,
+                    "gated": false
+                }
+            ]
+        });
+
+        let decoded: ExchangeDeltaMessage = serde_json::from_value(value).unwrap();
+
+        assert_eq!(
+            decoded.ops,
+            vec![ExchangeDeltaOp::ExchangeStatusChanged {
+                previous_bits: 128,
+                new_bits: 129,
+                previous_features: vec!["initialized".to_string()],
+                new_features: vec!["initialized".to_string(), "active".to_string()],
+                enabled_features: vec!["active".to_string()],
+                disabled_features: Vec::new(),
+                active: true,
+                gated: false,
+                withdrawals_available: true,
+            }]
         );
     }
 

--- a/rust/tests/invite_client_tests.rs
+++ b/rust/tests/invite_client_tests.rs
@@ -1,7 +1,7 @@
 use axum::http::StatusCode;
-use axum::routing::post;
+use axum::routing::{get, post};
 use axum::{Json, Router};
-use phoenix_rise::PhoenixHttpClient;
+use phoenix_rise::{ActivateReferralTxRequest, PhoenixHttpClient};
 use serde_json::{Value, json};
 use solana_pubkey::Pubkey;
 use tokio::net::TcpListener;
@@ -10,7 +10,15 @@ use tokio::net::TcpListener;
 async fn activate_invite_parses_object_response() {
     let app = Router::new()
         .route("/v1/invite/activate", post(activate_invite_handler))
-        .route("/v1/referral/activate", post(activate_referral_handler));
+        .route("/v1/referral/activate", post(activate_referral_handler))
+        .route(
+            "/v1/referral/activation-permission",
+            get(referral_activation_permission_handler),
+        )
+        .route(
+            "/v1/referral/activate-tx",
+            post(activate_referral_tx_handler),
+        );
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -21,7 +29,7 @@ async fn activate_invite_parses_object_response() {
     let client = PhoenixHttpClient::builder(format!("http://{}", addr))
         .build()
         .unwrap();
-    let authority = Pubkey::new_unique();
+    let authority = expected_authority();
 
     let trader_pda = client
         .register_trader(&authority, "invite-code")
@@ -35,6 +43,44 @@ async fn activate_invite_parses_object_response() {
         .await
         .unwrap();
     assert_eq!(referral_pda, "Trader2222222222222222222222222222222222");
+
+    let permission = client
+        .invite()
+        .get_referral_activation_permission()
+        .await
+        .unwrap();
+    assert_eq!(
+        permission.trader_onboarder,
+        "Onboarder111111111111111111111111111111111"
+    );
+    assert_eq!(
+        permission.risk_authority,
+        "Risk1111111111111111111111111111111111111"
+    );
+    assert_eq!(
+        permission.permission_account,
+        "Permission11111111111111111111111111111111"
+    );
+
+    let activation = client
+        .invite()
+        .activate_referral_tx(&ActivateReferralTxRequest {
+            referral_code: "ref-code".to_string(),
+            trader_authority: authority.to_string(),
+            trader_pda_index: Some(1),
+            trader_subaccount_index: Some(2),
+            recent_blockhash: "recent-blockhash".to_string(),
+            transaction: "base64-transaction".to_string(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(activation.signature.as_deref(), Some("tx-signature"));
+    assert_eq!(
+        activation.trader_pda,
+        "Trader3333333333333333333333333333333333"
+    );
+    assert_eq!(activation.referral_code, "REFCODE");
+    assert_eq!(activation.status, "submitted");
 
     server.abort();
 }
@@ -93,6 +139,52 @@ async fn activate_referral_handler(Json(body): Json<Value>) -> Json<Value> {
     Json(json!({
         "trader_pda": "Trader2222222222222222222222222222222222"
     }))
+}
+
+async fn referral_activation_permission_handler() -> Json<Value> {
+    Json(json!({
+        "trader_onboarder": "Onboarder111111111111111111111111111111111",
+        "risk_authority": "Risk1111111111111111111111111111111111111",
+        "permission_account": "Permission11111111111111111111111111111111"
+    }))
+}
+
+async fn activate_referral_tx_handler(Json(body): Json<Value>) -> Json<Value> {
+    let expected_authority = expected_authority().to_string();
+    assert_eq!(
+        body.get("referral_code").and_then(Value::as_str),
+        Some("ref-code")
+    );
+    assert_eq!(
+        body.get("trader_authority").and_then(Value::as_str),
+        Some(expected_authority.as_str())
+    );
+    assert_eq!(
+        body.get("trader_pda_index").and_then(Value::as_u64),
+        Some(1)
+    );
+    assert_eq!(
+        body.get("trader_subaccount_index").and_then(Value::as_u64),
+        Some(2)
+    );
+    assert_eq!(
+        body.get("recent_blockhash").and_then(Value::as_str),
+        Some("recent-blockhash")
+    );
+    assert_eq!(
+        body.get("transaction").and_then(Value::as_str),
+        Some("base64-transaction")
+    );
+    Json(json!({
+        "signature": "tx-signature",
+        "trader_pda": "Trader3333333333333333333333333333333333",
+        "referral_code": "REFCODE",
+        "status": "submitted"
+    }))
+}
+
+fn expected_authority() -> Pubkey {
+    Pubkey::new_from_array([9; 32])
 }
 
 async fn activate_referral_requires_auth_handler() -> (StatusCode, Json<Value>) {


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `f2a0ac7b66eae85ef8ddb3f21ff68ce6f7063754`
- Mode: automatic
- Synced paths:

- `rise/rust` -> `rust`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/programs` -> `programs`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `rust/CHANGELOG.md`

### Summary

- Added two new unauthenticated referral activation endpoints to `InviteClient`: `get_referral_activation_permission()` (`GET /v1/referral/activation-permission`) and `activate_referral_tx()` (`POST /v1/referral/activate-tx`), enabling a wallet-side transaction-signing flow for referral activation.
- New public types `ActivateReferralTxRequest`, `ActivateReferralTxResponse`, and `ReferralActivationPermissionResponse` are re-exported from the crate root under the `sdk` feature flag.
- Added `ExchangeStatusView` struct (fields: `active`, `gated`, `withdrawals_available`) and a corresponding `ExchangeClient::get_status()` method (`GET /exchange/status`).
- Added `withdrawals_available: bool` field to `ExchangeStateSnapshot` and the `ExchangeStatusChanged` variant of `ExchangeDeltaOp`; both default to `true` when the field is absent from the wire payload (backward-compatible deserialization).
- Added a `referral_activation_tx` example (requires `solana-keypair` feature) demonstrating the full end-to-end activate-tx wallet integration flow.

### Breaking Changes

- None identified in the synced diff.

### Consumer Notes

- If you pattern-match on `ExchangeDeltaOp::ExchangeStatusChanged`, you must now bind or ignore the new `withdrawals_available` field; omitting it is a compile error.
- `ExchangeStateSnapshot` gains a `withdrawals_available` field; struct literal construction (if any) must be updated to include it.
- `ExchangeStatusView` is a new type exported from `phoenix_rise_types`; no migration needed unless a local type of the same name exists.
- The `activate_referral_tx` flow requires the trader account to exist on-chain before calling `/v1/referral/activate-tx`; use `--register-if-missing` (or call `register_trader` first) if the account may not exist yet.