### PR TITLE
sync: Rise Rust v0.1.15

### DIFF
--- a/programs/close-position-and-withdraw/Cargo.lock
+++ b/programs/close-position-and-withdraw/Cargo.lock
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.6.0",

--- a/programs/close-position-and-withdraw/cli/Cargo.lock
+++ b/programs/close-position-and-withdraw/cli/Cargo.lock
@@ -1451,7 +1451,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "async-trait",
  "base64",

--- a/programs/trader-onboarder/Cargo.lock
+++ b/programs/trader-onboarder/Cargo.lock
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.6.0",

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -238,3 +238,23 @@ Source Phoenix commit: `f2a0ac7b66eae85ef8ddb3f21ff68ce6f7063754`
 - `ExchangeStateSnapshot` gains a `withdrawals_available` field; struct literal construction (if any) must be updated to include it.
 - `ExchangeStatusView` is a new type exported from `phoenix_rise_types`; no migration needed unless a local type of the same name exists.
 - The `activate_referral_tx` flow requires the trader account to exist on-chain before calling `/v1/referral/activate-tx`; use `--register-if-missing` (or call `register_trader` first) if the account may not exist yet.
+
+## v0.1.15 - 2026-06-25
+
+Source Phoenix commit: `823bb5e64efafb221f37a7e0a8f8720da843741c`
+
+### Summary
+
+- Added new public exports for inspecting trader activation status before building a referral activation transaction: `ReferralActivationTraderStatus` enum, `ReferralActivationTraderStatusError` error enum, `fetch_referral_activation_trader_status` async function, `has_referral_activation_capabilities` const function, and `referral_activation_trader_status` function.
+- The referral activation transaction now handles missing trader accounts automatically: when the trader account does not exist, the built transaction includes `register_trader` followed by delegated onboarding in a single atomic transaction. No separate registration step is required.
+- `ReferralActivationTraderStatus::should_include_register_trader()` returns `true` only for the `Missing` variant, making it straightforward to conditionally include the registration instruction when constructing activation transactions manually.
+
+### Breaking Changes
+
+- None identified in the synced diff.
+
+### Consumer Notes
+
+- The `referral_activation_tx` example no longer requires `--register-if-missing`; the flag is accepted but silently ignored for backward compatibility. Remove it from any example invocations you have documented.
+- If you call `fetch_referral_activation_trader_status` and receive `ReferralActivationTraderStatus::Missing`, pass `should_include_register_trader() == true` (and a valid `max_positions` in the range 32–128) to your transaction builder. Accounts in the `Registered` or `Activated` states skip registration and only set capabilities.
+- `--max-positions` in the example binary now enforces a minimum of 32 (previously 1). This affects the example only and does not change the library API.

--- a/rust/CRATES.md
+++ b/rust/CRATES.md
@@ -9,7 +9,7 @@
 
 ```toml
 [dependencies]
-phoenix-rise = "0.1.14"
+phoenix-rise = "0.1.15"
 ```
 
 Optional features:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "async-trait",
  "axum",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-sdk-cli"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "clap",
  "phoenix-rise",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,7 +17,7 @@ publish = true
 readme = "CRATES.md"
 repository = "https://github.com/Ellipsis-Labs/rise-public"
 rust-version = "1.84.0"
-version = "0.1.14"
+version = "0.1.15"
 
 [[example]]
 name              = "cancel_all_conditional_orders"
@@ -165,7 +165,7 @@ publish      = true
 readme       = "CRATES.md"
 repository   = "https://github.com/Ellipsis-Labs/rise-public"
 rust-version = "1.89.0"
-version      = "0.1.14"
+version      = "0.1.15"
 
 [workspace.dependencies]
 clap = { version = "4.5", features = ["derive"] }

--- a/rust/examples/referral_activation_tx.rs
+++ b/rust/examples/referral_activation_tx.rs
@@ -3,14 +3,13 @@
 //! This flow mirrors a wallet integration:
 //!
 //! 1. Fetch `/v1/referral/activation-permission`.
-//! 2. Build the delegated onboarding/capability transaction.
+//! 2. Build the activation transaction. If the trader account is missing, the
+//!    transaction includes `register_trader` followed by delegated onboarding.
+//!    If the trader account exists, it includes only delegated onboarding.
 //! 3. Sign it with the trader authority.
 //! 4. Submit it to `/v1/referral/activate-tx`; the API adds the onboarder
 //!    signature, submits the transaction, and waits for activation.
 //! 5. Wait 5s, then fetch and print the trader account from RPC.
-//!
-//! The activate-tx endpoint does not create the trader account. Pass
-//! `--register-if-missing` to register the trader first with the same keypair.
 //!
 //! Run with:
 //!   PHOENIX_ENV=beta \
@@ -18,8 +17,7 @@
 //!     --features solana-keypair -- <REFERRAL_CODE> \
 //!     --api-url http://127.0.0.1:8080 \
 //!     --rpc-url <RPC_URL> \
-//!     --trader-keypair-path ~/.config/solana/id.json \
-//!     --register-if-missing
+//!     --trader-keypair-path ~/.config/solana/id.json
 
 use std::str::FromStr;
 use std::time::Duration;
@@ -32,7 +30,10 @@ use phoenix_rise::phoenix_rise_ix::{
     OnboardTraderDelegatedParams, RegisterTraderParams, TRADER_ONBOARDING_PERMISSION,
     create_onboard_trader_delegated_ix, create_register_trader_ix,
 };
-use phoenix_rise::{ActivateReferralTxRequest, PhoenixHttpClient, PhoenixMetadata, TraderKey};
+use phoenix_rise::{
+    ActivateReferralTxRequest, PhoenixHttpClient, PhoenixMetadata, ReferralActivationTraderStatus,
+    TraderKey, fetch_referral_activation_trader_status,
+};
 use solana_commitment_config::CommitmentConfig;
 use solana_keypair::read_keypair_file;
 use solana_pubkey::Pubkey;
@@ -52,10 +53,10 @@ Options:
   --api-url <url>                       Phoenix API URL
   --rpc-url <url>                       Solana RPC URL
   --trader-keypair-path <path>          Trader authority keypair path
-  --trader-pda-index <n>                Trader PDA index (default: 0)
+  --trader-pda-index <n>                Trader PDA index (default: 0; activate-tx currently supports 0 only)
   --trader-subaccount-index <n>         Trader subaccount index (default: 0; activate-tx currently supports 0 only)
-  --register-if-missing                 Create the trader account first if it is missing
-  --max-positions <n>                   Max positions for --register-if-missing (default: 128)
+  --register-if-missing                 Deprecated no-op; missing traders are registered in the activation tx
+  --max-positions <n>                   Max positions when registering a missing trader (32-128, default: 128)
   --post-submit-wait-seconds <n>        Seconds to wait before printing the RPC trader account (default: 5)
   -h, --help                            Show this help
 
@@ -73,7 +74,6 @@ struct CliArgs {
     trader_keypair_path: String,
     trader_pda_index: u8,
     trader_subaccount_index: u8,
-    register_if_missing: bool,
     max_positions: u64,
     post_submit_wait: Duration,
 }
@@ -104,8 +104,8 @@ fn parse_u64(value: &str, flag: &str) -> u64 {
 
 fn parse_max_positions(value: &str) -> u64 {
     let max_positions = parse_u64(value, "--max-positions");
-    if max_positions == 0 || max_positions > DEFAULT_MAX_POSITIONS {
-        fail("--max-positions must be between 1 and 128");
+    if !(32..=DEFAULT_MAX_POSITIONS).contains(&max_positions) {
+        fail("--max-positions must be between 32 and 128");
     }
     max_positions
 }
@@ -120,7 +120,6 @@ fn parse_args(argv: Vec<String>) -> CliArgs {
         .unwrap_or_else(|_| default_keypair_path());
     let mut trader_pda_index = 0;
     let mut trader_subaccount_index = 0;
-    let mut register_if_missing = false;
     let mut max_positions = DEFAULT_MAX_POSITIONS;
     let mut post_submit_wait = Duration::from_secs(DEFAULT_POST_SUBMIT_WAIT_SECONDS);
     let mut referral_code = None::<String>;
@@ -156,7 +155,7 @@ fn parse_args(argv: Vec<String>) -> CliArgs {
                 trader_subaccount_index = parse_u8(&value, "--trader-subaccount-index");
             }
             "--register-if-missing" => {
-                register_if_missing = true;
+                // Retained for compatibility with older example invocations.
             }
             "--max-positions" => {
                 let value = args
@@ -185,6 +184,9 @@ fn parse_args(argv: Vec<String>) -> CliArgs {
         }
     }
 
+    if trader_pda_index != 0 {
+        fail("--trader-pda-index must be 0 for /v1/referral/activate-tx");
+    }
     if trader_subaccount_index != 0 {
         fail("--trader-subaccount-index must be 0 for /v1/referral/activate-tx");
     }
@@ -197,7 +199,6 @@ fn parse_args(argv: Vec<String>) -> CliArgs {
         trader_keypair_path,
         trader_pda_index,
         trader_subaccount_index,
-        register_if_missing,
         max_positions,
         post_submit_wait,
     }
@@ -215,40 +216,6 @@ async fn fetch_trader(
         return Ok(None);
     };
     Ok(Some(Trader::try_from_account_bytes(&account.data)?))
-}
-
-async fn register_trader_if_missing(
-    rpc: &RpcClient,
-    trader_keypair: &solana_keypair::Keypair,
-    trader: &TraderKey,
-    max_positions: u64,
-) -> Result<(), Box<dyn std::error::Error>> {
-    if fetch_trader(rpc, &trader.pda()).await?.is_some() {
-        println!("Trader account already exists; skipping registration.");
-        return Ok(());
-    }
-
-    let register_params = RegisterTraderParams::builder()
-        .payer(trader_keypair.pubkey())
-        .trader(trader.authority())
-        .trader_account(trader.pda())
-        .max_positions(max_positions)
-        .trader_pda_index(trader.pda_index)
-        .subaccount_index(trader.subaccount_index)
-        .build()?;
-    let instruction: solana_instruction::Instruction =
-        create_register_trader_ix(register_params)?.into();
-    let blockhash = rpc.get_latest_blockhash().await?;
-    let tx = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&trader_keypair.pubkey()),
-        &[trader_keypair],
-        blockhash,
-    );
-    let signature = rpc.send_and_confirm_transaction(&tx).await?;
-    println!("Registered trader account.");
-    println!("Register signature: {signature}");
-    Ok(())
 }
 
 async fn fetch_permission_account(
@@ -298,12 +265,27 @@ fn parse_pubkey(value: &str, field: &str) -> Result<Pubkey, Box<dyn std::error::
 async fn build_signed_activation_transaction_base64(
     trader_keypair: &solana_keypair::Keypair,
     trader: &TraderKey,
+    include_register_trader: bool,
+    max_positions: u64,
     trader_onboarder: Pubkey,
     permission_account: Pubkey,
     global_trader_index: Vec<Pubkey>,
     active_trader_buffer: Vec<Pubkey>,
     rpc: &RpcClient,
 ) -> Result<(String, String), Box<dyn std::error::Error>> {
+    let mut instructions = Vec::<solana_instruction::Instruction>::new();
+    if include_register_trader {
+        let register_params = RegisterTraderParams::builder()
+            .payer(trader_keypair.pubkey())
+            .trader(trader.authority())
+            .trader_account(trader.pda())
+            .max_positions(max_positions)
+            .trader_pda_index(trader.pda_index)
+            .subaccount_index(trader.subaccount_index)
+            .build()?;
+        instructions.push(create_register_trader_ix(register_params)?.into());
+    }
+
     let onboard_params = OnboardTraderDelegatedParams::builder()
         .authority(trader_onboarder)
         .permission_account(permission_account)
@@ -313,8 +295,9 @@ async fn build_signed_activation_transaction_base64(
         .build()?;
     let instruction: solana_instruction::Instruction =
         create_onboard_trader_delegated_ix(onboard_params)?.into();
+    instructions.push(instruction);
 
-    let mut tx = Transaction::new_with_payer(&[instruction], Some(&trader_keypair.pubkey()));
+    let mut tx = Transaction::new_with_payer(&instructions, Some(&trader_keypair.pubkey()));
     let recent_blockhash = rpc.get_latest_blockhash().await?;
     tx.try_partial_sign(&[trader_keypair], recent_blockhash)?;
     let versioned = VersionedTransaction::from(tx);
@@ -347,13 +330,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Trader account:      {}", trader.pda());
     println!("Referral code:       {}", args.referral_code);
 
-    if args.register_if_missing {
-        register_trader_if_missing(&rpc, &trader_keypair, &trader, args.max_positions).await?;
-    } else if fetch_trader(&rpc, &trader.pda()).await?.is_none() {
-        return Err(
-            "Trader account is missing. Re-run with --register-if-missing or register it first."
-                .into(),
-        );
+    let trader_status = fetch_referral_activation_trader_status(&rpc, &trader.pda()).await?;
+    match trader_status {
+        ReferralActivationTraderStatus::Missing => {
+            println!("Trader account missing; activation tx will register and set capabilities.");
+        }
+        ReferralActivationTraderStatus::Registered => {
+            println!(
+                "Trader account exists without activation capabilities; activation tx will only \
+                 set capabilities."
+            );
+        }
+        ReferralActivationTraderStatus::Activated => {
+            println!(
+                "Trader account already has activation capabilities; activation tx will only set \
+                 capabilities."
+            );
+        }
     }
 
     println!("\nFetching referral activation permission...");
@@ -391,6 +384,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (transaction, recent_blockhash) = build_signed_activation_transaction_base64(
         &trader_keypair,
         &trader,
+        trader_status.should_include_register_trader(),
+        args.max_positions,
         trader_onboarder,
         permission_account,
         global_trader_index,

--- a/rust/src/api/invite.rs
+++ b/rust/src/api/invite.rs
@@ -1,8 +1,13 @@
 use serde::{Deserialize, Serialize};
 use solana_pubkey::Pubkey;
+use solana_rpc_client::nonblocking::rpc_client::RpcClient;
+use solana_rpc_client_api::client_error::Error as RpcClientError;
+use thiserror::Error;
 
 use crate::http_client::HttpClientInner;
+use crate::phoenix_rise_ix::TRADER_CAPABILITY_CAN_DEPOSIT;
 use crate::phoenix_rise_types::PhoenixHttpError;
+use crate::phoenix_rise_types::accounts::{AccountDeserializeError, Trader};
 
 const REFERRAL_ACTIVATION_AUTH_MESSAGE: &str = concat!(
     "Referral activation requires an authenticated user session for the authority wallet. ",
@@ -68,6 +73,75 @@ impl InviteClient<'_> {
             .post_json("/v1/referral/activate-tx", request)
             .await
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReferralActivationTraderStatus {
+    Missing,
+    Registered,
+    Activated,
+}
+
+impl ReferralActivationTraderStatus {
+    pub const fn should_include_register_trader(self) -> bool {
+        matches!(self, Self::Missing)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ReferralActivationTraderStatusError {
+    #[error("failed to fetch trader account {trader}: {source}")]
+    Fetch {
+        trader: Pubkey,
+        source: RpcClientError,
+    },
+
+    #[error("failed to decode trader account {trader}: {source}")]
+    Decode {
+        trader: Pubkey,
+        source: AccountDeserializeError,
+    },
+}
+
+pub const fn has_referral_activation_capabilities(flags: u32) -> bool {
+    flags & TRADER_CAPABILITY_CAN_DEPOSIT == TRADER_CAPABILITY_CAN_DEPOSIT
+}
+
+pub fn referral_activation_trader_status(
+    trader: Option<&Trader>,
+) -> ReferralActivationTraderStatus {
+    match trader {
+        None => ReferralActivationTraderStatus::Missing,
+        Some(trader) if has_referral_activation_capabilities(trader.state.flags) => {
+            ReferralActivationTraderStatus::Activated
+        }
+        Some(_) => ReferralActivationTraderStatus::Registered,
+    }
+}
+
+pub async fn fetch_referral_activation_trader_status(
+    rpc: &RpcClient,
+    trader: &Pubkey,
+) -> Result<ReferralActivationTraderStatus, ReferralActivationTraderStatusError> {
+    let Some(account) = rpc
+        .get_account_with_commitment(trader, rpc.commitment())
+        .await
+        .map_err(|source| ReferralActivationTraderStatusError::Fetch {
+            trader: *trader,
+            source,
+        })?
+        .value
+    else {
+        return Ok(ReferralActivationTraderStatus::Missing);
+    };
+
+    let trader_account = Trader::try_from_account_bytes(&account.data).map_err(|source| {
+        ReferralActivationTraderStatusError::Decode {
+            trader: *trader,
+            source,
+        }
+    })?;
+    Ok(referral_activation_trader_status(Some(&trader_account)))
 }
 
 fn with_referral_activation_auth_context(error: PhoenixHttpError) -> PhoenixHttpError {

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -14,7 +14,9 @@ pub use exchange::ExchangeClient;
 pub use funding::FundingClient;
 pub use invite::{
     ActivateReferralTxRequest, ActivateReferralTxResponse, InviteClient,
-    ReferralActivationPermissionResponse,
+    ReferralActivationPermissionResponse, ReferralActivationTraderStatus,
+    ReferralActivationTraderStatusError, fetch_referral_activation_trader_status,
+    has_referral_activation_capabilities, referral_activation_trader_status,
 };
 pub use markets::MarketsClient;
 pub use orders::OrdersClient;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -103,7 +103,10 @@ pub use accounts::{AccountDataFetcher, PhoenixAccountClient, PhoenixAccountClien
 pub use api::{
     ActivateReferralTxRequest, ActivateReferralTxResponse, CandlesClient, CollateralClient,
     ExchangeClient, FundingClient, InviteClient, MarketsClient, OrdersClient,
-    ReferralActivationPermissionResponse, TradersClient, TradesClient,
+    ReferralActivationPermissionResponse, ReferralActivationTraderStatus,
+    ReferralActivationTraderStatusError, TradersClient, TradesClient,
+    fetch_referral_activation_trader_status, has_referral_activation_capabilities,
+    referral_activation_trader_status,
 };
 #[cfg(all(feature = "sdk", feature = "solana-keypair"))]
 pub use auth::PhoenixWalletSessionManager;

--- a/rust/tests/invite_client_tests.rs
+++ b/rust/tests/invite_client_tests.rs
@@ -1,7 +1,16 @@
+use std::fs;
+use std::path::PathBuf;
+
 use axum::http::StatusCode;
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use phoenix_rise::{ActivateReferralTxRequest, PhoenixHttpClient};
+use base64::Engine;
+use phoenix_rise::phoenix_rise_ix::TRADER_CAPABILITY_CAN_DEPOSIT;
+use phoenix_rise::phoenix_rise_types::accounts::Trader;
+use phoenix_rise::{
+    ActivateReferralTxRequest, PhoenixHttpClient, ReferralActivationTraderStatus,
+    has_referral_activation_capabilities, referral_activation_trader_status,
+};
 use serde_json::{Value, json};
 use solana_pubkey::Pubkey;
 use tokio::net::TcpListener;
@@ -121,6 +130,31 @@ async fn activate_referral_explains_user_auth_requirement() {
     server.abort();
 }
 
+#[test]
+fn referral_activation_trader_status_tracks_deposit_capability() {
+    assert_eq!(
+        referral_activation_trader_status(None),
+        ReferralActivationTraderStatus::Missing
+    );
+    assert!(!ReferralActivationTraderStatus::Registered.should_include_register_trader());
+    assert!(ReferralActivationTraderStatus::Missing.should_include_register_trader());
+
+    let mut trader = Trader::try_from_account_bytes(&mock_account_bytes("trader.json"))
+        .expect("trader fixture should decode");
+    assert_eq!(
+        referral_activation_trader_status(Some(&trader)),
+        ReferralActivationTraderStatus::Activated
+    );
+    assert!(has_referral_activation_capabilities(trader.state.flags));
+
+    trader.state.flags &= !TRADER_CAPABILITY_CAN_DEPOSIT;
+    assert_eq!(
+        referral_activation_trader_status(Some(&trader)),
+        ReferralActivationTraderStatus::Registered
+    );
+    assert!(!has_referral_activation_capabilities(trader.state.flags));
+}
+
 async fn activate_invite_handler(Json(body): Json<Value>) -> Json<Value> {
     assert_eq!(
         body.get("code").and_then(Value::as_str),
@@ -185,6 +219,21 @@ async fn activate_referral_tx_handler(Json(body): Json<Value>) -> Json<Value> {
 
 fn expected_authority() -> Pubkey {
     Pubkey::new_from_array([9; 32])
+}
+
+fn mock_account_bytes(file_name: &str) -> Vec<u8> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../ts/tests/mocks")
+        .join(file_name);
+    let fixture: Value =
+        serde_json::from_str(&fs::read_to_string(path).expect("fixture should be readable"))
+            .expect("fixture should parse");
+    let data = fixture["account"]["data"][0]
+        .as_str()
+        .expect("fixture account data should be base64");
+    base64::engine::general_purpose::STANDARD
+        .decode(data)
+        .expect("fixture should contain base64 account bytes")
 }
 
 async fn activate_referral_requires_auth_handler() -> (StatusCode, Json<Value>) {


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `823bb5e64efafb221f37a7e0a8f8720da843741c`
- Mode: manual
- Synced paths:

- `rise/rust` -> `rust`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/programs` -> `programs`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `rust/CHANGELOG.md`

### Summary

- Added new public exports for inspecting trader activation status before building a referral activation transaction: `ReferralActivationTraderStatus` enum, `ReferralActivationTraderStatusError` error enum, `fetch_referral_activation_trader_status` async function, `has_referral_activation_capabilities` const function, and `referral_activation_trader_status` function.
- The referral activation transaction now handles missing trader accounts automatically: when the trader account does not exist, the built transaction includes `register_trader` followed by delegated onboarding in a single atomic transaction. No separate registration step is required.
- `ReferralActivationTraderStatus::should_include_register_trader()` returns `true` only for the `Missing` variant, making it straightforward to conditionally include the registration instruction when constructing activation transactions manually.

### Breaking Changes

- None identified in the synced diff.

### Consumer Notes

- The `referral_activation_tx` example no longer requires `--register-if-missing`; the flag is accepted but silently ignored for backward compatibility. Remove it from any example invocations you have documented.
- If you call `fetch_referral_activation_trader_status` and receive `ReferralActivationTraderStatus::Missing`, pass `should_include_register_trader() == true` (and a valid `max_positions` in the range 32–128) to your transaction builder. Accounts in the `Registered` or `Activated` states skip registration and only set capabilities.
- `--max-positions` in the example binary now enforces a minimum of 32 (previously 1). This affects the example only and does not change the library API.