### PR TITLE
sync: Rise TypeScript v0.4.54

### DIFF
--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -518,3 +518,23 @@ Source Phoenix commit: `823bb5e64efafb221f37a7e0a8f8720da843741c`
 - `rentPayer` is still deprecated, but its behavior changed: when `includeRegisterTrader: true` is set and no `feePayer` is provided, `rentPayer` is now used as the fallback fee payer for the registration instruction. Existing callers that pass `rentPayer` without `includeRegisterTrader: true` are unaffected — it continues to be ignored in that case.
 - `registerTraderMaxPositions` must be between `32n` and `128n`; passing a value outside this range throws synchronously before any RPC call.
 - To use auto-detection, pass `rpc` (a `createSolanaRpc` instance) or `rpcUrl` to `buildActivateReferralTxRequest` and omit `includeRegisterTrader`. The returned `traderActivationState` reflects what the SDK observed on-chain.
+
+## v0.4.54 - 2026-06-25
+
+Source Phoenix commit: `190b6af2b821bd0670b4a1aea8dad552bcd62482`
+
+### Summary
+
+- **Service-account authentication for server-side tools.** `PhoenixAuthClient` gains three new methods — `loginWithServiceAccountSigner`, `loginWithServiceAccountCredential`, and `loginWithServiceAccountFromEnv` — enabling non-interactive authentication using Ed25519 keypair credentials.
+- **New public exports from `@ellipsis-labs/rise/auth`:** `PhoenixServiceAccountCredential`, `PhoenixServiceAccountAuthSigner`, `PhoenixServiceAccountAuthClient`, `PhoenixServiceAccountCredentialEnv`, `createServiceAccountAuthSigner`, `loginWithServiceAccountCredential`, `loginWithServiceAccountSigner`, `loginWithServiceAccountFromEnv`, `loadServiceAccountCredentialFromEnv`, and `loadServiceAccountCredentialFromPath`.
+- **Env-var credential loading** mirrors the Rise Rust SDK: set `PHOENIX_SERVICE_ACCOUNT_CREDENTIAL` (path to a JSON file) or the split vars `PHOENIX_SERVICE_ACCOUNT_CLIENT_ID` / `PHOENIX_SERVICE_ACCOUNT_KEY_ID` / `PHOENIX_SERVICE_ACCOUNT_PRIVATE_KEY`. Legacy `PHOENIX_SERVICE_CLIENT_ID`, `PHOENIX_SERVICE_KEY_ID`, and `PHOENIX_SERVICE_PRIVATE_KEY` aliases are also accepted.
+
+### Breaking Changes
+
+- None identified in the synced diff.
+
+### Consumer Notes
+
+- Credential file loading (`PHOENIX_SERVICE_ACCOUNT_CREDENTIAL` / `loadServiceAccountCredentialFromPath`) uses `node:fs/promises` and is only available in Node.js and Bun environments; browser bundles that import `loadServiceAccountCredentialFromEnv` with a file path will throw at runtime. Split env-var loading has no Node dependency and works anywhere `process.env` is accessible.
+- Partial split-env configuration (some but not all of `CLIENT_ID`, `KEY_ID`, `PRIVATE_KEY` present) throws `PhoenixAuthError` with code `incomplete_service_account_credential_env` rather than silently falling through.
+- Private keys must be 32-byte Ed25519 seeds encoded as base64url (no padding); a mismatched length throws `PhoenixAuthError` with code `invalid_service_account_private_key`.

--- a/ts/README.md
+++ b/ts/README.md
@@ -494,6 +494,31 @@ It does not force an eager login flow. Built-in route clients use the shared
 session opportunistically when one exists. For custom transport calls, use
 `RequestOptions.auth` to disable auth or require it explicitly.
 
+### Service-account sessions
+
+Server-side tools can authenticate with the same service-account credential env
+vars supported by Rise Rust:
+
+- `PHOENIX_SERVICE_ACCOUNT_CREDENTIAL`: path to a JSON credential with
+  `client_id`, `key_id`, and `private_key`
+- `PHOENIX_SERVICE_ACCOUNT_CLIENT_ID`
+- `PHOENIX_SERVICE_ACCOUNT_KEY_ID`
+- `PHOENIX_SERVICE_ACCOUNT_PRIVATE_KEY`
+
+The split vars also accept the legacy `PHOENIX_SERVICE_CLIENT_ID`,
+`PHOENIX_SERVICE_KEY_ID`, and `PHOENIX_SERVICE_PRIVATE_KEY` aliases.
+
+```ts
+import { createPhoenixClient } from "@ellipsis-labs/rise";
+
+const client = createPhoenixClient({
+  apiUrl: "https://perp-api.phoenix.trade",
+  auth: true,
+});
+
+await client.auth!.loginWithServiceAccountFromEnv();
+```
+
 ## WebSocket Streams
 
 If you only need streams, you can construct the WS client directly:

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/rise",
-  "version": "0.4.53",
+  "version": "0.4.54",
   "packageManager": "bun@1.3.13",
   "repository": {
     "type": "git",

--- a/ts/src/auth/client.ts
+++ b/ts/src/auth/client.ts
@@ -28,6 +28,13 @@ import {
   type WalletTransactionChallengeResponse,
   type WalletTransactionLoginRequest,
 } from "./types";
+import {
+  loginWithServiceAccountCredential,
+  loginWithServiceAccountFromEnv,
+  loginWithServiceAccountSigner,
+  type PhoenixServiceAccountAuthSigner,
+  type PhoenixServiceAccountCredential,
+} from "./serviceAccount";
 
 export interface PhoenixAuthClientConfig extends PhoenixApiUrlConfig {
   timeout?: number;
@@ -320,6 +327,22 @@ export class PhoenixAuthClient {
       request
     );
     return this.handleAuthResponse(response);
+  }
+
+  async loginWithServiceAccountSigner(
+    signer: PhoenixServiceAccountAuthSigner
+  ): Promise<AuthSession> {
+    return loginWithServiceAccountSigner(this, signer);
+  }
+
+  async loginWithServiceAccountCredential(
+    credential: PhoenixServiceAccountCredential
+  ): Promise<AuthSession> {
+    return loginWithServiceAccountCredential(this, credential);
+  }
+
+  async loginWithServiceAccountFromEnv(): Promise<AuthSession | null> {
+    return loginWithServiceAccountFromEnv(this);
   }
 
   async refresh(refreshToken: string): Promise<AuthSession> {

--- a/ts/src/auth/index.ts
+++ b/ts/src/auth/index.ts
@@ -2,6 +2,7 @@ export * from "./backoff";
 export * from "./client";
 export * from "./debug";
 export * from "./manager";
+export * from "./serviceAccount";
 export * from "./session";
 export * from "./storage";
 export * from "./types";

--- a/ts/src/auth/serviceAccount.ts
+++ b/ts/src/auth/serviceAccount.ts
@@ -1,0 +1,290 @@
+import {
+  createKeyPairSignerFromPrivateKeyBytes,
+  createSignableMessage,
+} from "@solana/kit";
+import { base64urlnopad } from "@scure/base";
+import z from "zod";
+
+import { PhoenixAuthError } from "@/errors";
+import type { AuthSession } from "./session";
+import type {
+  AuthChallengeResponse,
+  ServiceChallengeRequest,
+  ServiceLoginRequest,
+} from "./types";
+
+const ENV_SERVICE_ACCOUNT_CREDENTIAL = "PHOENIX_SERVICE_ACCOUNT_CREDENTIAL";
+const ENV_SERVICE_ACCOUNT_CLIENT_ID = "PHOENIX_SERVICE_ACCOUNT_CLIENT_ID";
+const ENV_SERVICE_ACCOUNT_KEY_ID = "PHOENIX_SERVICE_ACCOUNT_KEY_ID";
+const ENV_SERVICE_ACCOUNT_PRIVATE_KEY = "PHOENIX_SERVICE_ACCOUNT_PRIVATE_KEY";
+const ENV_SERVICE_CLIENT_ID = "PHOENIX_SERVICE_CLIENT_ID";
+const ENV_SERVICE_KEY_ID = "PHOENIX_SERVICE_KEY_ID";
+const ENV_SERVICE_PRIVATE_KEY = "PHOENIX_SERVICE_PRIVATE_KEY";
+
+export interface PhoenixServiceAccountCredential {
+  client_id: string;
+  key_id: string;
+  public_key?: string;
+  private_key: string;
+}
+
+const ServiceAccountCredentialSchema: z.ZodType<PhoenixServiceAccountCredential> =
+  z.object({
+    client_id: z.string().min(1),
+    key_id: z.string().min(1),
+    public_key: z.string().optional(),
+    private_key: z.string().min(1),
+  });
+
+export interface PhoenixServiceAccountAuthSigner {
+  clientId: string;
+  keyId?: string;
+  signChallenge(challenge: AuthChallengeResponse): Promise<string>;
+}
+
+export interface PhoenixServiceAccountAuthClient {
+  serviceChallenge(
+    request: ServiceChallengeRequest
+  ): Promise<AuthChallengeResponse>;
+  loginWithServiceSignature(request: ServiceLoginRequest): Promise<AuthSession>;
+}
+
+export type PhoenixServiceAccountCredentialEnv = Readonly<
+  Record<string, string | undefined>
+>;
+
+const readFirstTrimmedEnv = (
+  env: PhoenixServiceAccountCredentialEnv,
+  names: readonly string[]
+): string | undefined => {
+  for (const name of names) {
+    const value = env[name]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+};
+
+const currentEnv = (): PhoenixServiceAccountCredentialEnv => {
+  const processLike = globalThis as typeof globalThis & {
+    process?: { env?: PhoenixServiceAccountCredentialEnv };
+  };
+  return processLike.process?.env ?? {};
+};
+
+const expandHomePath = (
+  path: string,
+  env: PhoenixServiceAccountCredentialEnv
+): string => {
+  if (path !== "~" && !path.startsWith("~/")) {
+    return path;
+  }
+
+  const home = env.HOME?.trim();
+  if (!home) {
+    throw new PhoenixAuthError(
+      "Unable to resolve home directory",
+      "home_dir_unavailable"
+    );
+  }
+  return path === "~" ? home : `${home}/${path.slice(2)}`;
+};
+
+export const loadServiceAccountCredentialFromPath = async (
+  path: string
+): Promise<PhoenixServiceAccountCredential> =>
+  loadServiceAccountCredentialFromResolvedPath(path, currentEnv());
+
+export const loadServiceAccountCredentialFromEnv = async (
+  env: PhoenixServiceAccountCredentialEnv = currentEnv()
+): Promise<PhoenixServiceAccountCredential | null> => {
+  const credentialPath = readFirstTrimmedEnv(env, [
+    ENV_SERVICE_ACCOUNT_CREDENTIAL,
+  ]);
+  if (credentialPath) {
+    return loadServiceAccountCredentialFromResolvedPath(credentialPath, env);
+  }
+
+  const clientId = readFirstTrimmedEnv(env, [
+    ENV_SERVICE_ACCOUNT_CLIENT_ID,
+    ENV_SERVICE_CLIENT_ID,
+  ]);
+  const keyId = readFirstTrimmedEnv(env, [
+    ENV_SERVICE_ACCOUNT_KEY_ID,
+    ENV_SERVICE_KEY_ID,
+  ]);
+  const privateKey = readFirstTrimmedEnv(env, [
+    ENV_SERVICE_ACCOUNT_PRIVATE_KEY,
+    ENV_SERVICE_PRIVATE_KEY,
+  ]);
+
+  if (!clientId && !keyId && !privateKey) {
+    return null;
+  }
+
+  if (clientId && keyId && privateKey) {
+    return {
+      client_id: clientId,
+      key_id: keyId,
+      private_key: privateKey,
+    };
+  }
+
+  const missing: string[] = [];
+  if (!clientId) {
+    missing.push(
+      `${ENV_SERVICE_ACCOUNT_CLIENT_ID} (or ${ENV_SERVICE_CLIENT_ID})`
+    );
+  }
+  if (!keyId) {
+    missing.push(`${ENV_SERVICE_ACCOUNT_KEY_ID} (or ${ENV_SERVICE_KEY_ID})`);
+  }
+  if (!privateKey) {
+    missing.push(
+      `${ENV_SERVICE_ACCOUNT_PRIVATE_KEY} (or ${ENV_SERVICE_PRIVATE_KEY})`
+    );
+  }
+  throw new PhoenixAuthError(
+    `Incomplete service-account credential env; missing: ${missing.join(", ")}`,
+    "incomplete_service_account_credential_env"
+  );
+};
+
+const loadServiceAccountCredentialFromResolvedPath = async (
+  path: string,
+  env: PhoenixServiceAccountCredentialEnv
+): Promise<PhoenixServiceAccountCredential> => {
+  try {
+    const { readFile } = await loadNodeFsPromises();
+    const contents = await readFile(expandHomePath(path, env), "utf8");
+    return ServiceAccountCredentialSchema.parse(JSON.parse(contents));
+  } catch (error) {
+    if (error instanceof PhoenixAuthError) throw error;
+    throw new PhoenixAuthError(
+      error instanceof Error
+        ? `Failed to load service-account credential: ${error.message}`
+        : "Failed to load service-account credential",
+      "service_account_credential_load_failed",
+      { cause: error }
+    );
+  }
+};
+
+type NodeReadTextFile = (path: string, encoding: "utf8") => Promise<string>;
+
+interface NodeFsPromisesModule {
+  readFile: NodeReadTextFile;
+}
+
+const isNodeFsPromisesModule = (
+  value: unknown
+): value is NodeFsPromisesModule =>
+  value !== null &&
+  typeof value === "object" &&
+  "readFile" in value &&
+  typeof value.readFile === "function";
+
+const loadNodeFsPromises = async (): Promise<NodeFsPromisesModule> => {
+  const module: unknown = await import(nodeFsPromisesModuleSpecifier());
+  if (!isNodeFsPromisesModule(module)) {
+    throw new PhoenixAuthError(
+      "Node fs/promises module is unavailable",
+      "service_account_credential_file_unavailable"
+    );
+  }
+  return module;
+};
+
+const nodeFsPromisesModuleSpecifier = (): string =>
+  ["node:", "fs/promises"].join("");
+
+const decodePrivateKey = (privateKey: string): Uint8Array => {
+  try {
+    const bytes = base64urlnopad.decode(privateKey);
+    if (bytes.length !== 32) {
+      throw new Error(`expected 32 bytes, got ${bytes.length}`);
+    }
+    return bytes;
+  } catch (error) {
+    throw new PhoenixAuthError(
+      error instanceof Error
+        ? `Invalid service-account private key: ${error.message}`
+        : "Invalid service-account private key",
+      "invalid_service_account_private_key",
+      { cause: error }
+    );
+  }
+};
+
+const missingServiceAccountSignatureError = (): PhoenixAuthError =>
+  new PhoenixAuthError(
+    "Service-account signer did not return a message signature",
+    "service_account_signature_missing"
+  );
+
+export const createServiceAccountAuthSigner = async (
+  credential: PhoenixServiceAccountCredential
+): Promise<PhoenixServiceAccountAuthSigner> => {
+  const signer = await createKeyPairSignerFromPrivateKeyBytes(
+    decodePrivateKey(credential.private_key)
+  );
+
+  return {
+    clientId: credential.client_id,
+    keyId: credential.key_id,
+    async signChallenge(challenge) {
+      const [signature] = await signer.signMessages([
+        createSignableMessage(challenge.message),
+      ]);
+      if (!signature) {
+        throw missingServiceAccountSignatureError();
+      }
+      const bytes = signature[signer.address];
+      if (!bytes) {
+        throw missingServiceAccountSignatureError();
+      }
+      return base64urlnopad.encode(bytes);
+    },
+  };
+};
+
+export const loginWithServiceAccountSigner = async (
+  client: PhoenixServiceAccountAuthClient,
+  signer: PhoenixServiceAccountAuthSigner
+): Promise<AuthSession> => {
+  const challenge = await client.serviceChallenge({
+    client_id: signer.clientId,
+    ...(signer.keyId ? { key_id: signer.keyId } : {}),
+  });
+  if (!challenge.timestamp) {
+    throw new PhoenixAuthError(
+      "Service-account challenge is missing a timestamp",
+      "missing_timestamp_in_challenge"
+    );
+  }
+
+  return client.loginWithServiceSignature({
+    client_id: signer.clientId,
+    key_id: challenge.key_id,
+    nonce: challenge.nonce,
+    timestamp: challenge.timestamp,
+    signature: await signer.signChallenge(challenge),
+  });
+};
+
+export const loginWithServiceAccountCredential = async (
+  client: PhoenixServiceAccountAuthClient,
+  credential: PhoenixServiceAccountCredential
+): Promise<AuthSession> =>
+  loginWithServiceAccountSigner(
+    client,
+    await createServiceAccountAuthSigner(credential)
+  );
+
+export const loginWithServiceAccountFromEnv = async (
+  client: PhoenixServiceAccountAuthClient,
+  env?: PhoenixServiceAccountCredentialEnv
+): Promise<AuthSession | null> => {
+  const credential = await loadServiceAccountCredentialFromEnv(env);
+  if (!credential) return null;
+  return loginWithServiceAccountCredential(client, credential);
+};

--- a/ts/tests/auth-service-account.test.ts
+++ b/ts/tests/auth-service-account.test.ts
@@ -1,0 +1,173 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Buffer } from "node:buffer";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PhoenixAuthClient, loadServiceAccountCredentialFromEnv } from "@/auth";
+
+const toBase64Url = (value: unknown): string =>
+  Buffer.from(JSON.stringify(value)).toString("base64url");
+
+const makeJwt = (payload: Record<string, unknown>): string =>
+  `${toBase64Url({ alg: "none", typ: "JWT" })}.${toBase64Url(payload)}.sig`;
+
+const parseJsonObject = (value: string): Record<string, unknown> => {
+  const parsed: unknown = JSON.parse(value);
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Expected JSON object");
+  }
+  return parsed;
+};
+
+const expectStringField = (
+  body: Record<string, unknown>,
+  field: string
+): string => {
+  const value = body[field];
+  expect(typeof value).toBe("string");
+  return value;
+};
+
+const privateKey = Buffer.from(new Uint8Array(32).fill(7)).toString(
+  "base64url"
+);
+
+const authResponse = {
+  token_type: "Bearer" as const,
+  access_token: makeJwt({
+    sid: "sid-service",
+    jti: "jti-service",
+    exp: Math.floor(Date.now() / 1000) + 900,
+  }),
+  expires_in: 900,
+  refresh_token: "refresh-service",
+  refresh_expires_in: 3600,
+  pop_key: Buffer.from("pop-key-service").toString("base64url"),
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("service-account credential env loading", () => {
+  it("loads split env vars with rust-compatible aliases", async () => {
+    await expect(
+      loadServiceAccountCredentialFromEnv({
+        PHOENIX_SERVICE_ACCOUNT_CLIENT_ID: " service-client ",
+        PHOENIX_SERVICE_KEY_ID: " service-key ",
+        PHOENIX_SERVICE_ACCOUNT_PRIVATE_KEY: ` ${privateKey} `,
+      })
+    ).resolves.toEqual({
+      client_id: "service-client",
+      key_id: "service-key",
+      private_key: privateKey,
+    });
+  });
+
+  it("loads credential file path before split env vars", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "rise-service-account-"));
+    const credentialPath = join(dir, "credential.json");
+    await writeFile(
+      credentialPath,
+      JSON.stringify({
+        client_id: "file-client",
+        key_id: "file-key",
+        public_key: "ignored",
+        private_key: privateKey,
+      })
+    );
+
+    try {
+      await expect(
+        loadServiceAccountCredentialFromEnv({
+          HOME: dir,
+          PHOENIX_SERVICE_ACCOUNT_CREDENTIAL: "~/credential.json",
+          PHOENIX_SERVICE_ACCOUNT_CLIENT_ID: "split-client",
+          PHOENIX_SERVICE_ACCOUNT_KEY_ID: "split-key",
+          PHOENIX_SERVICE_ACCOUNT_PRIVATE_KEY: privateKey,
+        })
+      ).resolves.toEqual({
+        client_id: "file-client",
+        key_id: "file-key",
+        public_key: "ignored",
+        private_key: privateKey,
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null when no service-account env is present", async () => {
+    await expect(loadServiceAccountCredentialFromEnv({})).resolves.toBeNull();
+  });
+
+  it("fails closed on partial split env vars", async () => {
+    await expect(
+      loadServiceAccountCredentialFromEnv({
+        PHOENIX_SERVICE_ACCOUNT_CLIENT_ID: "service-client",
+      })
+    ).rejects.toMatchObject({
+      name: "PhoenixAuthError",
+      code: "incomplete_service_account_credential_env",
+    });
+  });
+});
+
+describe("service-account authentication", () => {
+  it("signs the service challenge and stores the resulting session", async () => {
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const body = parseJsonObject(String(init?.body ?? "{}"));
+
+        if (url.endsWith("/v1/auth/login/service/challenge")) {
+          expect(body).toEqual({
+            client_id: "service-client",
+            key_id: "service-key",
+          });
+          return new Response(
+            JSON.stringify({
+              nonce: "nonce-1",
+              message:
+                "Phoenix service login\nnonce:nonce-1\ntimestamp:2026-06-25T12:00:00Z",
+              expires_at: "2026-06-25T12:05:00Z",
+              key_id: "service-key",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
+
+        if (url.endsWith("/v1/auth/login/service")) {
+          expect(body).toEqual({
+            client_id: "service-client",
+            key_id: "service-key",
+            nonce: "nonce-1",
+            timestamp: "2026-06-25T12:00:00Z",
+            signature: expect.any(String),
+          });
+          expect(expectStringField(body, "signature").length).toBeGreaterThan(
+            40
+          );
+          return new Response(JSON.stringify(authResponse), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+
+        return new Response("not found", { status: 404 });
+      }
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new PhoenixAuthClient({ apiUrl: "https://example.com" });
+    const session = await client.loginWithServiceAccountCredential({
+      client_id: "service-client",
+      key_id: "service-key",
+      private_key: privateKey,
+    });
+
+    expect(session.refreshToken).toBe("refresh-service");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `190b6af2b821bd0670b4a1aea8dad552bcd62482`
- Mode: manual
- Synced paths:

- `rise/ts` -> `ts`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/programs` -> `programs`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `ts/CHANGELOG.md`

### Summary

- **Service-account authentication for server-side tools.** `PhoenixAuthClient` gains three new methods — `loginWithServiceAccountSigner`, `loginWithServiceAccountCredential`, and `loginWithServiceAccountFromEnv` — enabling non-interactive authentication using Ed25519 keypair credentials.
- **New public exports from `@ellipsis-labs/rise/auth`:** `PhoenixServiceAccountCredential`, `PhoenixServiceAccountAuthSigner`, `PhoenixServiceAccountAuthClient`, `PhoenixServiceAccountCredentialEnv`, `createServiceAccountAuthSigner`, `loginWithServiceAccountCredential`, `loginWithServiceAccountSigner`, `loginWithServiceAccountFromEnv`, `loadServiceAccountCredentialFromEnv`, and `loadServiceAccountCredentialFromPath`.
- **Env-var credential loading** mirrors the Rise Rust SDK: set `PHOENIX_SERVICE_ACCOUNT_CREDENTIAL` (path to a JSON file) or the split vars `PHOENIX_SERVICE_ACCOUNT_CLIENT_ID` / `PHOENIX_SERVICE_ACCOUNT_KEY_ID` / `PHOENIX_SERVICE_ACCOUNT_PRIVATE_KEY`. Legacy `PHOENIX_SERVICE_CLIENT_ID`, `PHOENIX_SERVICE_KEY_ID`, and `PHOENIX_SERVICE_PRIVATE_KEY` aliases are also accepted.

### Breaking Changes

- None identified in the synced diff.

### Consumer Notes

- Credential file loading (`PHOENIX_SERVICE_ACCOUNT_CREDENTIAL` / `loadServiceAccountCredentialFromPath`) uses `node:fs/promises` and is only available in Node.js and Bun environments; browser bundles that import `loadServiceAccountCredentialFromEnv` with a file path will throw at runtime. Split env-var loading has no Node dependency and works anywhere `process.env` is accessible.
- Partial split-env configuration (some but not all of `CLIENT_ID`, `KEY_ID`, `PRIVATE_KEY` present) throws `PhoenixAuthError` with code `incomplete_service_account_credential_env` rather than silently falling through.
- Private keys must be 32-byte Ed25519 seeds encoded as base64url (no padding); a mismatched length throws `PhoenixAuthError` with code `invalid_service_account_private_key`.