### PR TITLE
sync: Rise Rust v0.1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ TypeScript:
 - [rise/ts/examples/04-trader-state-store.ts](./ts/examples/04-trader-state-store.ts)
 - [rise/ts/examples/05-cancel-all-conditional-orders.ts](./ts/examples/05-cancel-all-conditional-orders.ts)
 - [rise/ts/examples/06-flight-market-order.ts](./ts/examples/06-flight-market-order.ts)
+- [rise/ts/examples/09-referral-activation-tx.ts](./ts/examples/09-referral-activation-tx.ts)
+- [rise/ts/examples/10-builder-onboarding-tx.ts](./ts/examples/10-builder-onboarding-tx.ts)
 - [rise/ts/examples/phoenix-client-example.ts](./ts/examples/phoenix-client-example.ts)
 - [rise/ts/examples/phoenix-ws-example.ts](./ts/examples/phoenix-ws-example.ts)
 - [rise/ts/README.md](./ts/README.md)
@@ -44,16 +46,34 @@ Rust:
 - [rise/rust/examples/send_limit_order.rs](./rust/examples/send_limit_order.rs)
 - [rise/rust/examples/send_market_order.rs](./rust/examples/send_market_order.rs)
 - [rise/rust/examples/send_flight_market_order.rs](./rust/examples/send_flight_market_order.rs)
+- [rise/rust/examples/referral_activation_tx.rs](./rust/examples/referral_activation_tx.rs)
+- [rise/rust/examples/builder_onboarding_tx.rs](./rust/examples/builder_onboarding_tx.rs)
 
-## Onboarding: Access Code vs Referral Code
+## Onboarding Paths
 
-These invite routes are not interchangeable:
+These onboarding routes are not interchangeable:
 
 - Use `POST /v1/invite/activate` when you have an access code / allowlist code.
   Send that value as `code`.
-- Use `POST /v1/referral/activate` when you have a referral code. Send that
-  value as `referral_code`. This route requires a user auth session for the
-  same authority wallet being activated.
+- Use `POST /v1/referral/activate-tx` when you have a referral code and want
+  delegated onboarding. The referral code is required, and the trader authority
+  must sign the transaction.
+- Use `POST /v1/exchange/build-register-ixs` followed by
+  `POST /v1/exchange/send-register-ixs` when a builder wants to register and
+  onboard a trader without a referral code. The builder chooses the transaction
+  fee payer, and the API signs only after validating and simulating the
+  submitted transaction.
+
+For copyable Rust and TypeScript examples of both delegated onboarding paths,
+see [sdk/delegated-onboarding.mdx](../sdk/delegated-onboarding.mdx). Runnable
+examples are also available in
+[09-referral-activation-tx.ts](./ts/examples/09-referral-activation-tx.ts),
+[10-builder-onboarding-tx.ts](./ts/examples/10-builder-onboarding-tx.ts),
+[referral_activation_tx.rs](./rust/examples/referral_activation_tx.rs), and
+[builder_onboarding_tx.rs](./rust/examples/builder_onboarding_tx.rs).
+
+The access-code route remains simpler because the user already has an allowlist
+code:
 
 TypeScript:
 
@@ -71,11 +91,6 @@ const activatedWithAccessCode = await client.invite().activateInvite({
   authority,
   code: "ACCESS_CODE",
 });
-
-const activatedWithReferral = await client.invite().activateReferral({
-  authority,
-  referral_code: "REF_CODE",
-});
 ```
 
 Rust:
@@ -92,16 +107,11 @@ let trader_from_access = client
     .invite()
     .activate_invite(&authority, "ACCESS_CODE")
     .await?;
-
-let trader_from_referral = client
-    .invite()
-    .activate_referral(&authority, "REF_CODE")
-    .await?;
 ```
 
 Use
 [register_trader.rs](./rust/examples/register_trader.rs)
-when you want a ready-to-run Rust version of this flow.
+when you want a ready-to-run Rust access-code example.
 
 ## Fetching Exchange, Market, and Trader State
 

--- a/programs/close-position-and-withdraw/Cargo.lock
+++ b/programs/close-position-and-withdraw/Cargo.lock
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.6.0",

--- a/programs/close-position-and-withdraw/cli/Cargo.lock
+++ b/programs/close-position-and-withdraw/cli/Cargo.lock
@@ -1451,7 +1451,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "async-trait",
  "base64",

--- a/programs/trader-onboarder/Cargo.lock
+++ b/programs/trader-onboarder/Cargo.lock
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.6.0",

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -258,3 +258,25 @@ Source Phoenix commit: `823bb5e64efafb221f37a7e0a8f8720da843741c`
 - The `referral_activation_tx` example no longer requires `--register-if-missing`; the flag is accepted but silently ignored for backward compatibility. Remove it from any example invocations you have documented.
 - If you call `fetch_referral_activation_trader_status` and receive `ReferralActivationTraderStatus::Missing`, pass `should_include_register_trader() == true` (and a valid `max_positions` in the range 32–128) to your transaction builder. Accounts in the `Registered` or `Activated` states skip registration and only set capabilities.
 - `--max-positions` in the example binary now enforces a minimum of 32 (previously 1). This affects the example only and does not change the library API.
+
+## v0.1.16 - 2026-06-25
+
+Source Phoenix commit: `2f2bb2ba1256f28465278ff1c00d61f0ffc2c5f2`
+
+### Summary
+
+- Added builder-initiated trader onboarding support: two new `ExchangeClient` methods — `build_register_ixs` and `send_register_ixs` — let a builder register and onboard a trader without a referral code, using `POST /v1/exchange/build-register-ixs` and `POST /v1/exchange/send-register-ixs`.
+- Six new public types exported from the crate root (under the `sdk` feature): `BuildRegisterIxsRequest`, `BuildRegisterIxsResponse`, `SendRegisterIxsRequest`, `SendRegisterIxsResponse`, `ApiInstructionResponse`, and `ApiAccountMeta`.
+- New `builder_onboarding_tx` example (requires `solana-keypair` feature) demonstrates the full build-sign-submit flow; run with `--trader-keypair-path` and an optional `--fee-payer-keypair-path`.
+- Documentation updated to clarify the three distinct onboarding paths: access-code (`/v1/invite/activate`), referral-code (`/v1/referral/activate-tx`), and builder (`/v1/exchange/build-register-ixs` + `/v1/exchange/send-register-ixs`).
+
+### Breaking Changes
+
+- None identified in the synced diff.
+
+### Consumer Notes
+
+- To use the new builder onboarding APIs, call `client.exchange().build_register_ixs(...)` with a `BuildRegisterIxsRequest` (trader authority, fee payer, optional `max_positions`), sign the returned instructions locally, then submit the base64-encoded signed transaction via `client.exchange().send_register_ixs(...)`. The API validates, co-signs, simulates, and broadcasts the transaction.
+- `ApiInstructionResponse` and `ApiAccountMeta` are the deserialized instruction shapes returned by `build_register_ixs`; downstream code that builds transactions from the response will need to import these types.
+- The `max_positions` field on both request types is optional (serialized only when `Some`); defaults to 128 on the server side.
+- `trader_pda_index` and `trader_subaccount_index` on `SendRegisterIxsRequest` are also optional; omit them to accept server defaults.

--- a/rust/CRATES.md
+++ b/rust/CRATES.md
@@ -9,7 +9,7 @@
 
 ```toml
 [dependencies]
-phoenix-rise = "0.1.15"
+phoenix-rise = "0.1.16"
 ```
 
 Optional features:
@@ -40,9 +40,16 @@ Examples that use a local Solana keypair require `solana-keypair`:
 
 ```bash
 cargo run -p phoenix-rise --example subscribe_trader_state --features solana-keypair
+cargo run -p phoenix-rise --example referral_activation_tx --features solana-keypair -- REFERRAL_CODE --trader-keypair-path ~/.config/solana/id.json
+cargo run -p phoenix-rise --example builder_onboarding_tx --features solana-keypair -- --trader-keypair-path ~/.config/solana/id.json
 cargo run -p phoenix-rise --example onboard_trader_delegated --features solana-keypair -- <TRADER_AUTHORITY>
 cargo run -p phoenix-rise --example delegated_trader_management_onboarding --features solana-keypair -- <TRADER_AUTHORITY>
 ```
+
+`referral_activation_tx` demonstrates delegated onboarding with a referral code
+through `/v1/referral/activate-tx`. `builder_onboarding_tx` demonstrates
+registering a trader without a referral code through
+`/v1/exchange/build-register-ixs` and `/v1/exchange/send-register-ixs`.
 
 Examples that do not need that feature can be run directly:
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "async-trait",
  "axum",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-sdk-cli"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "clap",
  "phoenix-rise",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,7 +17,7 @@ publish = true
 readme = "CRATES.md"
 repository = "https://github.com/Ellipsis-Labs/rise-public"
 rust-version = "1.84.0"
-version = "0.1.15"
+version = "0.1.16"
 
 [[example]]
 name              = "cancel_all_conditional_orders"
@@ -37,6 +37,10 @@ required-features = ["solana-keypair"]
 
 [[example]]
 name              = "delegated_trader_management_onboarding"
+required-features = ["solana-keypair"]
+
+[[example]]
+name              = "builder_onboarding_tx"
 required-features = ["solana-keypair"]
 
 [[example]]
@@ -165,7 +169,7 @@ publish      = true
 readme       = "CRATES.md"
 repository   = "https://github.com/Ellipsis-Labs/rise-public"
 rust-version = "1.89.0"
-version      = "0.1.15"
+version      = "0.1.16"
 
 [workspace.dependencies]
 clap = { version = "4.5", features = ["derive"] }

--- a/rust/README.md
+++ b/rust/README.md
@@ -186,7 +186,8 @@ Use `rise/rust/examples/` as the main reference set:
   `subscribe_candles.rs`, `subscribe_trades.rs`, `ws_debug_cli.rs`
 - Transaction building and trading: `send_limit_order.rs`,
   `send_market_order.rs`, `send_flight_market_order.rs`, `cancel_order.rs`,
-  `cancel_stop_loss.rs`, `deposit_funds.rs`, `onboard_trader_delegated.rs`,
+  `cancel_stop_loss.rs`, `deposit_funds.rs`, `referral_activation_tx.rs`,
+  `builder_onboarding_tx.rs`, `onboard_trader_delegated.rs`,
   `delegated_trader_management_onboarding.rs`
 - Isolated flows: `isolated_limit_order.rs`,
   `isolated_market_order_client.rs`, `isolated_market_order_server.rs`
@@ -208,7 +209,16 @@ cargo test
 cargo run -p phoenix-rise --example http_client
 cargo run -p phoenix-rise --example subscribe_l2_book -- SOL
 cargo run -p phoenix-rise --example subscribe_trader_state --features solana-keypair
+cargo run -p phoenix-rise --example referral_activation_tx --features solana-keypair -- \
+    REFERRAL_CODE --trader-keypair-path ~/.config/solana/id.json
+cargo run -p phoenix-rise --example builder_onboarding_tx --features solana-keypair -- \
+    --trader-keypair-path ~/.config/solana/id.json
 cargo run -p phoenix-rise --example send_market_order --features solana-keypair -- SOL
 cargo run -p phoenix-rise --example send_flight_market_order --features solana-keypair -- \
     Builder1111111111111111111111111111111111 0 0 SOL bid 67
 ```
+
+`referral_activation_tx` uses `/v1/referral/activate-tx` when the user has a
+referral code. `builder_onboarding_tx` uses
+`/v1/exchange/build-register-ixs` and `/v1/exchange/send-register-ixs` to
+register a trader without a referral code.

--- a/rust/examples/builder_onboarding_tx.rs
+++ b/rust/examples/builder_onboarding_tx.rs
@@ -1,0 +1,284 @@
+//! Example: register and onboard a trader without a referral code.
+//!
+//! This uses `POST /v1/exchange/build-register-ixs` to fetch the
+//! register/onboard instructions, signs the user-controlled signer slots, then
+//! submits the transaction to `POST /v1/exchange/send-register-ixs`. The API
+//! validates, signs with the configured Phoenix onboarding keypair, simulates,
+//! and sends it.
+//!
+//! Run with:
+//! ```text
+//!   cargo run -p phoenix-rise --example builder_onboarding_tx \
+//!     --features solana-keypair -- \
+//!     --trader-keypair-path ~/.config/solana/id.json
+//! ```
+//!
+//! Options:
+//!   --api-url <url>                  Phoenix API URL
+//!   --rpc-url <url>                  Solana RPC URL
+//!   --trader-keypair-path <path>     Trader authority keypair path
+//!   --fee-payer-keypair-path <path>  Fee-payer keypair path
+//!   --max-positions <n>              Max positions when registering
+//!   --recent-blockhash <blockhash>   Optional blockhash for the transaction
+//!
+//! Environment:
+//!   PHOENIX_API_URL
+//!   PHOENIX_RPC_URL / SOLANA_RPC_URL
+//!   TRADER_KEYPAIR_PATH / KEYPAIR_PATH
+//!   FEE_PAYER_KEYPAIR_PATH
+
+use std::str::FromStr;
+use std::{env, process};
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use phoenix_rise::{
+    ApiInstructionResponse, BuildRegisterIxsRequest, PhoenixHttpClient, SendRegisterIxsRequest,
+};
+use solana_commitment_config::CommitmentConfig;
+use solana_instruction::{AccountMeta, Instruction};
+use solana_keypair::read_keypair_file;
+use solana_pubkey::Pubkey;
+use solana_rpc_client::nonblocking::rpc_client::RpcClient;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+use solana_transaction::versioned::VersionedTransaction;
+
+const DEFAULT_API_URL: &str = "https://perp-api.phoenix.trade";
+const DEFAULT_RPC_URL: &str = "https://api.mainnet-beta.solana.com";
+const DEFAULT_MAX_POSITIONS: u32 = 128;
+const USAGE: &str = r#"Usage:
+  cargo run -p phoenix-rise --example builder_onboarding_tx --features solana-keypair -- [options]
+
+Options:
+  --api-url <url>                  Phoenix API URL
+  --rpc-url <url>                  Solana RPC URL
+  --trader-keypair-path <path>     Trader authority keypair path
+  --fee-payer-keypair-path <path>  Fee-payer keypair path (default: trader keypair)
+  --max-positions <n>              Max positions when registering (32-128, default: 128)
+  --recent-blockhash <blockhash>   Optional blockhash to use in the transaction
+  -h, --help                       Show this help
+
+Environment:
+  PHOENIX_API_URL
+  PHOENIX_RPC_URL / SOLANA_RPC_URL
+  TRADER_KEYPAIR_PATH / KEYPAIR_PATH
+  FEE_PAYER_KEYPAIR_PATH
+"#;
+
+struct CliArgs {
+    api_url: String,
+    rpc_url: String,
+    trader_keypair_path: String,
+    fee_payer_keypair_path: Option<String>,
+    max_positions: u32,
+    recent_blockhash: Option<String>,
+}
+
+fn fail(message: &str) -> ! {
+    eprintln!("{message}");
+    eprintln!();
+    eprintln!("{USAGE}");
+    process::exit(1);
+}
+
+fn default_keypair_path() -> String {
+    let home = env::var("HOME").expect("HOME environment variable not set");
+    format!("{home}/.config/solana/id.json")
+}
+
+fn parse_max_positions(value: &str) -> u32 {
+    let max_positions = value
+        .parse::<u32>()
+        .unwrap_or_else(|_| fail(&format!("Invalid value for --max-positions: {value}")));
+    if !(32..=DEFAULT_MAX_POSITIONS).contains(&max_positions) {
+        fail("--max-positions must be between 32 and 128");
+    }
+    max_positions
+}
+
+fn parse_args(argv: Vec<String>) -> CliArgs {
+    let mut api_url = env::var("PHOENIX_API_URL").unwrap_or_else(|_| DEFAULT_API_URL.to_string());
+    let mut rpc_url = env::var("PHOENIX_RPC_URL")
+        .or_else(|_| env::var("SOLANA_RPC_URL"))
+        .unwrap_or_else(|_| DEFAULT_RPC_URL.to_string());
+    let mut trader_keypair_path = env::var("TRADER_KEYPAIR_PATH")
+        .or_else(|_| env::var("KEYPAIR_PATH"))
+        .unwrap_or_else(|_| default_keypair_path());
+    let mut fee_payer_keypair_path = env::var("FEE_PAYER_KEYPAIR_PATH").ok();
+    let mut max_positions = DEFAULT_MAX_POSITIONS;
+    let mut recent_blockhash = None::<String>;
+
+    let mut args = argv.into_iter().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--api-url" => {
+                api_url = args
+                    .next()
+                    .unwrap_or_else(|| fail("Missing value for --api-url"));
+            }
+            "--rpc-url" => {
+                rpc_url = args
+                    .next()
+                    .unwrap_or_else(|| fail("Missing value for --rpc-url"));
+            }
+            "--trader-keypair-path" => {
+                trader_keypair_path = args
+                    .next()
+                    .unwrap_or_else(|| fail("Missing value for --trader-keypair-path"));
+            }
+            "--fee-payer-keypair-path" => {
+                fee_payer_keypair_path = Some(
+                    args.next()
+                        .unwrap_or_else(|| fail("Missing value for --fee-payer-keypair-path")),
+                );
+            }
+            "--max-positions" => {
+                let value = args
+                    .next()
+                    .unwrap_or_else(|| fail("Missing value for --max-positions"));
+                max_positions = parse_max_positions(&value);
+            }
+            "--recent-blockhash" => {
+                recent_blockhash = Some(
+                    args.next()
+                        .unwrap_or_else(|| fail("Missing value for --recent-blockhash")),
+                );
+            }
+            "-h" | "--help" => {
+                println!("{USAGE}");
+                process::exit(0);
+            }
+            value => fail(&format!("Unknown argument: {value}")),
+        }
+    }
+
+    CliArgs {
+        api_url,
+        rpc_url,
+        trader_keypair_path,
+        fee_payer_keypair_path,
+        max_positions,
+        recent_blockhash,
+    }
+}
+
+fn encode_transaction(
+    transaction: &VersionedTransaction,
+) -> Result<String, Box<dyn std::error::Error>> {
+    Ok(BASE64_STANDARD.encode(bincode::serialize(transaction)?))
+}
+
+fn to_instruction(
+    api_instruction: &ApiInstructionResponse,
+) -> Result<Instruction, Box<dyn std::error::Error>> {
+    Ok(Instruction {
+        program_id: Pubkey::from_str(&api_instruction.program_id)?,
+        accounts: api_instruction
+            .keys
+            .iter()
+            .map(|account| {
+                Ok(AccountMeta {
+                    pubkey: Pubkey::from_str(&account.pubkey)?,
+                    is_signer: account.is_signer,
+                    is_writable: account.is_writable,
+                })
+            })
+            .collect::<Result<Vec<_>, Box<dyn std::error::Error>>>()?,
+        data: api_instruction.data.clone(),
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let argv: Vec<String> = env::args().collect();
+    if argv.len() == 1 {
+        println!("This example submits a live builder onboarding transaction.");
+        println!(
+            "Pass --trader-keypair-path, or set TRADER_KEYPAIR_PATH, to register and onboard that \
+             trader without a referral code.\n"
+        );
+        println!("{USAGE}");
+        return Ok(());
+    }
+
+    let args = parse_args(argv);
+    let trader_keypair = read_keypair_file(&args.trader_keypair_path)
+        .map_err(|error| format!("Failed to read trader keypair: {error}"))?;
+    let fee_payer_keypair = args
+        .fee_payer_keypair_path
+        .as_deref()
+        .map(read_keypair_file)
+        .transpose()
+        .map_err(|error| format!("Failed to read fee-payer keypair: {error}"))?;
+    let trader_authority = trader_keypair.pubkey();
+    let tx_fee_payer = fee_payer_keypair
+        .as_ref()
+        .map(Signer::pubkey)
+        .unwrap_or(trader_authority);
+
+    println!("API URL:           {}", args.api_url);
+    println!("RPC URL:           {}", args.rpc_url);
+    println!("Trader authority:  {trader_authority}");
+    println!("Transaction payer: {tx_fee_payer}");
+
+    let http = PhoenixHttpClient::new_public(args.api_url)?;
+    let response = http
+        .exchange()
+        .build_register_ixs(&BuildRegisterIxsRequest {
+            trader_authority: trader_authority.to_string(),
+            tx_fee_payer: tx_fee_payer.to_string(),
+            max_positions: Some(args.max_positions),
+        })
+        .await?;
+    let instructions = response
+        .instructions
+        .iter()
+        .map(to_instruction)
+        .collect::<Result<Vec<_>, _>>()?;
+    let rpc = RpcClient::new_with_commitment(args.rpc_url, CommitmentConfig::confirmed());
+    let recent_blockhash = match args.recent_blockhash.as_deref() {
+        Some(blockhash) => blockhash.parse()?,
+        None => rpc.get_latest_blockhash().await?,
+    };
+    let mut transaction = Transaction::new_with_payer(&instructions, Some(&tx_fee_payer));
+    if let Some(fee_payer_keypair) = fee_payer_keypair.as_ref() {
+        if fee_payer_keypair.pubkey() != trader_authority {
+            transaction
+                .try_partial_sign(&[&trader_keypair, fee_payer_keypair], recent_blockhash)?;
+        } else {
+            transaction.try_partial_sign(&[&trader_keypair], recent_blockhash)?;
+        }
+    } else {
+        transaction.try_partial_sign(&[&trader_keypair], recent_blockhash)?;
+    }
+
+    let transaction = VersionedTransaction::from(transaction);
+    let signed_transaction = encode_transaction(&transaction)?;
+    println!("Trader PDA:        {}", response.trader_pda);
+    println!("Trader onboarder:  {}", response.trader_onboarder);
+    println!("Recent blockhash:  {recent_blockhash}");
+    println!("Max positions:     {}", response.max_positions);
+    println!("Includes register: {}", response.include_register_trader);
+    println!("Signed tx base64:  {signed_transaction}");
+
+    let submitted = http
+        .exchange()
+        .send_register_ixs(&SendRegisterIxsRequest {
+            transaction: signed_transaction,
+            trader_authority: trader_authority.to_string(),
+            tx_fee_payer: tx_fee_payer.to_string(),
+            max_positions: Some(args.max_positions),
+            trader_pda_index: Some(0),
+            trader_subaccount_index: Some(0),
+        })
+        .await?;
+    println!("\nTransaction submitted by API.");
+    println!("Signature: {}", submitted.signature);
+    println!(
+        "Explorer:  https://explorer.solana.com/tx/{}",
+        submitted.signature
+    );
+
+    Ok(())
+}

--- a/rust/src/api/exchange.rs
+++ b/rust/src/api/exchange.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::http_client::HttpClientInner;
 use crate::phoenix_rise_types::{
     ExchangeKeysView, ExchangeResponse, ExchangeSnapshotView, ExchangeStatusView, PhoenixHttpError,
@@ -23,4 +25,83 @@ impl ExchangeClient<'_> {
     pub async fn get_status(&self) -> Result<ExchangeStatusView, PhoenixHttpError> {
         self.http.get_json("/exchange/status").await
     }
+
+    pub async fn build_register_ixs(
+        &self,
+        request: &BuildRegisterIxsRequest,
+    ) -> Result<BuildRegisterIxsResponse, PhoenixHttpError> {
+        self.http
+            .post_json("/v1/exchange/build-register-ixs", request)
+            .await
+    }
+
+    pub async fn send_register_ixs(
+        &self,
+        request: &SendRegisterIxsRequest,
+    ) -> Result<SendRegisterIxsResponse, PhoenixHttpError> {
+        self.http
+            .post_json("/v1/exchange/send-register-ixs", request)
+            .await
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiAccountMeta {
+    pub pubkey: String,
+    pub is_signer: bool,
+    pub is_writable: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiInstructionResponse {
+    pub data: Vec<u8>,
+    pub keys: Vec<ApiAccountMeta>,
+    pub program_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildRegisterIxsRequest {
+    pub trader_authority: String,
+    pub tx_fee_payer: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_positions: Option<u32>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildRegisterIxsResponse {
+    pub instructions: Vec<ApiInstructionResponse>,
+    pub trader_pda: String,
+    pub trader_onboarder: String,
+    pub tx_fee_payer: String,
+    pub max_positions: u32,
+    pub include_register_trader: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SendRegisterIxsRequest {
+    pub transaction: String,
+    pub trader_authority: String,
+    pub tx_fee_payer: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_positions: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trader_pda_index: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trader_subaccount_index: Option<u8>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SendRegisterIxsResponse {
+    pub signature: String,
+    pub trader_pda: String,
+    pub trader_onboarder: String,
+    pub tx_fee_payer: String,
+    pub max_positions: u32,
+    pub include_register_trader: bool,
 }

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -10,7 +10,10 @@ mod trades;
 
 pub use candles::CandlesClient;
 pub use collateral::CollateralClient;
-pub use exchange::ExchangeClient;
+pub use exchange::{
+    ApiAccountMeta, ApiInstructionResponse, BuildRegisterIxsRequest, BuildRegisterIxsResponse,
+    ExchangeClient, SendRegisterIxsRequest, SendRegisterIxsResponse,
+};
 pub use funding::FundingClient;
 pub use invite::{
     ActivateReferralTxRequest, ActivateReferralTxResponse, InviteClient,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -101,12 +101,13 @@ mod ws_client;
 pub use accounts::{AccountDataFetcher, PhoenixAccountClient, PhoenixAccountClientError};
 #[cfg(feature = "sdk")]
 pub use api::{
-    ActivateReferralTxRequest, ActivateReferralTxResponse, CandlesClient, CollateralClient,
+    ActivateReferralTxRequest, ActivateReferralTxResponse, ApiAccountMeta, ApiInstructionResponse,
+    BuildRegisterIxsRequest, BuildRegisterIxsResponse, CandlesClient, CollateralClient,
     ExchangeClient, FundingClient, InviteClient, MarketsClient, OrdersClient,
     ReferralActivationPermissionResponse, ReferralActivationTraderStatus,
-    ReferralActivationTraderStatusError, TradersClient, TradesClient,
-    fetch_referral_activation_trader_status, has_referral_activation_capabilities,
-    referral_activation_trader_status,
+    ReferralActivationTraderStatusError, SendRegisterIxsRequest, SendRegisterIxsResponse,
+    TradersClient, TradesClient, fetch_referral_activation_trader_status,
+    has_referral_activation_capabilities, referral_activation_trader_status,
 };
 #[cfg(all(feature = "sdk", feature = "solana-keypair"))]
 pub use auth::PhoenixWalletSessionManager;

--- a/rust/tests/invite_client_tests.rs
+++ b/rust/tests/invite_client_tests.rs
@@ -8,8 +8,9 @@ use base64::Engine;
 use phoenix_rise::phoenix_rise_ix::TRADER_CAPABILITY_CAN_DEPOSIT;
 use phoenix_rise::phoenix_rise_types::accounts::Trader;
 use phoenix_rise::{
-    ActivateReferralTxRequest, PhoenixHttpClient, ReferralActivationTraderStatus,
-    has_referral_activation_capabilities, referral_activation_trader_status,
+    ActivateReferralTxRequest, BuildRegisterIxsRequest, PhoenixHttpClient,
+    ReferralActivationTraderStatus, SendRegisterIxsRequest, has_referral_activation_capabilities,
+    referral_activation_trader_status,
 };
 use serde_json::{Value, json};
 use solana_pubkey::Pubkey;
@@ -27,6 +28,14 @@ async fn activate_invite_parses_object_response() {
         .route(
             "/v1/referral/activate-tx",
             post(activate_referral_tx_handler),
+        )
+        .route(
+            "/v1/exchange/build-register-ixs",
+            post(build_register_ixs_handler),
+        )
+        .route(
+            "/v1/exchange/send-register-ixs",
+            post(send_register_ixs_handler),
         );
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -90,6 +99,43 @@ async fn activate_invite_parses_object_response() {
     );
     assert_eq!(activation.referral_code, "REFCODE");
     assert_eq!(activation.status, "submitted");
+
+    let onboarding = client
+        .exchange()
+        .build_register_ixs(&BuildRegisterIxsRequest {
+            trader_authority: authority.to_string(),
+            tx_fee_payer: "FeePayer11111111111111111111111111111111".to_string(),
+            max_positions: Some(128),
+        })
+        .await
+        .unwrap();
+    assert_eq!(onboarding.instructions.len(), 1);
+    assert_eq!(
+        onboarding.trader_pda,
+        "Trader4444444444444444444444444444444444"
+    );
+    assert_eq!(onboarding.max_positions, 128);
+    assert!(onboarding.include_register_trader);
+
+    let submitted = client
+        .exchange()
+        .send_register_ixs(&SendRegisterIxsRequest {
+            transaction: "base64-user-signed-tx".to_string(),
+            trader_authority: authority.to_string(),
+            tx_fee_payer: "FeePayer11111111111111111111111111111111".to_string(),
+            max_positions: Some(128),
+            trader_pda_index: Some(0),
+            trader_subaccount_index: Some(0),
+        })
+        .await
+        .unwrap();
+    assert_eq!(submitted.signature, "sent-register-signature");
+    assert_eq!(
+        submitted.trader_pda,
+        "Trader4444444444444444444444444444444444"
+    );
+    assert_eq!(submitted.max_positions, 128);
+    assert!(submitted.include_register_trader);
 
     server.abort();
 }
@@ -214,6 +260,69 @@ async fn activate_referral_tx_handler(Json(body): Json<Value>) -> Json<Value> {
         "trader_pda": "Trader3333333333333333333333333333333333",
         "referral_code": "REFCODE",
         "status": "submitted"
+    }))
+}
+
+async fn build_register_ixs_handler(Json(body): Json<Value>) -> Json<Value> {
+    let expected_authority = expected_authority().to_string();
+    assert_eq!(
+        body.get("traderAuthority").and_then(Value::as_str),
+        Some(expected_authority.as_str())
+    );
+    assert_eq!(
+        body.get("txFeePayer").and_then(Value::as_str),
+        Some("FeePayer11111111111111111111111111111111")
+    );
+    assert_eq!(body.get("maxPositions").and_then(Value::as_u64), Some(128));
+    Json(json!({
+        "instructions": [
+            {
+                "programId": "Program1111111111111111111111111111111111",
+                "keys": [
+                    {
+                        "pubkey": "FeePayer11111111111111111111111111111111",
+                        "isSigner": true,
+                        "isWritable": true
+                    }
+                ],
+                "data": [1, 2, 3]
+            }
+        ],
+        "traderPda": "Trader4444444444444444444444444444444444",
+        "traderOnboarder": "Onboarder111111111111111111111111111111111",
+        "txFeePayer": "FeePayer11111111111111111111111111111111",
+        "maxPositions": 128,
+        "includeRegisterTrader": true
+    }))
+}
+
+async fn send_register_ixs_handler(Json(body): Json<Value>) -> Json<Value> {
+    let expected_authority = expected_authority().to_string();
+    assert_eq!(
+        body.get("transaction").and_then(Value::as_str),
+        Some("base64-user-signed-tx")
+    );
+    assert_eq!(
+        body.get("traderAuthority").and_then(Value::as_str),
+        Some(expected_authority.as_str())
+    );
+    assert_eq!(
+        body.get("txFeePayer").and_then(Value::as_str),
+        Some("FeePayer11111111111111111111111111111111")
+    );
+    assert_eq!(body.get("maxPositions").and_then(Value::as_u64), Some(128));
+    assert_eq!(body.get("traderPdaIndex").and_then(Value::as_u64), Some(0));
+    assert_eq!(
+        body.get("traderSubaccountIndex").and_then(Value::as_u64),
+        Some(0)
+    );
+    Json(json!({
+        "signature": "sent-register-signature",
+        "traderPda": "Trader4444444444444444444444444444444444",
+        "traderOnboarder": "Onboarder111111111111111111111111111111111",
+        "txFeePayer": "FeePayer11111111111111111111111111111111",
+        "maxPositions": 128,
+        "includeRegisterTrader": true
     }))
 }
 


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `2f2bb2ba1256f28465278ff1c00d61f0ffc2c5f2`
- Mode: automatic
- Synced paths:

- `rise/rust` -> `rust`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/programs` -> `programs`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `rust/CHANGELOG.md`

### Summary

- Added builder-initiated trader onboarding support: two new `ExchangeClient` methods — `build_register_ixs` and `send_register_ixs` — let a builder register and onboard a trader without a referral code, using `POST /v1/exchange/build-register-ixs` and `POST /v1/exchange/send-register-ixs`.
- Six new public types exported from the crate root (under the `sdk` feature): `BuildRegisterIxsRequest`, `BuildRegisterIxsResponse`, `SendRegisterIxsRequest`, `SendRegisterIxsResponse`, `ApiInstructionResponse`, and `ApiAccountMeta`.
- New `builder_onboarding_tx` example (requires `solana-keypair` feature) demonstrates the full build-sign-submit flow; run with `--trader-keypair-path` and an optional `--fee-payer-keypair-path`.
- Documentation updated to clarify the three distinct onboarding paths: access-code (`/v1/invite/activate`), referral-code (`/v1/referral/activate-tx`), and builder (`/v1/exchange/build-register-ixs` + `/v1/exchange/send-register-ixs`).

### Breaking Changes

- None identified in the synced diff.

### Consumer Notes

- To use the new builder onboarding APIs, call `client.exchange().build_register_ixs(...)` with a `BuildRegisterIxsRequest` (trader authority, fee payer, optional `max_positions`), sign the returned instructions locally, then submit the base64-encoded signed transaction via `client.exchange().send_register_ixs(...)`. The API validates, co-signs, simulates, and broadcasts the transaction.
- `ApiInstructionResponse` and `ApiAccountMeta` are the deserialized instruction shapes returned by `build_register_ixs`; downstream code that builds transactions from the response will need to import these types.
- The `max_positions` field on both request types is optional (serialized only when `Some`); defaults to 128 on the server side.
- `trader_pda_index` and `trader_subaccount_index` on `SendRegisterIxsRequest` are also optional; omit them to accept server defaults.