### PR TITLE
sync: Rise TypeScript v0.4.59

### DIFF
--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -3,6 +3,22 @@
 Entries are drafted by Phoenix Rise sync PRs. Review and edit each
 entry in this repo before merging.
 
+## v0.4.59 - 2026-06-30
+
+Source Phoenix commit: `e6a5f77bd8cbda7bddfa2e8687408ce87237aa0f`
+
+### Summary
+
+- Routine sync from Phoenix `0.4.58` to `0.4.59`. The synced diff only touches the package version bump and internal localnet test-harness/test files (`ts/tests/test-harness/localnet.ts`, `ts/tests/sdk-localnet-flows.test.ts`) — no changes to published package source were included.
+
+### Breaking Changes
+
+- None identified in the synced diff.
+
+### Consumer Notes
+
+- None identified in the synced diff.
+
 ## v0.4.58 - 2026-06-30
 
 Source Phoenix commit: `1fdded8e2b1c9104c74a89a0f8ce79e4ad9a9873`

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/rise",
-  "version": "0.4.58",
+  "version": "0.4.59",
   "packageManager": "bun@1.3.13",
   "repository": {
     "type": "git",

--- a/ts/tests/sdk-localnet-flows.test.ts
+++ b/ts/tests/sdk-localnet-flows.test.ts
@@ -534,7 +534,15 @@ describe("SDK localnet common flows", () => {
         "limit order"
       );
       expect(position.source).toBe("activeTraderBuffer");
-      expect(position.activePositionState?.bidOrders.size).toBeGreaterThan(0);
+      if (!position.activePositionState) {
+        throw new Error(
+          "Expected active trader position state for limit order"
+        );
+      }
+      expect(position.activePositionState.bidOrders.head).not.toBeNull();
+      expect(
+        position.activePositionState.totalNonReduceOnlyBidBaseLots
+      ).toBeGreaterThan(0n);
     },
     TEST_TIMEOUT_MS
   );

--- a/ts/tests/test-harness/localnet.ts
+++ b/ts/tests/test-harness/localnet.ts
@@ -111,15 +111,14 @@ export interface SdkLocalnetInstructionExecution {
   metadata: TransactionMetadata;
 }
 
-export interface SdkLocalnetLimitOrderListState {
-  size: number;
+export interface SdkLocalnetLimitOrderHeadState {
   head: number | null;
 }
 
 export interface SdkLocalnetActiveTraderPositionState {
   position: TraderPosition;
-  askOrders: SdkLocalnetLimitOrderListState;
-  bidOrders: SdkLocalnetLimitOrderListState;
+  askOrders: SdkLocalnetLimitOrderHeadState;
+  bidOrders: SdkLocalnetLimitOrderHeadState;
   totalNonReduceOnlyAskBaseLots: bigint;
   totalNonReduceOnlyBidBaseLots: bigint;
 }
@@ -822,16 +821,14 @@ const decodeSdkLocalnetActiveTraderPositionState = (
     bytes,
     offset
   );
-  const [askOrders, afterAskOrders] = readLimitOrderListState(
-    bytes,
-    afterPosition
+  const askOrders = readLimitOrderHead(bytes, afterPosition + 4);
+  const bidOrders = readLimitOrderHead(bytes, afterPosition + 12);
+  const totalNonReduceOnlyAskBaseLots = BigInt(
+    readU32LE(bytes, afterPosition + 16)
   );
-  const [bidOrders, afterBidOrders] = readLimitOrderListState(
-    bytes,
-    afterAskOrders
+  const totalNonReduceOnlyBidBaseLots = BigInt(
+    readU32LE(bytes, afterPosition + 24)
   );
-  const totalNonReduceOnlyAskBaseLots = readU64LE(bytes, afterBidOrders);
-  const totalNonReduceOnlyBidBaseLots = readU64LE(bytes, afterBidOrders + 8);
 
   return {
     position,
@@ -842,16 +839,12 @@ const decodeSdkLocalnetActiveTraderPositionState = (
   };
 };
 
-const readLimitOrderListState = (
+const readLimitOrderHead = (
   bytes: Uint8Array,
   offset: number
-): [SdkLocalnetLimitOrderListState, number] => [
-  {
-    size: readU32LE(bytes, offset),
-    head: readOptionalU32LE(bytes, offset + 4),
-  },
-  offset + 8,
-];
+): SdkLocalnetLimitOrderHeadState => ({
+  head: readOptionalU32LE(bytes, offset),
+});
 
 const compareTraderPositionId = (
   bytes: Uint8Array,


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `e6a5f77bd8cbda7bddfa2e8687408ce87237aa0f`
- Mode: automatic
- Synced paths:

- `rise/ts` -> `ts`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/programs` -> `programs`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `ts/CHANGELOG.md`

### Summary

- Routine sync from Phoenix `0.4.58` to `0.4.59`. The synced diff only touches the package version bump and internal localnet test-harness/test files (`ts/tests/test-harness/localnet.ts`, `ts/tests/sdk-localnet-flows.test.ts`) — no changes to published package source were included.

### Breaking Changes

- None identified in the synced diff.

### Consumer Notes

- None identified in the synced diff.