### PR TITLE
sync: Rise TypeScript v0.4.61

### DIFF
--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -3,6 +3,23 @@
 Entries are drafted by Phoenix Rise sync PRs. Review and edit each
 entry in this repo before merging.
 
+## v0.4.61 - 2026-07-02
+
+Source Phoenix commit: `64e433145ad2776c55d9ca53762ecfa78ba3ed51`
+
+### Summary
+
+- Added an optional `feePayer` field to `PlaceMultiLimitOrderFlowParams`. For isolated-margin multi-limit orders that require registering a fresh child subaccount, this account now pays the trader-account rent and signs the register instruction, instead of always defaulting to `authority`.
+
+### Breaking Changes
+
+- None identified in the synced diff.
+
+### Consumer Notes
+
+- `feePayer` is optional and defaults to previous behavior (`authority`) when omitted, so existing calls to `buildPlaceMultiLimitOrderFlow` are unaffected.
+- If you place isolated-margin multi-limit orders through sponsored and/or delegated sessions — where neither the sponsor nor the delegate can sign for `authority` — pass a `feePayer` to cover trader-account rent and the register signature; otherwise flows that need to register a new child subaccount in that setup will fail.
+
 ## v0.4.60 - 2026-07-01
 
 Source Phoenix commit: `cf8419bc21f9f539306198f7c08d0aca14a39580`

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/rise",
-  "version": "0.4.60",
+  "version": "0.4.61",
   "packageManager": "bun@1.3.13",
   "repository": {
     "type": "git",

--- a/ts/src/flows.ts
+++ b/ts/src/flows.ts
@@ -229,6 +229,14 @@ export interface PlaceMarketOrderFlowResult {
 export interface PlaceMultiLimitOrderFlowParams {
   authority: Authority;
   positionAuthority?: Authority;
+  /**
+   * Sponsor fee payer. Isolated-only: when a fresh child subaccount must be
+   * registered, this account pays the trader-account rent and signs the
+   * register instruction (matching the backend `place-isolated-*` endpoints).
+   * Defaults to `authority` — which fails for sponsored + delegated sessions,
+   * where neither the sponsor nor the delegate can sign for `authority`.
+   */
+  feePayer?: Authority | null;
   symbol: Symbol;
   side: Side;
   /** Pre-computed ladder levels (e.g. from `computeScaleOrderLevels`). */
@@ -973,6 +981,12 @@ export const buildPlaceMultiLimitOrderFlow = async (
             marginType: MarginType.Isolated,
             traderPdaIndex: pdaIndex,
             traderSubaccountIndex: subaccountIndex,
+            // Rent payer + register signer. Resolves to the sponsor fee payer
+            // when provided so sponsored sessions (where `authority` never
+            // signs) don't add an unsatisfiable third required signer; the
+            // token is a type-level discriminator only, unused by the builder.
+            feePayer: resolveFlowPayer(params),
+            sponsorshipToken: "",
           },
           client
         )


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `64e433145ad2776c55d9ca53762ecfa78ba3ed51`
- Mode: automatic
- Synced paths:

- `rise/ts` -> `ts`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/programs` -> `programs`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `ts/CHANGELOG.md`

### Summary

- Added an optional `feePayer` field to `PlaceMultiLimitOrderFlowParams`. For isolated-margin multi-limit orders that require registering a fresh child subaccount, this account now pays the trader-account rent and signs the register instruction, instead of always defaulting to `authority`.

### Breaking Changes

- None identified in the synced diff.

### Consumer Notes

- `feePayer` is optional and defaults to previous behavior (`authority`) when omitted, so existing calls to `buildPlaceMultiLimitOrderFlow` are unaffected.
- If you place isolated-margin multi-limit orders through sponsored and/or delegated sessions — where neither the sponsor nor the delegate can sign for `authority` — pass a `feePayer` to cover trader-account rent and the register signature; otherwise flows that need to register a new child subaccount in that setup will fail.