### PR TITLE
sync: Rise TypeScript v0.4.63

### DIFF
--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -3,6 +3,28 @@
 Entries are drafted by Phoenix Rise sync PRs. Review and edit each
 entry in this repo before merging.
 
+## v0.4.63 - 2026-07-06
+
+Source Phoenix commit: `014384041aa15c0f02a8a5277745b907ae510ee4`
+
+### Summary
+
+- Added an optional `options` parameter (`MarginCalculationOptions`) to `computeTraderMargin`, `computeSubaccountMargin`, `computeTraderMarginFromInputs`, `computeSubaccountMarginFromInputs`, and the corresponding `MarginCalculator` methods, letting callers pass per-symbol order leverage preferences via `orderLeverageLimitsBySymbol`.
+- Order leverage limits are applied only to order/limit-order sizing math (initial margin from open orders, limit order margin requirements); position-only margin, withdrawal margin, maintenance/backstop/high-risk margin, and risk state/tier are always computed from protocol leverage tiers, unaffected by the new option.
+- `MarginTotals` gains an optional `orderLeverageAdjustedInitialMarginQuoteLots` field, and `OrderMarginResult` gains an optional `orderLeverageAdjustedMarginRequirementQuoteLots` field; both are omitted entirely when no limit is supplied or when the adjusted value matches the protocol value.
+- Limit values are validated defensively: non-finite, non-integer-safe, sub-1, or above-protocol-max values are silently ignored and fall back to protocol leverage; valid fractional values floor to the nearest integer leverage.
+- Calling existing margin functions with no `options` argument (or an empty options object) produces byte-identical output to the prior release.
+
+### Breaking Changes
+
+- None identified in the synced diff.
+
+### Consumer Notes
+
+- All new behavior is opt-in via the new `options` parameter — no changes are required to existing integrations.
+- Consumers that want to preview reduced-leverage order/margin requirements (e.g. surfacing a lower "order leverage" preference in UI) can pass `{ orderLeverageLimitsBySymbol: { "SOL-PERP": 5 } }` and read the new `orderLeverageAdjusted*` fields where present; treat their absence as "no adjustment applies."
+- Do not rely on `orderLeverageAdjustedInitialMarginQuoteLots` for withdrawal eligibility or risk-state checks — those continue to use protocol-only margin figures.
+
 ## v0.4.62 - 2026-07-02
 
 Source Phoenix commit: `e427d47ea42afce753295b0559ac3a0e8c505518`

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/rise",
-  "version": "0.4.62",
+  "version": "0.4.63",
   "packageManager": "bun@1.3.13",
   "repository": {
     "type": "git",

--- a/ts/src/margin/compute.ts
+++ b/ts/src/margin/compute.ts
@@ -18,6 +18,8 @@ import { buildLimitOrderMarginStateFromOrders } from "./inputs";
 import type {
   LimitOrderMarginInput,
   LimitOrderMarginState,
+  MarginCalculationOptions,
+  MarginTotals,
   MarginPositionState,
   MarginRiskState,
   MarginRiskTier,
@@ -60,15 +62,21 @@ export const buildMarketParamsBySymbol = (
 
 export interface MarginCalculator {
   markets: NormalizedMarketParamsBySymbol;
-  computeTraderMargin: (inputs: TraderMarginInputs) => TraderMarginResult;
+  computeTraderMargin: (
+    inputs: TraderMarginInputs,
+    options?: MarginCalculationOptions
+  ) => TraderMarginResult;
   computeSubaccountMargin: (
-    inputs: SubaccountMarginInputs
+    inputs: SubaccountMarginInputs,
+    options?: MarginCalculationOptions
   ) => SubaccountMarginResult;
   computeTraderMarginFromInputs: (
-    inputs: TraderMarginInputs
+    inputs: TraderMarginInputs,
+    options?: MarginCalculationOptions
   ) => TraderMarginResult;
   computeSubaccountMarginFromInputs: (
-    inputs: SubaccountMarginInputs
+    inputs: SubaccountMarginInputs,
+    options?: MarginCalculationOptions
   ) => SubaccountMarginResult;
 }
 
@@ -78,49 +86,56 @@ export const createMarginCalculator = (
   const normalized = buildNormalizedMarketParamsBySymbol(markets);
   return {
     markets: normalized,
-    computeTraderMargin: (inputs) => computeTraderMargin(inputs, normalized),
-    computeSubaccountMargin: (inputs) =>
-      computeSubaccountMargin(inputs, normalized),
-    computeTraderMarginFromInputs: (inputs) =>
-      computeTraderMarginFromInputs(inputs, normalized),
-    computeSubaccountMarginFromInputs: (inputs) =>
-      computeSubaccountMarginFromInputs(inputs, normalized),
+    computeTraderMargin: (inputs, callOptions) =>
+      computeTraderMargin(inputs, normalized, callOptions),
+    computeSubaccountMargin: (inputs, callOptions) =>
+      computeSubaccountMargin(inputs, normalized, callOptions),
+    computeTraderMarginFromInputs: (inputs, callOptions) =>
+      computeTraderMarginFromInputs(inputs, normalized, callOptions),
+    computeSubaccountMarginFromInputs: (inputs, callOptions) =>
+      computeSubaccountMarginFromInputs(inputs, normalized, callOptions),
   };
 };
 
 export const computeTraderMargin = (
   inputs: TraderMarginInputs,
-  marketsBySymbol: NormalizedMarketParamsBySymbol
+  marketsBySymbol: NormalizedMarketParamsBySymbol,
+  options?: MarginCalculationOptions
 ): TraderMarginResult => {
-  return computeTraderMarginFromInputs(inputs, marketsBySymbol);
+  return computeTraderMarginFromInputs(inputs, marketsBySymbol, options);
 };
 
 export const computeSubaccountMargin = (
   inputs: SubaccountMarginInputs,
-  marketsBySymbol: NormalizedMarketParamsBySymbol
+  marketsBySymbol: NormalizedMarketParamsBySymbol,
+  options?: MarginCalculationOptions
 ): SubaccountMarginResult => {
-  return computeSubaccountMarginFromInputs(inputs, marketsBySymbol);
+  return computeSubaccountMarginFromInputs(inputs, marketsBySymbol, options);
 };
 
 export const computeTraderMarginFromInputs = (
   inputs: TraderMarginInputs,
-  marketsBySymbol: NormalizedMarketParamsBySymbol
+  marketsBySymbol: NormalizedMarketParamsBySymbol,
+  options?: MarginCalculationOptions
 ): TraderMarginResult => ({
   authority: inputs.authority,
   traderPdaIndex: inputs.traderPdaIndex,
   subaccounts: inputs.subaccounts.map((subaccount) =>
-    computeSubaccountMarginFromInputs(subaccount, marketsBySymbol)
+    computeSubaccountMarginFromInputs(subaccount, marketsBySymbol, options)
   ),
 });
 
 export const computeSubaccountMarginFromInputs = (
   inputs: SubaccountMarginInputs,
-  marketsBySymbol: NormalizedMarketParamsBySymbol
+  marketsBySymbol: NormalizedMarketParamsBySymbol,
+  options?: MarginCalculationOptions
 ): SubaccountMarginResult => {
   const marketMargins: MarketMarginResult[] = [];
   const limitOrders: OrderMarginResult[] = [];
 
   let totalInitialMargin = 0n;
+  let hasOrderLeverageAdjustedInitialMargin = false;
+  let totalOrderLeverageAdjustedInitialMargin = 0n;
   let totalInitialMarginForWithdrawals = 0n;
   let totalMaintenanceMargin = 0n;
   let totalCancelMargin = 0n;
@@ -148,12 +163,22 @@ export const computeSubaccountMarginFromInputs = (
       throw new Error(`Missing market params for symbol ${symbol}`);
     }
 
-    const result = computeMarketMarginFromInputs(marketInput, marketParams);
+    const result = computeMarketMarginFromInputs(
+      marketInput,
+      marketParams,
+      options
+    );
 
     marketMargins.push(result.market);
     limitOrders.push(...result.limitOrders);
 
     totalInitialMargin += result.margin.initialMargin;
+    hasOrderLeverageAdjustedInitialMargin =
+      hasOrderLeverageAdjustedInitialMargin ||
+      result.margin.orderLeverageAdjustedInitialMargin !== undefined;
+    totalOrderLeverageAdjustedInitialMargin +=
+      result.margin.orderLeverageAdjustedInitialMargin ??
+      result.margin.initialMargin;
     totalInitialMarginForWithdrawals +=
       result.margin.initialMarginForWithdrawals;
     totalMaintenanceMargin += result.margin.maintenanceMargin;
@@ -197,31 +222,40 @@ export const computeSubaccountMarginFromInputs = (
     effectiveCollateral
   );
 
+  const margin: MarginTotals = {
+    collateralBalanceQuoteLots: collateralBalance.toString(),
+    effectiveCollateralQuoteLots: effectiveCollateral.toString(),
+    effectiveCollateralForWithdrawalsQuoteLots:
+      effectiveCollateralForWithdrawals.toString(),
+    portfolioValueQuoteLots: portfolioValue.toString(),
+    initialMarginQuoteLots: totalInitialMargin.toString(),
+    initialMarginForWithdrawalsQuoteLots:
+      totalInitialMarginForWithdrawals.toString(),
+    maintenanceMarginQuoteLots: totalMaintenanceMargin.toString(),
+    cancelMarginQuoteLots: totalCancelMargin.toString(),
+    backstopMarginQuoteLots: totalBackstopMargin.toString(),
+    highRiskMarginQuoteLots: totalHighRiskMargin.toString(),
+    limitOrderMarginQuoteLots: totalLimitOrderMargin.toString(),
+    unrealizedPnlQuoteLots: totalUnrealizedPnl.toString(),
+    discountedUnrealizedPnlQuoteLots: totalDiscountedUnrealizedPnl.toString(),
+    discountedPnlForWithdrawalsQuoteLots:
+      totalDiscountedPnlForWithdrawals.toString(),
+    unsettledFundingQuoteLots: totalUnsettledFunding.toString(),
+    accumulatedFundingQuoteLots: totalAccumulatedFunding.toString(),
+    riskState,
+    riskTier,
+  };
+  if (
+    hasOrderLeverageAdjustedInitialMargin &&
+    totalOrderLeverageAdjustedInitialMargin !== totalInitialMargin
+  ) {
+    margin.orderLeverageAdjustedInitialMarginQuoteLots =
+      totalOrderLeverageAdjustedInitialMargin.toString();
+  }
+
   return {
     subaccountIndex: inputs.subaccountIndex,
-    margin: {
-      collateralBalanceQuoteLots: collateralBalance.toString(),
-      effectiveCollateralQuoteLots: effectiveCollateral.toString(),
-      effectiveCollateralForWithdrawalsQuoteLots:
-        effectiveCollateralForWithdrawals.toString(),
-      portfolioValueQuoteLots: portfolioValue.toString(),
-      initialMarginQuoteLots: totalInitialMargin.toString(),
-      initialMarginForWithdrawalsQuoteLots:
-        totalInitialMarginForWithdrawals.toString(),
-      maintenanceMarginQuoteLots: totalMaintenanceMargin.toString(),
-      cancelMarginQuoteLots: totalCancelMargin.toString(),
-      backstopMarginQuoteLots: totalBackstopMargin.toString(),
-      highRiskMarginQuoteLots: totalHighRiskMargin.toString(),
-      limitOrderMarginQuoteLots: totalLimitOrderMargin.toString(),
-      unrealizedPnlQuoteLots: totalUnrealizedPnl.toString(),
-      discountedUnrealizedPnlQuoteLots: totalDiscountedUnrealizedPnl.toString(),
-      discountedPnlForWithdrawalsQuoteLots:
-        totalDiscountedPnlForWithdrawals.toString(),
-      unsettledFundingQuoteLots: totalUnsettledFunding.toString(),
-      accumulatedFundingQuoteLots: totalAccumulatedFunding.toString(),
-      riskState,
-      riskTier,
-    },
+    margin,
     marketMargins,
     limitOrders,
   };
@@ -245,21 +279,54 @@ const resolveLimitOrderMarginState = (
   return buildLimitOrderMarginStateFromOrders(orders);
 };
 
+const getOrderLeverageLimitForSymbol = (
+  symbol: string,
+  options?: MarginCalculationOptions
+): bigint | undefined => {
+  // User/product preferences are intentionally permissive: fractional values
+  // floor to safe integer leverage, while invalid values silently fall back to
+  // protocol leverage.
+  const rawLimit = options?.orderLeverageLimitsBySymbol?.[symbol];
+  if (rawLimit === undefined || !Number.isFinite(rawLimit)) {
+    return undefined;
+  }
+
+  const flooredLimit = Math.floor(rawLimit);
+  if (flooredLimit < 1 || !Number.isSafeInteger(flooredLimit)) {
+    return undefined;
+  }
+
+  return BigInt(flooredLimit);
+};
+
+const getEffectiveLeverageConstant = (
+  tiers: LeverageTier[],
+  positionSize: bigint,
+  orderLeverageLimit?: bigint
+): bigint => {
+  const protocolMaxLeverage = getLeverageConstant(tiers, positionSize);
+  return orderLeverageLimit !== undefined &&
+    orderLeverageLimit < protocolMaxLeverage
+    ? orderLeverageLimit
+    : protocolMaxLeverage;
+};
+
 const computeMarketMarginFromInputs = (
   input: MarketMarginInputs,
-  marketParams: NormalizedMarketParams
+  marketParams: NormalizedMarketParams,
+  options?: MarginCalculationOptions
 ): {
   market: MarketMarginResult;
   limitOrders: OrderMarginResult[];
   margin: {
     initialMargin: bigint;
+    orderLeverageAdjustedInitialMargin?: bigint;
     initialMarginForWithdrawals: bigint;
     maintenanceMargin: bigint;
     backstopMargin: bigint;
     highRiskMargin: bigint;
     cancelMargin: bigint;
     limitOrderMargin: bigint;
-    positionOnlyInitialMargin: bigint;
     unrealizedPnl: bigint;
     discountedUnrealizedPnl: bigint;
     discountedPnlForWithdrawals: bigint;
@@ -313,6 +380,10 @@ const computeMarketMarginFromInputs = (
     ? toBigInt(limitOrderState.totalNonReduceOnlyAskBaseLots)
     : 0n;
   const leverageTiers = marketParams.leverageTiers;
+  const orderLeverageLimit = getOrderLeverageLimitForSymbol(
+    input.symbol,
+    options
+  );
 
   const initialMargin = initialMarginForAsset(
     basePositionLots,
@@ -322,6 +393,19 @@ const computeMarketMarginFromInputs = (
     leverageTiers,
     false
   );
+
+  const orderLeverageAdjustedInitialMargin =
+    orderLeverageLimit === undefined
+      ? initialMargin
+      : initialMarginForAsset(
+          basePositionLots,
+          totalBid,
+          totalAsk,
+          assetUnitPrice,
+          leverageTiers,
+          false,
+          orderLeverageLimit
+        );
 
   const positionOnlyInitialMargin = initialMarginForAsset(
     basePositionLots,
@@ -345,6 +429,10 @@ const computeMarketMarginFromInputs = (
     initialMargin - positionOnlyInitialMargin,
     0n
   );
+  const orderLeverageAdjustedInitialMarginOverride =
+    orderLeverageAdjustedInitialMargin !== initialMargin
+      ? orderLeverageAdjustedInitialMargin
+      : undefined;
 
   const maintenanceMargin = applyBps(
     initialMargin,
@@ -363,43 +451,60 @@ const computeMarketMarginFromInputs = (
     marketParams.cancelOrderRiskFactorBps
   );
 
-  const limitOrders = computeLimitOrderMargins(
+  const protocolLimitOrders = computeLimitOrderMargins(
     input.symbol,
     basePositionLots,
     activeOrders,
     assetUnitPrice,
     leverageTiers
   );
+  const limitOrders =
+    orderLeverageLimit === undefined
+      ? protocolLimitOrders
+      : withOrderLeverageAdjustedLimitOrderMargins(
+          protocolLimitOrders,
+          computeLimitOrderMargins(
+            input.symbol,
+            basePositionLots,
+            activeOrders,
+            assetUnitPrice,
+            leverageTiers,
+            orderLeverageLimit
+          )
+        );
+
+  const market: MarketMarginResult = {
+    symbol: input.symbol,
+    basePositionLots: basePositionLots.toString(),
+    virtualQuotePositionLots: virtualQuotePositionLots.toString(),
+    entryPriceTicks: entryPriceTicks.toString(),
+    unrealizedPnlQuoteLots: unrealizedPnl.toString(),
+    discountedUnrealizedPnlQuoteLots: discountedUnrealizedPnl.toString(),
+    positionInitialMarginQuoteLots: positionOnlyInitialMargin.toString(),
+    initialMarginQuoteLots: initialMargin.toString(),
+    maintenanceMarginQuoteLots: maintenanceMargin.toString(),
+    cancelMarginQuoteLots: cancelMargin.toString(),
+    backstopMarginQuoteLots: backstopMargin.toString(),
+    highRiskMarginQuoteLots: highRiskMargin.toString(),
+    limitOrderMarginQuoteLots: limitOrderMargin.toString(),
+    positionValueQuoteLots: positionValue.toString(),
+    unsettledFundingQuoteLots: unsettledFunding.toString(),
+    accumulatedFundingQuoteLots: accumulatedFunding.toString(),
+  };
 
   return {
-    market: {
-      symbol: input.symbol,
-      basePositionLots: basePositionLots.toString(),
-      virtualQuotePositionLots: virtualQuotePositionLots.toString(),
-      entryPriceTicks: entryPriceTicks.toString(),
-      unrealizedPnlQuoteLots: unrealizedPnl.toString(),
-      discountedUnrealizedPnlQuoteLots: discountedUnrealizedPnl.toString(),
-      positionInitialMarginQuoteLots: positionOnlyInitialMargin.toString(),
-      initialMarginQuoteLots: initialMargin.toString(),
-      maintenanceMarginQuoteLots: maintenanceMargin.toString(),
-      cancelMarginQuoteLots: cancelMargin.toString(),
-      backstopMarginQuoteLots: backstopMargin.toString(),
-      highRiskMarginQuoteLots: highRiskMargin.toString(),
-      limitOrderMarginQuoteLots: limitOrderMargin.toString(),
-      positionValueQuoteLots: positionValue.toString(),
-      unsettledFundingQuoteLots: unsettledFunding.toString(),
-      accumulatedFundingQuoteLots: accumulatedFunding.toString(),
-    },
+    market,
     limitOrders,
     margin: {
       initialMargin,
+      orderLeverageAdjustedInitialMargin:
+        orderLeverageAdjustedInitialMarginOverride,
       initialMarginForWithdrawals,
       maintenanceMargin,
       backstopMargin,
       highRiskMargin,
       cancelMargin,
       limitOrderMargin,
-      positionOnlyInitialMargin,
       unrealizedPnl,
       discountedUnrealizedPnl,
       discountedPnlForWithdrawals,
@@ -416,7 +521,8 @@ const initialMarginForAsset = (
   totalAsk: bigint,
   assetUnitPrice: bigint,
   tiers: LeverageTier[],
-  bypassRiskFactor: boolean
+  bypassRiskFactor: boolean,
+  orderLeverageLimit?: bigint
 ): bigint => {
   if (position === 0n && totalBid === 0n && totalAsk === 0n) {
     return 0n;
@@ -428,7 +534,11 @@ const initialMarginForAsset = (
   if (position !== 0n) {
     const absolutePositionSize = absBigInt(position);
     const absoluteBookValue = assetUnitPrice * absolutePositionSize;
-    const leverage = getLeverageConstant(tiers, absolutePositionSize);
+    const leverage = getEffectiveLeverageConstant(
+      tiers,
+      absolutePositionSize,
+      orderLeverageLimit
+    );
     const leverageBasedMargin = divCeil(absoluteBookValue, leverage);
     collateralRequired += leverageBasedMargin;
     existingPositionMarginOffset = leverageBasedMargin;
@@ -442,7 +552,8 @@ const initialMarginForAsset = (
           assetUnitPrice,
           tiers,
           existingPositionMarginOffset,
-          bypassRiskFactor
+          bypassRiskFactor,
+          orderLeverageLimit
         )
       : 0n;
 
@@ -454,7 +565,8 @@ const initialMarginForAsset = (
           assetUnitPrice,
           tiers,
           existingPositionMarginOffset,
-          bypassRiskFactor
+          bypassRiskFactor,
+          orderLeverageLimit
         )
       : 0n;
 
@@ -469,7 +581,8 @@ const marginIncreaseForBids = (
   assetUnitPrice: bigint,
   tiers: LeverageTier[],
   existingPositionMarginOffset: bigint,
-  bypassRiskFactor: boolean
+  bypassRiskFactor: boolean,
+  orderLeverageLimit?: bigint
 ): bigint => {
   const newExposureSigned = bidSize + position - absBigInt(position);
   if (newExposureSigned <= 0n) {
@@ -479,7 +592,11 @@ const marginIncreaseForBids = (
   const totalExposureSigned = position + bidSize;
   const totalExposure = absBigInt(totalExposureSigned);
   const totalGrossValue = assetUnitPrice * totalExposure;
-  const totalLeverage = getLeverageConstant(tiers, totalExposure);
+  const totalLeverage = getEffectiveLeverageConstant(
+    tiers,
+    totalExposure,
+    orderLeverageLimit
+  );
   const totalMargin = divCeil(totalGrossValue, totalLeverage);
   const incrementalMargin = maxBigInt(
     totalMargin - existingPositionMarginOffset,
@@ -500,7 +617,8 @@ const marginIncreaseForAsks = (
   assetUnitPrice: bigint,
   tiers: LeverageTier[],
   existingPositionMarginOffset: bigint,
-  bypassRiskFactor: boolean
+  bypassRiskFactor: boolean,
+  orderLeverageLimit?: bigint
 ): bigint => {
   const newExposureSigned = askSize - position - absBigInt(position);
   if (newExposureSigned <= 0n) {
@@ -510,7 +628,11 @@ const marginIncreaseForAsks = (
   const totalExposureSigned = position - askSize;
   const totalExposure = absBigInt(totalExposureSigned);
   const totalGrossValue = assetUnitPrice * totalExposure;
-  const totalLeverage = getLeverageConstant(tiers, totalExposure);
+  const totalLeverage = getEffectiveLeverageConstant(
+    tiers,
+    totalExposure,
+    orderLeverageLimit
+  );
   const totalMargin = divCeil(totalGrossValue, totalLeverage);
   const incrementalMargin = maxBigInt(
     totalMargin - existingPositionMarginOffset,
@@ -525,12 +647,34 @@ const marginIncreaseForAsks = (
   return applyBpsCeil(incrementalMargin, riskFactor);
 };
 
+const withOrderLeverageAdjustedLimitOrderMargins = (
+  protocolOrders: OrderMarginResult[],
+  orderLeverageAdjustedOrders: OrderMarginResult[]
+): OrderMarginResult[] =>
+  protocolOrders.map((order, index) => {
+    const orderLeverageAdjustedOrder = orderLeverageAdjustedOrders[index];
+    if (
+      !orderLeverageAdjustedOrder ||
+      orderLeverageAdjustedOrder.marginRequirementQuoteLots ===
+        order.marginRequirementQuoteLots
+    ) {
+      return order;
+    }
+
+    return {
+      ...order,
+      orderLeverageAdjustedMarginRequirementQuoteLots:
+        orderLeverageAdjustedOrder.marginRequirementQuoteLots,
+    };
+  });
+
 const computeLimitOrderMargins = (
   symbol: string,
   position: bigint,
   orders: LimitOrderMarginInput[],
   assetUnitPrice: bigint,
-  tiers: LeverageTier[]
+  tiers: LeverageTier[],
+  orderLeverageLimit?: bigint
 ): OrderMarginResult[] => {
   const result: OrderMarginResult[] = [];
   const existingPositionMarginOffset =
@@ -538,7 +682,11 @@ const computeLimitOrderMargins = (
       ? 0n
       : divCeil(
           assetUnitPrice * absBigInt(position),
-          getLeverageConstant(tiers, absBigInt(position))
+          getEffectiveLeverageConstant(
+            tiers,
+            absBigInt(position),
+            orderLeverageLimit
+          )
         );
 
   for (const order of orders) {
@@ -555,7 +703,8 @@ const computeLimitOrderMargins = (
             assetUnitPrice,
             tiers,
             existingPositionMarginOffset,
-            false
+            false,
+            orderLeverageLimit
           )
         : marginIncreaseForAsks(
             position,
@@ -563,7 +712,8 @@ const computeLimitOrderMargins = (
             assetUnitPrice,
             tiers,
             existingPositionMarginOffset,
-            false
+            false,
+            orderLeverageLimit
           );
 
     const marginFactor =

--- a/ts/src/margin/types.ts
+++ b/ts/src/margin/types.ts
@@ -79,6 +79,17 @@ export interface MarketMarginInputs {
   limitOrders?: LimitOrderMarginInput[];
 }
 
+/**
+ * Per-symbol product/order leverage preferences. The margin calculator floors
+ * finite values to safe integers and ignores non-finite values, unsafe values,
+ * or values below 1.
+ */
+export type OrderLeverageLimitsBySymbol = Record<string, number>;
+
+export interface MarginCalculationOptions {
+  orderLeverageLimitsBySymbol?: OrderLeverageLimitsBySymbol;
+}
+
 export interface SubaccountMarginInputs {
   subaccountIndex: number;
   collateralBalanceQuoteLots: string;
@@ -111,6 +122,11 @@ export interface MarginTotals {
   effectiveCollateralForWithdrawalsQuoteLots: string;
   portfolioValueQuoteLots: string;
   initialMarginQuoteLots: string;
+  /**
+   * Initial margin computed with optional order leverage limits.
+   * Present only when it differs from protocol initial margin.
+   */
+  orderLeverageAdjustedInitialMarginQuoteLots?: string;
   initialMarginForWithdrawalsQuoteLots: string;
   maintenanceMarginQuoteLots: string;
   cancelMarginQuoteLots: string;
@@ -156,6 +172,11 @@ export interface OrderMarginResult {
   isStopLoss: boolean;
   isStopLossDirection: boolean;
   marginRequirementQuoteLots: string;
+  /**
+   * Margin requirement computed with optional order leverage limits.
+   * Present only when it differs from protocol margin requirement.
+   */
+  orderLeverageAdjustedMarginRequirementQuoteLots?: string;
   marginFactorBps: string;
 }
 

--- a/ts/tests/margin-order-leverage-limits.test.ts
+++ b/ts/tests/margin-order-leverage-limits.test.ts
@@ -1,0 +1,435 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeSubaccountMarginFromInputs,
+  computeTraderMarginFromInputs,
+  createMarginCalculator,
+  type MarketParams,
+  type SubaccountMarginInputs,
+  type TraderMarginInputs,
+} from "@/margin";
+
+const marketParams: MarketParams = {
+  symbol: "SOL-PERP",
+  assetId: 1,
+  markPriceTicks: "100",
+  tickSize: "1",
+  baseLotDecimals: 0,
+  leverageTiers: [
+    {
+      upperBoundSize: "1000",
+      maxLeverage: "20",
+      limitOrderRiskFactorBps: "10000",
+    },
+  ],
+  riskFactors: {
+    maintenanceMarginFactorBps: "5000",
+    backstopMarginFactorBps: "2000",
+    highRiskMarginFactorBps: "1000",
+  },
+  cancelOrderRiskFactorBps: "7000",
+  upnlRiskFactor: "10000",
+  upnlRiskFactorForWithdrawals: "10000",
+  isolatedOnly: false,
+};
+
+const positionInputs = (): SubaccountMarginInputs => ({
+  subaccountIndex: 0,
+  collateralBalanceQuoteLots: "1000",
+  markets: [
+    {
+      symbol: "SOL-PERP",
+      position: {
+        basePositionLots: "10",
+        virtualQuotePositionLots: "-1000",
+        entryPriceTicks: "100",
+        unsettledFundingQuoteLots: "0",
+        accumulatedFundingQuoteLots: "0",
+      },
+    },
+  ],
+});
+
+const limitOrderInputs = (): SubaccountMarginInputs => ({
+  subaccountIndex: 0,
+  collateralBalanceQuoteLots: "1000",
+  markets: [
+    {
+      symbol: "SOL-PERP",
+      limitOrders: [
+        {
+          orderSequenceNumber: "1",
+          side: "bid",
+          priceTicks: "100",
+          sizeRemainingLots: "10",
+          initialSizeLots: "10",
+          reduceOnly: false,
+        },
+      ],
+    },
+  ],
+});
+
+const calculator = createMarginCalculator([marketParams]);
+
+const secondMarketParams: MarketParams = {
+  ...marketParams,
+  symbol: "ETH-PERP",
+  assetId: 2,
+  markPriceTicks: "200",
+};
+
+const multiMarketInputs = (): SubaccountMarginInputs => ({
+  subaccountIndex: 0,
+  collateralBalanceQuoteLots: "1000",
+  markets: [
+    {
+      symbol: "SOL-PERP",
+      position: {
+        basePositionLots: "10",
+        virtualQuotePositionLots: "-1000",
+        entryPriceTicks: "100",
+        unsettledFundingQuoteLots: "0",
+        accumulatedFundingQuoteLots: "0",
+      },
+    },
+    {
+      symbol: "ETH-PERP",
+      position: {
+        basePositionLots: "5",
+        virtualQuotePositionLots: "-1000",
+        entryPriceTicks: "200",
+        unsettledFundingQuoteLots: "0",
+        accumulatedFundingQuoteLots: "0",
+      },
+    },
+  ],
+});
+
+const limitOrderOnPositionInputs = (): SubaccountMarginInputs => ({
+  subaccountIndex: 0,
+  collateralBalanceQuoteLots: "1000",
+  markets: [
+    {
+      symbol: "SOL-PERP",
+      position: {
+        basePositionLots: "10",
+        virtualQuotePositionLots: "-1000",
+        entryPriceTicks: "100",
+        unsettledFundingQuoteLots: "0",
+        accumulatedFundingQuoteLots: "0",
+      },
+      limitOrders: [
+        {
+          orderSequenceNumber: "1",
+          side: "bid",
+          priceTicks: "100",
+          sizeRemainingLots: "10",
+          initialSizeLots: "10",
+          reduceOnly: false,
+        },
+      ],
+    },
+  ],
+});
+
+const traderInputs = (): TraderMarginInputs => ({
+  authority: "authority",
+  traderPdaIndex: 0,
+  subaccounts: [positionInputs()],
+});
+
+const expectNoMarketLevelOrderLeverageAdjustedFields = (
+  marketMargin: unknown
+) => {
+  expect(marketMargin).toBeDefined();
+  expect(marketMargin).not.toHaveProperty(
+    "orderLeverageAdjustedPositionInitialMarginQuoteLots"
+  );
+  expect(marketMargin).not.toHaveProperty(
+    "orderLeverageAdjustedInitialMarginQuoteLots"
+  );
+  expect(marketMargin).not.toHaveProperty(
+    "orderLeverageAdjustedLimitOrderMarginQuoteLots"
+  );
+};
+
+const expectNoAggregateOrderLeverageAdjustedLimitOrderMargin = (
+  margin: unknown
+) => {
+  expect(margin).not.toHaveProperty(
+    "orderLeverageAdjustedLimitOrderMarginQuoteLots"
+  );
+};
+
+describe("order leverage limits in margin calculations", () => {
+  it("preserves protocol leverage outputs when no options are provided", () => {
+    const baseline =
+      calculator.computeSubaccountMarginFromInputs(positionInputs());
+    const emptyOptions = calculator.computeSubaccountMarginFromInputs(
+      positionInputs(),
+      {}
+    );
+
+    expect(emptyOptions).toEqual(baseline);
+    expect(baseline.margin.initialMarginQuoteLots).toBe("50");
+    expect(
+      baseline.margin.orderLeverageAdjustedInitialMarginQuoteLots
+    ).toBeUndefined();
+    expect(baseline.marketMargins[0]?.positionInitialMarginQuoteLots).toBe(
+      "50"
+    );
+    expectNoAggregateOrderLeverageAdjustedLimitOrderMargin(baseline.margin);
+    expectNoMarketLevelOrderLeverageAdjustedFields(baseline.marketMargins[0]);
+  });
+
+  it("uses a lower floored limit for order-leverage-adjusted display margin", () => {
+    const result = calculator.computeSubaccountMarginFromInputs(
+      positionInputs(),
+      {
+        orderLeverageLimitsBySymbol: {
+          "SOL-PERP": 5.9,
+        },
+      }
+    );
+
+    expect(result.margin.initialMarginQuoteLots).toBe("50");
+    expect(result.margin.orderLeverageAdjustedInitialMarginQuoteLots).toBe(
+      "200"
+    );
+    expect(result.marketMargins[0]?.initialMarginQuoteLots).toBe("50");
+    expect(result.marketMargins[0]?.positionInitialMarginQuoteLots).toBe("50");
+    expectNoAggregateOrderLeverageAdjustedLimitOrderMargin(result.margin);
+    expectNoMarketLevelOrderLeverageAdjustedFields(result.marketMargins[0]);
+  });
+
+  it("ignores limits above the market max leverage", () => {
+    const baseline =
+      calculator.computeSubaccountMarginFromInputs(positionInputs());
+    const result = calculator.computeSubaccountMarginFromInputs(
+      positionInputs(),
+      {
+        orderLeverageLimitsBySymbol: {
+          "SOL-PERP": 50,
+        },
+      }
+    );
+
+    expect(result).toEqual(baseline);
+  });
+
+  it("ignores invalid limits", () => {
+    const invalidLimits = [
+      Number.NaN,
+      Infinity,
+      Number.MAX_SAFE_INTEGER + 1,
+      Number.MAX_VALUE,
+      0.99,
+      0,
+      -1,
+    ];
+
+    for (const invalidLimit of invalidLimits) {
+      const result = calculator.computeSubaccountMarginFromInputs(
+        positionInputs(),
+        {
+          orderLeverageLimitsBySymbol: {
+            "SOL-PERP": invalidLimit,
+          },
+        }
+      );
+
+      expect(result.margin.initialMarginQuoteLots).toBe("50");
+      expect(
+        result.margin.orderLeverageAdjustedInitialMarginQuoteLots
+      ).toBeUndefined();
+      expect(result.marketMargins[0]?.positionInitialMarginQuoteLots).toBe(
+        "50"
+      );
+      expectNoAggregateOrderLeverageAdjustedLimitOrderMargin(result.margin);
+      expectNoMarketLevelOrderLeverageAdjustedFields(result.marketMargins[0]);
+    }
+  });
+
+  it("does not apply order leverage limits to withdrawal initial margin", () => {
+    const baseline =
+      calculator.computeSubaccountMarginFromInputs(positionInputs());
+    const result = calculator.computeSubaccountMarginFromInputs(
+      positionInputs(),
+      {
+        orderLeverageLimitsBySymbol: {
+          "SOL-PERP": 5,
+        },
+      }
+    );
+
+    expect(result.margin.initialMarginQuoteLots).toBe("50");
+    expect(result.margin.orderLeverageAdjustedInitialMarginQuoteLots).toBe(
+      "200"
+    );
+    expect(result.margin.initialMarginForWithdrawalsQuoteLots).toBe(
+      baseline.margin.initialMarginForWithdrawalsQuoteLots
+    );
+    expect(result.margin.initialMarginForWithdrawalsQuoteLots).toBe("50");
+  });
+
+  it("does not apply order leverage limits to withdrawal initial margin for open limit orders", () => {
+    const baseline =
+      calculator.computeSubaccountMarginFromInputs(limitOrderInputs());
+    const result = calculator.computeSubaccountMarginFromInputs(
+      limitOrderInputs(),
+      {
+        orderLeverageLimitsBySymbol: {
+          "SOL-PERP": 5,
+        },
+      }
+    );
+
+    expect(result.margin.initialMarginQuoteLots).toBe("50");
+    expect(result.margin.orderLeverageAdjustedInitialMarginQuoteLots).toBe(
+      "200"
+    );
+    expect(result.margin.initialMarginForWithdrawalsQuoteLots).toBe(
+      baseline.margin.initialMarginForWithdrawalsQuoteLots
+    );
+    expect(result.margin.initialMarginForWithdrawalsQuoteLots).toBe("50");
+  });
+
+  it("applies order leverage limits per symbol", () => {
+    const multiMarketCalculator = createMarginCalculator([
+      marketParams,
+      secondMarketParams,
+    ]);
+
+    const result = multiMarketCalculator.computeSubaccountMarginFromInputs(
+      multiMarketInputs(),
+      {
+        orderLeverageLimitsBySymbol: {
+          "DOGE-PERP": 2,
+          "SOL-PERP": 5,
+        },
+      }
+    );
+
+    const solMargin = result.marketMargins.find(
+      (market) => market.symbol === "SOL-PERP"
+    );
+    const ethMargin = result.marketMargins.find(
+      (market) => market.symbol === "ETH-PERP"
+    );
+
+    expect(result.margin.initialMarginQuoteLots).toBe("100");
+    expect(result.margin.orderLeverageAdjustedInitialMarginQuoteLots).toBe(
+      "250"
+    );
+    expect(solMargin?.initialMarginQuoteLots).toBe("50");
+    expect(ethMargin?.initialMarginQuoteLots).toBe("50");
+    expectNoMarketLevelOrderLeverageAdjustedFields(solMargin);
+    expectNoMarketLevelOrderLeverageAdjustedFields(ethMargin);
+  });
+
+  it("threads order leverage limits through trader-level margin calls", () => {
+    const result = computeTraderMarginFromInputs(
+      traderInputs(),
+      calculator.markets,
+      {
+        orderLeverageLimitsBySymbol: {
+          "SOL-PERP": 5,
+        },
+      }
+    );
+    const calculatorResult = calculator.computeTraderMarginFromInputs(
+      traderInputs(),
+      {
+        orderLeverageLimitsBySymbol: {
+          "SOL-PERP": 5,
+        },
+      }
+    );
+
+    expect(result.subaccounts[0]?.margin.initialMarginQuoteLots).toBe("50");
+    expect(
+      result.subaccounts[0]?.margin.orderLeverageAdjustedInitialMarginQuoteLots
+    ).toBe("200");
+    expect(calculatorResult.subaccounts[0]?.margin.initialMarginQuoteLots).toBe(
+      "50"
+    );
+    expect(
+      calculatorResult.subaccounts[0]?.margin
+        .orderLeverageAdjustedInitialMarginQuoteLots
+    ).toBe("200");
+  });
+
+  it("uses effective leverage for order-leverage-adjusted limit-order margin", () => {
+    const result = computeSubaccountMarginFromInputs(
+      limitOrderInputs(),
+      calculator.markets,
+      {
+        orderLeverageLimitsBySymbol: {
+          "SOL-PERP": 5,
+        },
+      }
+    );
+
+    expect(result.margin.initialMarginQuoteLots).toBe("50");
+    expect(result.margin.orderLeverageAdjustedInitialMarginQuoteLots).toBe(
+      "200"
+    );
+    expect(result.margin.limitOrderMarginQuoteLots).toBe("50");
+    expectNoAggregateOrderLeverageAdjustedLimitOrderMargin(result.margin);
+    expect(result.limitOrders[0]?.marginRequirementQuoteLots).toBe("50");
+    expect(
+      result.limitOrders[0]?.orderLeverageAdjustedMarginRequirementQuoteLots
+    ).toBe("200");
+  });
+
+  it("uses effective leverage for limit-order margin over existing positions", () => {
+    const result = calculator.computeSubaccountMarginFromInputs(
+      limitOrderOnPositionInputs(),
+      {
+        orderLeverageLimitsBySymbol: {
+          "SOL-PERP": 5,
+        },
+      }
+    );
+
+    expect(result.margin.initialMarginQuoteLots).toBe("100");
+    expect(result.margin.orderLeverageAdjustedInitialMarginQuoteLots).toBe(
+      "400"
+    );
+    expect(result.marketMargins[0]?.positionInitialMarginQuoteLots).toBe("50");
+    expectNoMarketLevelOrderLeverageAdjustedFields(result.marketMargins[0]);
+    expect(result.margin.limitOrderMarginQuoteLots).toBe("50");
+    expectNoAggregateOrderLeverageAdjustedLimitOrderMargin(result.margin);
+    expect(result.limitOrders[0]?.marginRequirementQuoteLots).toBe("50");
+    expect(
+      result.limitOrders[0]?.orderLeverageAdjustedMarginRequirementQuoteLots
+    ).toBe("200");
+  });
+
+  it("keeps protocol risk thresholds and labels on unclamped initial margin", () => {
+    const result = calculator.computeSubaccountMarginFromInputs(
+      {
+        ...positionInputs(),
+        collateralBalanceQuoteLots: "100",
+      },
+      {
+        orderLeverageLimitsBySymbol: {
+          "SOL-PERP": 5,
+        },
+      }
+    );
+
+    expect(result.margin.initialMarginQuoteLots).toBe("50");
+    expect(result.margin.orderLeverageAdjustedInitialMarginQuoteLots).toBe(
+      "200"
+    );
+    expect(result.margin.maintenanceMarginQuoteLots).toBe("25");
+    expect(result.margin.riskState).toBe("healthy");
+    expect(result.margin.riskTier).toBe("safe");
+    expect(result.marketMargins[0]?.positionInitialMarginQuoteLots).toBe("50");
+    expectNoMarketLevelOrderLeverageAdjustedFields(result.marketMargins[0]);
+    expect(result.margin.cancelMarginQuoteLots).toBe("35");
+    expect(result.margin.backstopMarginQuoteLots).toBe("10");
+    expect(result.margin.highRiskMarginQuoteLots).toBe("5");
+  });
+});


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `014384041aa15c0f02a8a5277745b907ae510ee4`
- Mode: automatic
- Synced paths:

- `rise/ts` -> `ts`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/programs` -> `programs`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `ts/CHANGELOG.md`

### Summary

- Added an optional `options` parameter (`MarginCalculationOptions`) to `computeTraderMargin`, `computeSubaccountMargin`, `computeTraderMarginFromInputs`, `computeSubaccountMarginFromInputs`, and the corresponding `MarginCalculator` methods, letting callers pass per-symbol order leverage preferences via `orderLeverageLimitsBySymbol`.
- Order leverage limits are applied only to order/limit-order sizing math (initial margin from open orders, limit order margin requirements); position-only margin, withdrawal margin, maintenance/backstop/high-risk margin, and risk state/tier are always computed from protocol leverage tiers, unaffected by the new option.
- `MarginTotals` gains an optional `orderLeverageAdjustedInitialMarginQuoteLots` field, and `OrderMarginResult` gains an optional `orderLeverageAdjustedMarginRequirementQuoteLots` field; both are omitted entirely when no limit is supplied or when the adjusted value matches the protocol value.
- Limit values are validated defensively: non-finite, non-integer-safe, sub-1, or above-protocol-max values are silently ignored and fall back to protocol leverage; valid fractional values floor to the nearest integer leverage.
- Calling existing margin functions with no `options` argument (or an empty options object) produces byte-identical output to the prior release.

### Breaking Changes

- None identified in the synced diff.

### Consumer Notes

- All new behavior is opt-in via the new `options` parameter — no changes are required to existing integrations.
- Consumers that want to preview reduced-leverage order/margin requirements (e.g. surfacing a lower "order leverage" preference in UI) can pass `{ orderLeverageLimitsBySymbol: { "SOL-PERP": 5 } }` and read the new `orderLeverageAdjusted*` fields where present; treat their absence as "no adjustment applies."
- Do not rely on `orderLeverageAdjustedInitialMarginQuoteLots` for withdrawal eligibility or risk-state checks — those continue to use protocol-only margin figures.