### PR TITLE
sync: Rise TypeScript v0.4.65

### DIFF
--- a/programs/close-position-and-withdraw/Cargo.lock
+++ b/programs/close-position-and-withdraw/Cargo.lock
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "phoenix-rise-accounts",
  "phoenix-rise-api",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-accounts"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "borsh",
  "bs58",
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-api"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "base64 0.22.1",
  "bytemuck",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-ix"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-litesvm-test"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-math"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-types"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "phoenix-rise-math",

--- a/programs/close-position-and-withdraw/cli/Cargo.lock
+++ b/programs/close-position-and-withdraw/cli/Cargo.lock
@@ -1670,7 +1670,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phoenix-rise"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "phoenix-rise-accounts",
  "phoenix-rise-api",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-accounts"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-api"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-ix"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-math"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -1762,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-types"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "phoenix-rise-math",

--- a/programs/example-program/Cargo.lock
+++ b/programs/example-program/Cargo.lock
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "phoenix-rise-accounts",
  "phoenix-rise-api",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-accounts"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "borsh",
  "bs58",
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-api"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "base64 0.22.1",
  "bytemuck",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-ix"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-litesvm-test"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-math"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-types"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "phoenix-rise-math",

--- a/programs/trader-onboarder/Cargo.lock
+++ b/programs/trader-onboarder/Cargo.lock
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "phoenix-rise-accounts",
  "phoenix-rise-api",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-accounts"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "borsh",
  "bs58",
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-api"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "base64 0.22.1",
  "bytemuck",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-ix"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-litesvm-test"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-math"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-types"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "phoenix-rise-math",

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -3,6 +3,27 @@
 Entries are drafted by Phoenix Rise sync PRs. Review and edit each
 entry in this repo before merging.
 
+## v0.4.65 - 2026-07-07
+
+Source Phoenix commit: `25625a376965069d216ba53f8bbf0457f097a927`
+
+### Summary
+
+- Margin calculations now reserve additional collateral for resting limit orders priced adversely to the mark price (an "adverse fill-loss" reserve), mirroring the on-chain `program-core` margin logic.
+- Reduce-only order margin reserves are now capped by the size of the opposite-side position they can actually reduce, preventing over-reservation for large reduce-only orders against small positions.
+- `LimitOrderMarginState` and the internal margin aggregation helpers gained new fields (best bid/ask, reduce-only totals) to support the fill-loss calculation.
+
+### Breaking Changes
+
+- `LimitOrderMarginState` now requires `numAskOrders`, `numBidOrders` (previously optional), plus new required fields `lowestAsk`, `highestBid`, `totalReduceOnlyAskBaseLots`, and `totalReduceOnlyBidBaseLots`. Code that constructs this type directly (e.g. passing `limitOrderMargin` as a computed-margin input) must supply all of these fields or compilation/runtime behavior will differ.
+- `buildLimitOrderMarginStateFromOrders` gained a second parameter, `basePositionLots`, used to cap reduce-only reserves against the opposite position. It defaults to `0n`, so existing calls still compile, but omitting it means reduce-only orders are treated as fully reducing a zero position (capped to zero) rather than uncapped as before.
+
+### Consumer Notes
+
+- Accounts with resting limit orders priced away from mark should expect `initialMarginQuoteLots` and `limitOrderMarginQuoteLots` from `computeSubaccountMarginFromInputs` (via `createMarginCalculator`) to increase, since adverse-fill-loss is now included in the reserve.
+- If you rely on `buildLimitOrderMarginStateFromOrders` for reduce-only sizing, pass the account's current `basePositionLots` (signed, base lots) as the second argument to get correctly capped reserves instead of the new zero-position default.
+- Callers that only supply `limitOrders` (not a precomputed `limitOrderMargin`) need no changes — the new fields are derived automatically from order data and position size.
+
 ## v0.4.64 - 2026-07-06
 
 Source Phoenix commit: `84c3feb1a2f5d9b4e94f9372a706b0e3e3c88b0e`

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/rise",
-  "version": "0.4.64",
+  "version": "0.4.65",
   "packageManager": "bun@1.3.13",
   "repository": {
     "type": "git",

--- a/ts/scripts/lib/marginParityExport.ts
+++ b/ts/scripts/lib/marginParityExport.ts
@@ -62,10 +62,14 @@ export type MarginParitySnapshotFile = {
             accumulatedFundingQuoteLots: string;
           };
           limitOrderState: {
-            numBidOrders: number;
             numAskOrders: number;
-            totalNonReduceOnlyBidBaseLots: string;
+            numBidOrders: number;
+            lowestAsk: string;
+            highestBid: string;
             totalNonReduceOnlyAskBaseLots: string;
+            totalReduceOnlyAskBaseLots: string;
+            totalNonReduceOnlyBidBaseLots: string;
+            totalReduceOnlyBidBaseLots: string;
           };
           visibleLimitOrders: Array<{
             orderSequenceNumber: string;
@@ -410,12 +414,18 @@ export const buildMarginParityOutput = (
               }
             : undefined,
           limitOrderMargin: {
-            numBidOrders: market.limitOrderState.numBidOrders,
             numAskOrders: market.limitOrderState.numAskOrders,
-            totalNonReduceOnlyBidBaseLots:
-              market.limitOrderState.totalNonReduceOnlyBidBaseLots,
+            numBidOrders: market.limitOrderState.numBidOrders,
+            lowestAsk: market.limitOrderState.lowestAsk,
+            highestBid: market.limitOrderState.highestBid,
             totalNonReduceOnlyAskBaseLots:
               market.limitOrderState.totalNonReduceOnlyAskBaseLots,
+            totalReduceOnlyAskBaseLots:
+              market.limitOrderState.totalReduceOnlyAskBaseLots,
+            totalNonReduceOnlyBidBaseLots:
+              market.limitOrderState.totalNonReduceOnlyBidBaseLots,
+            totalReduceOnlyBidBaseLots:
+              market.limitOrderState.totalReduceOnlyBidBaseLots,
           },
           limitOrders: (market.visibleLimitOrders ?? []).map((order) => ({
             orderSequenceNumber: order.orderSequenceNumber,

--- a/ts/src/margin/compute.ts
+++ b/ts/src/margin/compute.ts
@@ -1642,7 +1642,8 @@ const filterActiveOrders = (
 
 const resolveLimitOrderMarginState = (
   orders: LimitOrderMarginInput[],
-  limitOrderMargin: LimitOrderMarginState | undefined
+  limitOrderMargin: LimitOrderMarginState | undefined,
+  basePositionLots: bigint
 ): LimitOrderMarginState | undefined => {
   if (limitOrderMargin) {
     return limitOrderMargin;
@@ -1650,7 +1651,7 @@ const resolveLimitOrderMarginState = (
   if (orders.length === 0) {
     return undefined;
   }
-  return buildLimitOrderMarginStateFromOrders(orders);
+  return buildLimitOrderMarginStateFromOrders(orders, basePositionLots);
 };
 
 const getOrderLeverageLimitForSymbol = (
@@ -1745,7 +1746,8 @@ const computeMarketMarginFromInputs = (
   const activeOrders = filterActiveOrders(input.limitOrders ?? []);
   const limitOrderState = resolveLimitOrderMarginState(
     activeOrders,
-    input.limitOrderMargin
+    input.limitOrderMargin,
+    basePositionLots
   );
   const totalBid = limitOrderState
     ? toBigInt(limitOrderState.totalNonReduceOnlyBidBaseLots)
@@ -1759,13 +1761,34 @@ const computeMarketMarginFromInputs = (
     options
   );
 
+  // Reduce-only orders still rest on the book, so the fill-loss reserve is
+  // computed over the total base lots on each side, using the best resting price.
+  const fillLossInputs: FillLossInputs = limitOrderState
+    ? {
+        totalBidBaseLots:
+          totalBid + toBigInt(limitOrderState.totalReduceOnlyBidBaseLots),
+        totalAskBaseLots:
+          totalAsk + toBigInt(limitOrderState.totalReduceOnlyAskBaseLots),
+        highestBid: toBigInt(limitOrderState.highestBid),
+        lowestAsk: toBigInt(limitOrderState.lowestAsk),
+        tickSize: marketParams.tickSize,
+      }
+    : {
+        totalBidBaseLots: 0n,
+        totalAskBaseLots: 0n,
+        highestBid: 0n,
+        lowestAsk: 0n,
+        tickSize: marketParams.tickSize,
+      };
+
   const initialMargin = initialMarginForAsset(
     basePositionLots,
     totalBid,
     totalAsk,
     assetUnitPrice,
     leverageTiers,
-    false
+    false,
+    fillLossInputs
   );
 
   const orderLeverageAdjustedInitialMargin =
@@ -1778,6 +1801,7 @@ const computeMarketMarginFromInputs = (
           assetUnitPrice,
           leverageTiers,
           false,
+          fillLossInputs,
           orderLeverageLimit
         );
 
@@ -1796,7 +1820,8 @@ const computeMarketMarginFromInputs = (
     totalAsk,
     assetUnitPrice,
     leverageTiers,
-    true
+    true,
+    fillLossInputs
   );
 
   const limitOrderMargin = maxBigInt(
@@ -1889,6 +1914,52 @@ const computeMarketMarginFromInputs = (
   };
 };
 
+/**
+ * Inputs for the adverse-fill-loss reserve. `totalBid/AskBaseLots` include
+ * reduce-only orders (they still rest on the book); the tick prices are the best
+ * resting price on each side (0 when there are no orders that side).
+ */
+interface FillLossInputs {
+  totalBidBaseLots: bigint;
+  totalAskBaseLots: bigint;
+  highestBid: bigint;
+  lowestAsk: bigint;
+  tickSize: bigint;
+}
+
+/**
+ * Reserve for the immediate mark-to-market loss if resting orders on `side` were
+ * to fill at their limit price. A resting bid above mark (or ask below mark)
+ * fills in-the-money for the counterparty, so reserve `size * |limitPrice -
+ * markPrice|`. Orders resting on the passive side of mark contribute nothing.
+ * Mirrors `limit_order_fill_loss` in program-core/exchange/src/margin.rs.
+ */
+const limitOrderFillLoss = (
+  side: "bid" | "ask",
+  size: bigint,
+  limitPriceTicks: bigint,
+  markPrice: bigint,
+  tickSize: bigint
+): bigint => {
+  if (limitPriceTicks === 0n) {
+    return 0n;
+  }
+  const limitPrice = limitPriceTicks * tickSize;
+  let priceDifference: bigint;
+  if (side === "bid") {
+    if (limitPrice <= markPrice) {
+      return 0n;
+    }
+    priceDifference = limitPrice - markPrice;
+  } else {
+    if (limitPrice >= markPrice) {
+      return 0n;
+    }
+    priceDifference = markPrice - limitPrice;
+  }
+  return size * priceDifference;
+};
+
 const initialMarginForAsset = (
   position: bigint,
   totalBid: bigint,
@@ -1896,9 +1967,18 @@ const initialMarginForAsset = (
   assetUnitPrice: bigint,
   tiers: LeverageTier[],
   bypassRiskFactor: boolean,
+  fillLoss?: FillLossInputs,
   orderLeverageLimit?: bigint
 ): bigint => {
-  if (position === 0n && totalBid === 0n && totalAsk === 0n) {
+  const totalBidAll = fillLoss?.totalBidBaseLots ?? 0n;
+  const totalAskAll = fillLoss?.totalAskBaseLots ?? 0n;
+  if (
+    position === 0n &&
+    totalBid === 0n &&
+    totalAsk === 0n &&
+    totalBidAll === 0n &&
+    totalAskAll === 0n
+  ) {
     return 0n;
   }
 
@@ -1945,6 +2025,30 @@ const initialMarginForAsset = (
       : 0n;
 
   collateralRequired += maxBigInt(marginBid, marginAsk);
+
+  if (fillLoss) {
+    const bidFillLoss =
+      totalBidAll > 0n
+        ? limitOrderFillLoss(
+            "bid",
+            totalBidAll,
+            fillLoss.highestBid,
+            assetUnitPrice,
+            fillLoss.tickSize
+          )
+        : 0n;
+    const askFillLoss =
+      totalAskAll > 0n
+        ? limitOrderFillLoss(
+            "ask",
+            totalAskAll,
+            fillLoss.lowestAsk,
+            assetUnitPrice,
+            fillLoss.tickSize
+          )
+        : 0n;
+    collateralRequired += bidFillLoss + askFillLoss;
+  }
 
   return collateralRequired;
 };

--- a/ts/src/margin/inputs.ts
+++ b/ts/src/margin/inputs.ts
@@ -1,14 +1,28 @@
-import { toBigInt } from "./math";
+import { minBigInt, toBigInt } from "./math";
 import type { LimitOrderMarginInput, LimitOrderMarginState } from "./types";
 
 const isActiveOrder = (order: LimitOrderMarginInput): boolean =>
   order.status ? order.status === "active" : true;
 
+/**
+ * Aggregate active orders into a `LimitOrderMarginState`.
+ *
+ * `basePositionLots` is the signed base-lot position; reduce-only totals are
+ * capped by the position they can actually reduce (a reduce-only ask can only
+ * reduce a long, a reduce-only bid only a short), mirroring the canonical
+ * `From<&TraderPositionState>`. Without the cap a large reduce-only order
+ * against a small opposite position would over-reserve adverse-fill margin.
+ */
 export const buildLimitOrderMarginStateFromOrders = (
-  orders: LimitOrderMarginInput[]
+  orders: LimitOrderMarginInput[],
+  basePositionLots: bigint = 0n
 ): LimitOrderMarginState => {
   let totalNonReduceOnlyBidBaseLots = 0n;
   let totalNonReduceOnlyAskBaseLots = 0n;
+  let totalReduceOnlyBidBaseLots = 0n;
+  let totalReduceOnlyAskBaseLots = 0n;
+  let highestBid = 0n;
+  let lowestAsk = 0n;
   let numBidOrders = 0;
   let numAskOrders = 0;
 
@@ -16,23 +30,52 @@ export const buildLimitOrderMarginStateFromOrders = (
     if (!isActiveOrder(order)) {
       continue;
     }
+    const size = toBigInt(order.sizeRemainingLots);
+    const priceTicks = toBigInt(order.priceTicks);
     if (order.side === "bid") {
       numBidOrders += 1;
-      if (!order.reduceOnly) {
-        totalNonReduceOnlyBidBaseLots += toBigInt(order.sizeRemainingLots);
+      if (priceTicks > highestBid) {
+        highestBid = priceTicks;
+      }
+      if (order.reduceOnly) {
+        totalReduceOnlyBidBaseLots += size;
+      } else {
+        totalNonReduceOnlyBidBaseLots += size;
       }
     } else {
       numAskOrders += 1;
-      if (!order.reduceOnly) {
-        totalNonReduceOnlyAskBaseLots += toBigInt(order.sizeRemainingLots);
+      if (lowestAsk === 0n || priceTicks < lowestAsk) {
+        lowestAsk = priceTicks;
+      }
+      if (order.reduceOnly) {
+        totalReduceOnlyAskBaseLots += size;
+      } else {
+        totalNonReduceOnlyAskBaseLots += size;
       }
     }
   }
 
+  // A reduce-only ask can only reduce a long position; a reduce-only bid only a
+  // short. Cap each reduce-only total by the reducible position size.
+  const reducibleLong = basePositionLots > 0n ? basePositionLots : 0n;
+  const reducibleShort = basePositionLots < 0n ? -basePositionLots : 0n;
+  const cappedReduceOnlyAskBaseLots = minBigInt(
+    totalReduceOnlyAskBaseLots,
+    reducibleLong
+  );
+  const cappedReduceOnlyBidBaseLots = minBigInt(
+    totalReduceOnlyBidBaseLots,
+    reducibleShort
+  );
+
   return {
-    totalNonReduceOnlyBidBaseLots: totalNonReduceOnlyBidBaseLots.toString(),
-    totalNonReduceOnlyAskBaseLots: totalNonReduceOnlyAskBaseLots.toString(),
-    numBidOrders,
     numAskOrders,
+    numBidOrders,
+    lowestAsk: lowestAsk.toString(),
+    highestBid: highestBid.toString(),
+    totalNonReduceOnlyAskBaseLots: totalNonReduceOnlyAskBaseLots.toString(),
+    totalReduceOnlyAskBaseLots: cappedReduceOnlyAskBaseLots.toString(),
+    totalNonReduceOnlyBidBaseLots: totalNonReduceOnlyBidBaseLots.toString(),
+    totalReduceOnlyBidBaseLots: cappedReduceOnlyBidBaseLots.toString(),
   };
 };

--- a/ts/src/margin/math.ts
+++ b/ts/src/margin/math.ts
@@ -21,6 +21,8 @@ export const absBigInt = (value: bigint): bigint =>
 
 export const maxBigInt = (a: bigint, b: bigint): bigint => (a > b ? a : b);
 
+export const minBigInt = (a: bigint, b: bigint): bigint => (a < b ? a : b);
+
 export const divCeil = (numerator: bigint, denominator: bigint): bigint => {
   if (denominator === 0n) {
     throw new Error("division by zero");

--- a/ts/src/margin/snapshot.ts
+++ b/ts/src/margin/snapshot.ts
@@ -1,4 +1,5 @@
 import { buildLimitOrderMarginStateFromOrders } from "./inputs";
+import { toBigInt } from "./math";
 import type {
   LimitOrderMarginInput,
   MarginPositionState,
@@ -90,9 +91,10 @@ export const buildMarketMarginInputsFromSnapshot = (
 ): MarketMarginInputs => {
   const limitOrders = orders.map(toLimitOrderMarginInput);
   const activeOrders = limitOrders.filter(isActiveOrder);
+  const basePositionLots = position ? toBigInt(position.basePositionLots) : 0n;
   const limitOrderMargin =
     activeOrders.length > 0
-      ? buildLimitOrderMarginStateFromOrders(activeOrders)
+      ? buildLimitOrderMarginStateFromOrders(activeOrders, basePositionLots)
       : undefined;
 
   return {

--- a/ts/src/margin/types.ts
+++ b/ts/src/margin/types.ts
@@ -50,10 +50,14 @@ export interface MarginPositionState {
 }
 
 export interface LimitOrderMarginState {
-  totalNonReduceOnlyBidBaseLots: string;
+  numAskOrders: number;
+  numBidOrders: number;
+  lowestAsk: string;
+  highestBid: string;
   totalNonReduceOnlyAskBaseLots: string;
-  numBidOrders?: number;
-  numAskOrders?: number;
+  totalReduceOnlyAskBaseLots: string;
+  totalNonReduceOnlyBidBaseLots: string;
+  totalReduceOnlyBidBaseLots: string;
 }
 
 export interface LimitOrderMarginInput {

--- a/ts/tests/margin-limit-order-fill-loss.test.ts
+++ b/ts/tests/margin-limit-order-fill-loss.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import { createMarginCalculator } from "@/margin";
+import type { MarketParams } from "@/margin";
+
+// Mirrors the canonical Rust test
+// `limit_order_margin_includes_adverse_fill_loss_against_mark`
+// (program-core/exchange/src/margin.rs): tick size 10, mark price 100 ticks
+// (= 1000 quote lots per base lot), flat 10x leverage, 100% limit-order risk
+// factor so the leverage-based order margin is undiscounted.
+const fillLossMarketParams = (): MarketParams => ({
+  symbol: "TEST-PERP",
+  assetId: 1,
+  markPriceTicks: "100",
+  tickSize: "10",
+  baseLotDecimals: 0,
+  leverageTiers: [
+    {
+      upperBoundSize: "1000000",
+      maxLeverage: "10",
+      limitOrderRiskFactorBps: "10000",
+    },
+  ],
+  riskFactors: {
+    maintenanceMarginFactorBps: "5000",
+    backstopMarginFactorBps: "4000",
+    highRiskMarginFactorBps: "3000",
+  },
+  cancelOrderRiskFactorBps: "5500",
+  upnlRiskFactor: "5000",
+  upnlRiskFactorForWithdrawals: "7500",
+  isolatedOnly: false,
+});
+
+const computeInitialMargin = (
+  orders: Array<{
+    side: "bid" | "ask";
+    priceTicks: string;
+    sizeRemainingLots: string;
+    reduceOnly: boolean;
+  }>
+): { initialMargin: string; limitOrderMargin: string } => {
+  const calculator = createMarginCalculator([fillLossMarketParams()]);
+  const result = calculator.computeSubaccountMarginFromInputs({
+    subaccountIndex: 0,
+    collateralBalanceQuoteLots: "0",
+    markets: [
+      {
+        symbol: "TEST-PERP",
+        limitOrders: orders.map((order, index) => ({
+          orderSequenceNumber: String(index),
+          side: order.side,
+          priceTicks: order.priceTicks,
+          sizeRemainingLots: order.sizeRemainingLots,
+          initialSizeLots: order.sizeRemainingLots,
+          reduceOnly: order.reduceOnly,
+        })),
+      },
+    ],
+  });
+  return {
+    initialMargin: result.margin.initialMarginQuoteLots,
+    limitOrderMargin: result.margin.limitOrderMarginQuoteLots,
+  };
+};
+
+describe("limit order adverse-fill-loss reserve", () => {
+  it("reserves fill loss for a resting bid above mark", () => {
+    // Bid at 200 ticks vs mark at 100 ticks: leverage margin 1_000 plus an
+    // adverse fill loss of 10 * (2000 - 1000) = 10_000.
+    const { initialMargin, limitOrderMargin } = computeInitialMargin([
+      {
+        side: "bid",
+        priceTicks: "200",
+        sizeRemainingLots: "10",
+        reduceOnly: false,
+      },
+    ]);
+    expect(initialMargin).toBe("11000");
+    expect(limitOrderMargin).toBe("11000");
+  });
+
+  it("reserves fill loss for a resting ask below mark", () => {
+    // Ask at 50 ticks vs mark at 100 ticks: leverage margin 1_000 plus an
+    // adverse fill loss of 10 * (1000 - 500) = 5_000.
+    const { initialMargin } = computeInitialMargin([
+      {
+        side: "ask",
+        priceTicks: "50",
+        sizeRemainingLots: "10",
+        reduceOnly: false,
+      },
+    ]);
+    expect(initialMargin).toBe("6000");
+  });
+
+  it("reserves nothing for orders resting on the passive side of mark", () => {
+    // Bid below mark and ask above mark fill out-of-the-money, so no fill-loss
+    // reserve; only the leverage-based order margin (1_000 each, max = 1_000).
+    const { initialMargin } = computeInitialMargin([
+      {
+        side: "bid",
+        priceTicks: "50",
+        sizeRemainingLots: "10",
+        reduceOnly: false,
+      },
+      {
+        side: "ask",
+        priceTicks: "200",
+        sizeRemainingLots: "10",
+        reduceOnly: false,
+      },
+    ]);
+    expect(initialMargin).toBe("1000");
+  });
+});
+
+const computeInitialMarginWithPosition = (
+  basePositionLots: string,
+  orders: Array<{
+    side: "bid" | "ask";
+    priceTicks: string;
+    sizeRemainingLots: string;
+    reduceOnly: boolean;
+  }>
+): string => {
+  const calculator = createMarginCalculator([fillLossMarketParams()]);
+  const result = calculator.computeSubaccountMarginFromInputs({
+    subaccountIndex: 0,
+    collateralBalanceQuoteLots: "0",
+    markets: [
+      {
+        symbol: "TEST-PERP",
+        position: {
+          basePositionLots,
+          virtualQuotePositionLots: "0",
+          entryPriceTicks: "0",
+          unsettledFundingQuoteLots: "0",
+          accumulatedFundingQuoteLots: "0",
+        },
+        limitOrders: orders.map((order, index) => ({
+          orderSequenceNumber: String(index),
+          side: order.side,
+          priceTicks: order.priceTicks,
+          sizeRemainingLots: order.sizeRemainingLots,
+          initialSizeLots: order.sizeRemainingLots,
+          reduceOnly: order.reduceOnly,
+        })),
+      },
+    ],
+  });
+  return result.margin.initialMarginQuoteLots;
+};
+
+describe("reduce-only fill-loss capping by opposite position", () => {
+  it("caps a huge reduce-only order to the small opposite position", () => {
+    // Long 5 lots with a reduce-only ask of 1_000 lots at 50 ticks. Only 5 lots
+    // can actually reduce the long, so the reserve is 5 * (1000 - 500) = 2_500,
+    // plus position margin 500 -> 3_000. Uncapped it would be 500_500.
+    const initialMargin = computeInitialMarginWithPosition("5", [
+      {
+        side: "ask",
+        priceTicks: "50",
+        sizeRemainingLots: "1000",
+        reduceOnly: true,
+      },
+    ]);
+    expect(initialMargin).toBe("3000");
+  });
+
+  it("reserves nothing for a reduce-only order on the position's own side", () => {
+    // Long 5 lots with a reduce-only bid: a bid would increase the long, so it
+    // is capped to zero and reserves no fill loss. Only position margin (500).
+    const initialMargin = computeInitialMarginWithPosition("5", [
+      {
+        side: "bid",
+        priceTicks: "200",
+        sizeRemainingLots: "1000",
+        reduceOnly: true,
+      },
+    ]);
+    expect(initialMargin).toBe("500");
+  });
+
+  it("reserves the full fill loss when reduce-only fits within the position", () => {
+    // Short 10 lots with a reduce-only bid of 10 lots at 200 ticks: not capped,
+    // reserve 10 * (2000 - 1000) = 10_000 plus position margin 1_000 -> 11_000.
+    const initialMargin = computeInitialMarginWithPosition("-10", [
+      {
+        side: "bid",
+        priceTicks: "200",
+        sizeRemainingLots: "10",
+        reduceOnly: true,
+      },
+    ]);
+    expect(initialMargin).toBe("11000");
+  });
+});

--- a/ts/tests/margin-liquidation-price.test.ts
+++ b/ts/tests/margin-liquidation-price.test.ts
@@ -642,8 +642,14 @@ describe("margin liquidation price", () => {
           {
             symbol: "SOL-PERP",
             limitOrderMargin: {
+              numAskOrders: 0,
+              numBidOrders: 0,
+              lowestAsk: "0",
+              highestBid: "0",
               totalNonReduceOnlyBidBaseLots: "100",
               totalNonReduceOnlyAskBaseLots: "0",
+              totalReduceOnlyBidBaseLots: "0",
+              totalReduceOnlyAskBaseLots: "0",
             },
           },
         ],


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `25625a376965069d216ba53f8bbf0457f097a927`
- Mode: automatic
- Synced paths:

- `rise/ts` -> `ts`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/programs` -> `programs`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `ts/CHANGELOG.md`

### Summary

- Margin calculations now reserve additional collateral for resting limit orders priced adversely to the mark price (an "adverse fill-loss" reserve), mirroring the on-chain `program-core` margin logic.
- Reduce-only order margin reserves are now capped by the size of the opposite-side position they can actually reduce, preventing over-reservation for large reduce-only orders against small positions.
- `LimitOrderMarginState` and the internal margin aggregation helpers gained new fields (best bid/ask, reduce-only totals) to support the fill-loss calculation.

### Breaking Changes

- `LimitOrderMarginState` now requires `numAskOrders`, `numBidOrders` (previously optional), plus new required fields `lowestAsk`, `highestBid`, `totalReduceOnlyAskBaseLots`, and `totalReduceOnlyBidBaseLots`. Code that constructs this type directly (e.g. passing `limitOrderMargin` as a computed-margin input) must supply all of these fields or compilation/runtime behavior will differ.
- `buildLimitOrderMarginStateFromOrders` gained a second parameter, `basePositionLots`, used to cap reduce-only reserves against the opposite position. It defaults to `0n`, so existing calls still compile, but omitting it means reduce-only orders are treated as fully reducing a zero position (capped to zero) rather than uncapped as before.

### Consumer Notes

- Accounts with resting limit orders priced away from mark should expect `initialMarginQuoteLots` and `limitOrderMarginQuoteLots` from `computeSubaccountMarginFromInputs` (via `createMarginCalculator`) to increase, since adverse-fill-loss is now included in the reserve.
- If you rely on `buildLimitOrderMarginStateFromOrders` for reduce-only sizing, pass the account's current `basePositionLots` (signed, base lots) as the second argument to get correctly capped reserves instead of the new zero-position default.
- Callers that only supply `limitOrders` (not a precomputed `limitOrderMargin`) need no changes — the new fields are derived automatically from order data and position size.