### PR TITLE
sync: Rise TypeScript v0.4.66

### DIFF
--- a/programs/close-position-and-withdraw/Cargo.lock
+++ b/programs/close-position-and-withdraw/Cargo.lock
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "phoenix-rise-accounts",
  "phoenix-rise-api",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-accounts"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "borsh",
  "bs58",
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-api"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base64 0.22.1",
  "bytemuck",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-ix"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-litesvm-test"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-math"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-types"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "phoenix-rise-math",

--- a/programs/close-position-and-withdraw/cli/Cargo.lock
+++ b/programs/close-position-and-withdraw/cli/Cargo.lock
@@ -1670,7 +1670,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phoenix-rise"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "phoenix-rise-accounts",
  "phoenix-rise-api",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-accounts"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-api"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-ix"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-math"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -1762,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-types"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "phoenix-rise-math",

--- a/programs/example-program/Cargo.lock
+++ b/programs/example-program/Cargo.lock
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "phoenix-rise-accounts",
  "phoenix-rise-api",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-accounts"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "borsh",
  "bs58",
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-api"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base64 0.22.1",
  "bytemuck",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-ix"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-litesvm-test"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-math"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-types"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "phoenix-rise-math",

--- a/programs/trader-onboarder/Cargo.lock
+++ b/programs/trader-onboarder/Cargo.lock
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "phoenix-rise-accounts",
  "phoenix-rise-api",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-accounts"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "borsh",
  "bs58",
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-api"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base64 0.22.1",
  "bytemuck",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-ix"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-litesvm-test"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-math"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "phoenix-rise-types"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "phoenix-rise-math",

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -3,6 +3,28 @@
 Entries are drafted by Phoenix Rise sync PRs. Review and edit each
 entry in this repo before merging.
 
+## v0.4.66 - 2026-07-08
+
+Source Phoenix commit: `6051225fb045fbb5b6a454bd445e7fc2e31e5722`
+
+### Summary
+
+- Rewrote the SDK's liquidation-price search to use a numeric mark-price boundary search instead of the previous closed-form equation, fixing incorrect results for already-liquidatable positions and for same-market resting orders.
+- Added a new "projected liquidation" API — `computeProjectedLiquidation`, `computeMarketProjectedLiquidationFromMargin`, `computeSubaccountProjectedLiquidationFromMargin`, `createProjectedLiquidationCalculator`, `aggregateLimitOrderStateFromOrders`, and related types — that estimates liquidation risk after a trader's own resting orders fill along the adverse price path.
+- Limit-order margin best-bid/best-ask sentinels are now computed relative to the current mark price via the new `buildLimitOrderMarginStateFromOrdersAtMark`, so only orders that could actually cross at the current mark reserve fill-loss margin.
+
+### Breaking Changes
+
+- `computeMarketLiquidationPriceFromMargin`, `computeSubaccountLiquidationPricesFromMargin`, and `computeTraderLiquidationPricesFromMargin` now return the current mark price for already-liquidatable positions and otherwise use the new boundary-search algorithm — expect different numeric outputs than 0.4.65 for identical inputs.
+- `buildMarketMarginInputsFromSnapshot` no longer populates `limitOrderMargin` on its returned `MarketMarginInputs`; margin/liquidation computation now derives limit-order sentinels internally from `limitOrders` and the market's mark price. Code reading `.limitOrderMargin` directly off this helper's output will now see `undefined`.
+- Same-market limit-order maintenance margin is now mark-price-dependent (only crossing-side resting orders count toward fill-loss margin), changing computed margin/liquidation values for accounts with resting orders on the far side of the mark.
+
+### Consumer Notes
+
+- Treat the existing static liquidation-price functions as the canonical current-state ("Hawkeye-compatible") value; use the new projected-liquidation functions only for scenario/risk displays, not for liquidation-eligibility or program parity checks.
+- `calculateLiquidationPriceUsd` gained an optional `targetLimitOrderMaintenanceCoefficient` input, defaulting to `0` for backward compatibility.
+- `buildLimitOrderMarginStateFromOrders` keeps its prior signature/behavior for existing callers; switch to `buildLimitOrderMarginStateFromOrdersAtMark` where mark-relative sentinels are needed.
+
 ## v0.4.65 - 2026-07-07
 
 Source Phoenix commit: `25625a376965069d216ba53f8bbf0457f097a927`

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ellipsis-labs/rise",
-  "version": "0.4.65",
+  "version": "0.4.66",
   "packageManager": "bun@1.3.13",
   "repository": {
     "type": "git",

--- a/ts/scripts/lib/marginParityExport.ts
+++ b/ts/scripts/lib/marginParityExport.ts
@@ -2,12 +2,19 @@ import {
   computeSubaccountMarginFromInputs,
   createMarginCalculator,
 } from "../../src/margin/compute";
-import { calculateLiquidationPriceUsd } from "../../src/margin/liquidation";
+import {
+  computeProjectedLiquidation,
+  type ProjectedLiquidationInput,
+} from "../../src/margin/liquidation";
+import { normalizeMarketParams } from "../../src/margin/normalize";
 import {
   absBigInt,
   applyBps,
+  applyBpsCeil,
   divCeil,
   getLeverageConstant,
+  getLimitOrderRiskFactor,
+  maxBigInt,
   toBigInt,
   type LeverageTier,
 } from "../../src/margin/math";
@@ -112,6 +119,7 @@ export type MarginParityOutputFile = {
       marketMargins: Array<
         MarketMarginResult & {
           liquidationPriceTicks?: string;
+          projectedLiquidationPriceTicks?: string;
           cancelMarginQuoteLots: string;
           highRiskMarginQuoteLots: string;
           maxLimitBidBaseLots: string;
@@ -160,30 +168,18 @@ const computeRiskScore = (
   );
 };
 
-const quoteLotsToUsd = (quoteLots: bigint): number =>
-  Number(quoteLots) / 1_000_000;
-
-const baseLotsToUnits = (baseLots: bigint, baseLotDecimals: number): number =>
-  Number(baseLots) / Math.pow(10, baseLotDecimals);
-
-const priceToTicks = (
-  price: number,
-  market: MarginParitySnapshotFile["markets"][number]
-): bigint | undefined => {
-  if (!Number.isFinite(price) || price <= 0) {
-    return undefined;
-  }
-  const numerator = price * 1_000_000;
-  const denominator =
-    Number(market.tickSize) * Math.pow(10, market.baseLotDecimals);
-  if (!Number.isFinite(denominator) || denominator <= 0) {
-    return undefined;
-  }
-  const ticks = Math.round(numerator / denominator);
-  if (!Number.isFinite(ticks) || ticks < 0) {
-    return undefined;
-  }
-  return BigInt(ticks);
+const MAX_HAWKEYE_LIQUIDATION_TICKS = 0xffff_ffffn;
+const emptyLimitOrderState: NonNullable<
+  MarketMarginInputs["limitOrderMargin"]
+> = {
+  numAskOrders: 0,
+  numBidOrders: 0,
+  lowestAsk: "0",
+  highestBid: "0",
+  totalNonReduceOnlyAskBaseLots: "0",
+  totalReduceOnlyAskBaseLots: "0",
+  totalNonReduceOnlyBidBaseLots: "0",
+  totalReduceOnlyBidBaseLots: "0",
 };
 
 const parseLeverageTiers = (
@@ -198,93 +194,111 @@ const parseLeverageTiers = (
 const computeLiquidationPriceTicks = (
   market: MarketMarginResult,
   totals: MarginTotals,
-  marketParams: MarginParitySnapshotFile["markets"][number]
+  marketParams: MarginParitySnapshotFile["markets"][number],
+  marketInput: MarketMarginInputs
 ): string | undefined => {
   const basePositionLots = toBigInt(market.basePositionLots);
   if (basePositionLots === 0n) {
     return undefined;
   }
-  const basePosition = baseLotsToUnits(
-    basePositionLots,
-    marketParams.baseLotDecimals
-  );
-  if (!Number.isFinite(basePosition) || Math.abs(basePosition) === 0) {
-    return undefined;
+  const currentMarkTicks = toBigInt(marketParams.markPriceTicks);
+  if (
+    isLiquidatableAtTicks(
+      currentMarkTicks,
+      market,
+      totals,
+      marketParams,
+      marketInput
+    )
+  ) {
+    return currentMarkTicks.toString();
   }
-
-  const entryPrice =
-    quoteLotsToUsd(absBigInt(toBigInt(market.virtualQuotePositionLots))) /
-    Math.abs(basePosition);
-  const collateralUsd = quoteLotsToUsd(
-    toBigInt(String(totals.collateralBalanceQuoteLots)) +
-      toBigInt(String(totals.unsettledFundingQuoteLots))
+  const liquidationPriceTicks = findLiquidationBoundaryTicks(
+    market,
+    totals,
+    marketParams,
+    marketInput
   );
-  const otherAssetUnrealizedPnl = quoteLotsToUsd(
-    toBigInt(String(totals.discountedUnrealizedPnlQuoteLots)) -
-      toBigInt(market.discountedUnrealizedPnlQuoteLots)
-  );
-  const maintenanceBps = toBigInt(
-    marketParams.riskFactors.maintenanceMarginFactorBps
-  );
-  const otherAssetMaintenanceMargin = quoteLotsToUsd(
-    otherAssetMaintenanceMarginQuoteLots(market, totals, marketParams)
-  );
-  const leverage = getLeverageConstant(
-    parseLeverageTiers(marketParams),
-    absBigInt(basePositionLots)
-  );
-  const liquidationPrice = calculateLiquidationPriceUsd({
-    positionSize: basePosition,
-    entryPriceUsd: entryPrice,
-    leverage: Number(leverage),
-    maintenanceMarginBps: Number(maintenanceBps),
-    upnlRiskFactorBps: Number(toBigInt(marketParams.upnlRiskFactor)),
-    collateralUsd,
-    otherAssetUnrealizedPnlUsd: otherAssetUnrealizedPnl,
-    otherAssetMaintenanceMarginUsd: otherAssetMaintenanceMargin,
-  });
-  const liquidationPriceTicks =
-    liquidationPrice === null
-      ? undefined
-      : priceToTicks(liquidationPrice, marketParams);
   return liquidationPriceTicks?.toString();
 };
 
-const otherAssetMaintenanceMarginQuoteLots = (
+/**
+ * Computes the projected (path-dependent) liquidation boundary through the
+ * rise TypeScript SDK implementation so the exported value exercises the same
+ * code integrators call.
+ */
+const computeProjectedLiquidationPriceTicks = (
   market: MarketMarginResult,
   totals: MarginTotals,
-  marketParams: MarginParitySnapshotFile["markets"][number]
+  marketParams: MarginParitySnapshotFile["markets"][number],
+  marketInput: MarketMarginInputs
+): string | undefined => {
+  const basePositionLots = toBigInt(market.basePositionLots);
+  if (basePositionLots === 0n) {
+    return undefined;
+  }
+
+  const state = marketInput.limitOrderMargin ?? emptyLimitOrderState;
+  const input: ProjectedLiquidationInput = {
+    basePositionLots,
+    virtualQuotePositionLots: toBigInt(market.virtualQuotePositionLots),
+    limitOrderState: {
+      totalNonReduceOnlyAskBaseLots: toBigInt(
+        state.totalNonReduceOnlyAskBaseLots
+      ),
+      totalReduceOnlyAskBaseLots: toBigInt(state.totalReduceOnlyAskBaseLots),
+      totalNonReduceOnlyBidBaseLots: toBigInt(
+        state.totalNonReduceOnlyBidBaseLots
+      ),
+      totalReduceOnlyBidBaseLots: toBigInt(state.totalReduceOnlyBidBaseLots),
+      lowestAsk: toBigInt(state.lowestAsk),
+      highestBid: toBigInt(state.highestBid),
+    },
+    visibleOrders: (marketInput.limitOrders ?? []).map((order) => ({
+      side: order.side,
+      priceTicks: toBigInt(order.priceTicks),
+      baseLotsRemaining: toBigInt(order.sizeRemainingLots),
+      reduceOnly: order.reduceOnly,
+    })),
+    collateralBalanceQuoteLots: toBigInt(
+      String(totals.collateralBalanceQuoteLots)
+    ),
+    portfolioUnsettledFundingQuoteLots: toBigInt(
+      String(totals.unsettledFundingQuoteLots)
+    ),
+    portfolioDiscountedUnrealizedPnlQuoteLots: toBigInt(
+      String(totals.discountedUnrealizedPnlQuoteLots)
+    ),
+    portfolioMaintenanceMarginQuoteLots: toBigInt(
+      String(totals.maintenanceMarginQuoteLots)
+    ),
+    targetDiscountedUnrealizedPnlQuoteLots: toBigInt(
+      market.discountedUnrealizedPnlQuoteLots
+    ),
+    targetMaintenanceMarginQuoteLots: toBigInt(
+      market.maintenanceMarginQuoteLots
+    ),
+  };
+
+  const result = computeProjectedLiquidation(
+    input,
+    normalizeMarketParams(marketParams)
+  );
+  return result.liquidationPriceTicks?.toString();
+};
+
+const otherMarketMaintenanceMarginQuoteLots = (
+  market: MarketMarginResult,
+  totals: MarginTotals
 ): bigint => {
-  const targetPositionOnlyMaintenanceMargin =
-    positionOnlyMaintenanceMarginQuoteLots(market, marketParams);
   const portfolioMaintenanceMargin = toBigInt(
     String(totals.maintenanceMarginQuoteLots)
   );
 
   return checkedSubtractQuoteLots(
     portfolioMaintenanceMargin,
-    targetPositionOnlyMaintenanceMargin,
-    `Portfolio maintenance margin underflow for symbol ${market.symbol}`
-  );
-};
-
-const positionOnlyMaintenanceMarginQuoteLots = (
-  market: MarketMarginResult,
-  marketParams: MarginParitySnapshotFile["markets"][number]
-): bigint => {
-  const maintenanceBps = toBigInt(
-    marketParams.riskFactors.maintenanceMarginFactorBps
-  );
-  const discountedLimitOrderMaintenanceMargin = applyBps(
-    toBigInt(market.limitOrderMarginQuoteLots),
-    maintenanceBps
-  );
-
-  // Mirrors phoenix-state Margin::position_only_maintenance_margin.
-  return checkedSubtractQuoteLots(
     toBigInt(market.maintenanceMarginQuoteLots),
-    discountedLimitOrderMaintenanceMargin,
-    `Position maintenance margin underflow for symbol ${market.symbol}`
+    `Portfolio maintenance margin underflow for symbol ${market.symbol}`
   );
 };
 
@@ -300,6 +314,283 @@ const checkedSubtractQuoteLots = (
   }
 
   return minuend - subtrahend;
+};
+
+const findLiquidationBoundaryTicks = (
+  market: MarketMarginResult,
+  totals: MarginTotals,
+  marketParams: MarginParitySnapshotFile["markets"][number],
+  marketInput: MarketMarginInputs
+): bigint | undefined => {
+  const basePositionLots = toBigInt(market.basePositionLots);
+  if (basePositionLots === 0n) {
+    return undefined;
+  }
+
+  const currentMarkTicks = toBigInt(marketParams.markPriceTicks);
+  if (currentMarkTicks <= 0n) {
+    return undefined;
+  }
+
+  if (basePositionLots > 0n) {
+    if (!isLiquidatableAtTicks(0n, market, totals, marketParams, marketInput)) {
+      return undefined;
+    }
+
+    let low = 0n;
+    let high = currentMarkTicks;
+    while (low + 1n < high) {
+      const mid = low + (high - low) / 2n;
+      if (
+        isLiquidatableAtTicks(mid, market, totals, marketParams, marketInput)
+      ) {
+        low = mid;
+      } else {
+        high = mid;
+      }
+    }
+
+    return low;
+  }
+
+  if (
+    !isLiquidatableAtTicks(
+      MAX_HAWKEYE_LIQUIDATION_TICKS,
+      market,
+      totals,
+      marketParams,
+      marketInput
+    )
+  ) {
+    return undefined;
+  }
+
+  let low = currentMarkTicks;
+  let high = MAX_HAWKEYE_LIQUIDATION_TICKS;
+  while (low + 1n < high) {
+    const mid = low + (high - low) / 2n;
+    if (isLiquidatableAtTicks(mid, market, totals, marketParams, marketInput)) {
+      high = mid;
+    } else {
+      low = mid;
+    }
+  }
+
+  return high;
+};
+
+const isLiquidatableAtTicks = (
+  ticks: bigint,
+  market: MarketMarginResult,
+  totals: MarginTotals,
+  marketParams: MarginParitySnapshotFile["markets"][number],
+  marketInput: MarketMarginInputs
+): boolean => {
+  const basePositionLots = toBigInt(market.basePositionLots);
+  const virtualQuotePositionLots = toBigInt(market.virtualQuotePositionLots);
+  const tickSize = toBigInt(marketParams.tickSize);
+  const rawTargetPnl =
+    virtualQuotePositionLots + basePositionLots * ticks * tickSize;
+  const upnlRiskFactor = toBigInt(marketParams.upnlRiskFactor);
+  const targetDiscountedPnl =
+    rawTargetPnl > 0n
+      ? applyBpsCeil(rawTargetPnl, upnlRiskFactor)
+      : rawTargetPnl;
+  const effectiveCollateral =
+    toBigInt(String(totals.collateralBalanceQuoteLots)) +
+    toBigInt(String(totals.unsettledFundingQuoteLots)) +
+    (toBigInt(String(totals.discountedUnrealizedPnlQuoteLots)) -
+      toBigInt(market.discountedUnrealizedPnlQuoteLots)) +
+    targetDiscountedPnl;
+  if (effectiveCollateral < 0n) {
+    return true;
+  }
+
+  const maintenance =
+    otherMarketMaintenanceMarginQuoteLots(market, totals) +
+    maintenanceMarginAtTicks(ticks, market, marketParams, marketInput);
+  return effectiveCollateral < maintenance;
+};
+
+const maintenanceMarginAtTicks = (
+  ticks: bigint,
+  market: MarketMarginResult,
+  marketParams: MarginParitySnapshotFile["markets"][number],
+  marketInput: MarketMarginInputs
+): bigint => {
+  const initialMargin = initialMarginForAssetAtTicks(
+    toBigInt(market.basePositionLots),
+    marketInput.limitOrderMargin ?? emptyLimitOrderState,
+    ticks,
+    marketParams
+  );
+  const maintenanceBps = toBigInt(
+    marketParams.riskFactors.maintenanceMarginFactorBps
+  );
+  return applyBps(initialMargin, maintenanceBps);
+};
+
+const initialMarginForAssetAtTicks = (
+  position: bigint,
+  limitOrderState: NonNullable<MarketMarginInputs["limitOrderMargin"]>,
+  ticks: bigint,
+  marketParams: MarginParitySnapshotFile["markets"][number]
+): bigint => {
+  const totalBid = toBigInt(limitOrderState.totalNonReduceOnlyBidBaseLots);
+  const totalAsk = toBigInt(limitOrderState.totalNonReduceOnlyAskBaseLots);
+  const totalBidAll =
+    totalBid + toBigInt(limitOrderState.totalReduceOnlyBidBaseLots);
+  const totalAskAll =
+    totalAsk + toBigInt(limitOrderState.totalReduceOnlyAskBaseLots);
+  if (
+    position === 0n &&
+    totalBid === 0n &&
+    totalAsk === 0n &&
+    totalBidAll === 0n &&
+    totalAskAll === 0n
+  ) {
+    return 0n;
+  }
+
+  const tiers = parseLeverageTiers(marketParams);
+  const tickSize = toBigInt(marketParams.tickSize);
+  const assetUnitPrice = ticks * tickSize;
+  let collateralRequired = 0n;
+  let existingPositionMarginOffset = 0n;
+
+  if (position !== 0n) {
+    const absolutePositionSize = absBigInt(position);
+    const absoluteBookValue = assetUnitPrice * absolutePositionSize;
+    const leverage = getLeverageConstant(tiers, absolutePositionSize);
+    const leverageBasedMargin = divCeil(absoluteBookValue, leverage);
+    collateralRequired += leverageBasedMargin;
+    existingPositionMarginOffset = leverageBasedMargin;
+  }
+
+  const marginBid =
+    totalBid > 0n
+      ? marginIncreaseForBids(
+          position,
+          totalBid,
+          assetUnitPrice,
+          tiers,
+          existingPositionMarginOffset
+        )
+      : 0n;
+  const marginAsk =
+    totalAsk > 0n
+      ? marginIncreaseForAsks(
+          position,
+          totalAsk,
+          assetUnitPrice,
+          tiers,
+          existingPositionMarginOffset
+        )
+      : 0n;
+
+  collateralRequired += maxBigInt(marginBid, marginAsk);
+  collateralRequired +=
+    totalBidAll > 0n
+      ? limitOrderFillLoss(
+          "bid",
+          totalBidAll,
+          toBigInt(limitOrderState.highestBid),
+          assetUnitPrice,
+          tickSize
+        )
+      : 0n;
+  collateralRequired +=
+    totalAskAll > 0n
+      ? limitOrderFillLoss(
+          "ask",
+          totalAskAll,
+          toBigInt(limitOrderState.lowestAsk),
+          assetUnitPrice,
+          tickSize
+        )
+      : 0n;
+
+  return collateralRequired;
+};
+
+const marginIncreaseForBids = (
+  position: bigint,
+  bidSize: bigint,
+  assetUnitPrice: bigint,
+  tiers: LeverageTier[],
+  existingPositionMarginOffset: bigint
+): bigint => {
+  const newExposureSigned = bidSize + position - absBigInt(position);
+  if (newExposureSigned <= 0n) {
+    return 0n;
+  }
+
+  const totalExposure = absBigInt(position + bidSize);
+  const totalGrossValue = assetUnitPrice * totalExposure;
+  const totalLeverage = getLeverageConstant(tiers, totalExposure);
+  const totalMargin = divCeil(totalGrossValue, totalLeverage);
+  const incrementalMargin = maxBigInt(
+    totalMargin - existingPositionMarginOffset,
+    0n
+  );
+  return applyBpsCeil(
+    incrementalMargin,
+    getLimitOrderRiskFactor(tiers, totalExposure)
+  );
+};
+
+const marginIncreaseForAsks = (
+  position: bigint,
+  askSize: bigint,
+  assetUnitPrice: bigint,
+  tiers: LeverageTier[],
+  existingPositionMarginOffset: bigint
+): bigint => {
+  const newExposureSigned = askSize - position - absBigInt(position);
+  if (newExposureSigned <= 0n) {
+    return 0n;
+  }
+
+  const totalExposure = absBigInt(position - askSize);
+  const totalGrossValue = assetUnitPrice * totalExposure;
+  const totalLeverage = getLeverageConstant(tiers, totalExposure);
+  const totalMargin = divCeil(totalGrossValue, totalLeverage);
+  const incrementalMargin = maxBigInt(
+    totalMargin - existingPositionMarginOffset,
+    0n
+  );
+  return applyBpsCeil(
+    incrementalMargin,
+    getLimitOrderRiskFactor(tiers, totalExposure)
+  );
+};
+
+const limitOrderFillLoss = (
+  side: "bid" | "ask",
+  size: bigint,
+  limitPriceTicks: bigint,
+  assetUnitPrice: bigint,
+  tickSize: bigint
+): bigint => {
+  if (limitPriceTicks === 0n) {
+    return 0n;
+  }
+  const limitPrice = limitPriceTicks * tickSize;
+  if (side === "bid") {
+    return limitPrice > assetUnitPrice
+      ? size * (limitPrice - assetUnitPrice)
+      : 0n;
+  }
+  return limitPrice < assetUnitPrice
+    ? size * (assetUnitPrice - limitPrice)
+    : 0n;
+};
+
+const ceilDiv = (numerator: bigint, denominator: bigint): bigint => {
+  if (denominator <= 0n) {
+    throw new Error("ceilDiv denominator must be positive");
+  }
+  return (numerator + denominator - 1n) / denominator;
 };
 
 const analyticalSolutionForMaxPosition = (
@@ -414,18 +705,18 @@ export const buildMarginParityOutput = (
               }
             : undefined,
           limitOrderMargin: {
-            numAskOrders: market.limitOrderState.numAskOrders,
-            numBidOrders: market.limitOrderState.numBidOrders,
-            lowestAsk: market.limitOrderState.lowestAsk,
-            highestBid: market.limitOrderState.highestBid,
+            numAskOrders: market.limitOrderState.numAskOrders ?? 0,
+            numBidOrders: market.limitOrderState.numBidOrders ?? 0,
+            lowestAsk: market.limitOrderState.lowestAsk ?? "0",
+            highestBid: market.limitOrderState.highestBid ?? "0",
             totalNonReduceOnlyAskBaseLots:
-              market.limitOrderState.totalNonReduceOnlyAskBaseLots,
+              market.limitOrderState.totalNonReduceOnlyAskBaseLots ?? "0",
             totalReduceOnlyAskBaseLots:
-              market.limitOrderState.totalReduceOnlyAskBaseLots,
+              market.limitOrderState.totalReduceOnlyAskBaseLots ?? "0",
             totalNonReduceOnlyBidBaseLots:
-              market.limitOrderState.totalNonReduceOnlyBidBaseLots,
+              market.limitOrderState.totalNonReduceOnlyBidBaseLots ?? "0",
             totalReduceOnlyBidBaseLots:
-              market.limitOrderState.totalReduceOnlyBidBaseLots,
+              market.limitOrderState.totalReduceOnlyBidBaseLots ?? "0",
           },
           limitOrders: (market.visibleLimitOrders ?? []).map((order) => ({
             orderSequenceNumber: order.orderSequenceNumber,
@@ -462,6 +753,12 @@ export const buildMarginParityOutput = (
             `missing snapshot market params for ${market.symbol}`
           );
         }
+        const marketInput = inputs.markets.find(
+          (input) => input.symbol === market.symbol
+        );
+        if (!marketInput) {
+          throw new Error(`missing market input for ${market.symbol}`);
+        }
         const currentPosition = toBigInt(market.basePositionLots);
         const markPriceTicks = toBigInt(marketParams.markPriceTicks);
         const bestBidTicks = marketParams.bestBidTicks
@@ -492,8 +789,19 @@ export const buildMarginParityOutput = (
         return {
           ...market,
           liquidationPriceTicks:
-            computeLiquidationPriceTicks(market, result.margin, marketParams) ??
-            undefined,
+            computeLiquidationPriceTicks(
+              market,
+              result.margin,
+              marketParams,
+              marketInput
+            ) ?? undefined,
+          projectedLiquidationPriceTicks:
+            computeProjectedLiquidationPriceTicks(
+              market,
+              result.margin,
+              marketParams,
+              marketInput
+            ) ?? undefined,
           maxLimitBidBaseLots: maxLimit.maxBidLots.toString(),
           maxLimitAskBaseLots: maxLimit.maxAskLots.toString(),
           maxMarketBuyBaseLotsEstimate: maxMarketBuy.maxBidLots.toString(),

--- a/ts/src/margin/compute.ts
+++ b/ts/src/margin/compute.ts
@@ -21,7 +21,7 @@ import type {
   NormalizedMarketParams,
   NormalizedMarketParamsBySymbol,
 } from "./normalize";
-import { buildLimitOrderMarginStateFromOrders } from "./inputs";
+import { buildLimitOrderMarginStateFromOrdersAtMark } from "./inputs";
 import type {
   LimitOrderMarginInput,
   LimitOrderMarginState,
@@ -1643,7 +1643,8 @@ const filterActiveOrders = (
 const resolveLimitOrderMarginState = (
   orders: LimitOrderMarginInput[],
   limitOrderMargin: LimitOrderMarginState | undefined,
-  basePositionLots: bigint
+  basePositionLots: bigint,
+  markPriceTicks: bigint
 ): LimitOrderMarginState | undefined => {
   if (limitOrderMargin) {
     return limitOrderMargin;
@@ -1651,7 +1652,11 @@ const resolveLimitOrderMarginState = (
   if (orders.length === 0) {
     return undefined;
   }
-  return buildLimitOrderMarginStateFromOrders(orders, basePositionLots);
+  return buildLimitOrderMarginStateFromOrdersAtMark(
+    orders,
+    basePositionLots,
+    markPriceTicks
+  );
 };
 
 const getOrderLeverageLimitForSymbol = (
@@ -1747,7 +1752,8 @@ const computeMarketMarginFromInputs = (
   const limitOrderState = resolveLimitOrderMarginState(
     activeOrders,
     input.limitOrderMargin,
-    basePositionLots
+    basePositionLots,
+    marketParams.markPriceTicks
   );
   const totalBid = limitOrderState
     ? toBigInt(limitOrderState.totalNonReduceOnlyBidBaseLots)

--- a/ts/src/margin/inputs.ts
+++ b/ts/src/margin/inputs.ts
@@ -16,6 +16,24 @@ const isActiveOrder = (order: LimitOrderMarginInput): boolean =>
 export const buildLimitOrderMarginStateFromOrders = (
   orders: LimitOrderMarginInput[],
   basePositionLots: bigint = 0n
+): LimitOrderMarginState =>
+  buildLimitOrderMarginStateFromOrdersInternal(orders, basePositionLots);
+
+export const buildLimitOrderMarginStateFromOrdersAtMark = (
+  orders: LimitOrderMarginInput[],
+  basePositionLots: bigint = 0n,
+  markPriceTicks: bigint
+): LimitOrderMarginState =>
+  buildLimitOrderMarginStateFromOrdersInternal(
+    orders,
+    basePositionLots,
+    markPriceTicks
+  );
+
+const buildLimitOrderMarginStateFromOrdersInternal = (
+  orders: LimitOrderMarginInput[],
+  basePositionLots: bigint,
+  markPriceTicks?: bigint
 ): LimitOrderMarginState => {
   let totalNonReduceOnlyBidBaseLots = 0n;
   let totalNonReduceOnlyAskBaseLots = 0n;
@@ -34,7 +52,10 @@ export const buildLimitOrderMarginStateFromOrders = (
     const priceTicks = toBigInt(order.priceTicks);
     if (order.side === "bid") {
       numBidOrders += 1;
-      if (priceTicks > highestBid) {
+      if (
+        (markPriceTicks === undefined || priceTicks > markPriceTicks) &&
+        priceTicks > highestBid
+      ) {
         highestBid = priceTicks;
       }
       if (order.reduceOnly) {
@@ -44,7 +65,10 @@ export const buildLimitOrderMarginStateFromOrders = (
       }
     } else {
       numAskOrders += 1;
-      if (lowestAsk === 0n || priceTicks < lowestAsk) {
+      if (
+        (markPriceTicks === undefined || priceTicks < markPriceTicks) &&
+        (lowestAsk === 0n || priceTicks < lowestAsk)
+      ) {
         lowestAsk = priceTicks;
       }
       if (order.reduceOnly) {

--- a/ts/src/margin/liquidation.ts
+++ b/ts/src/margin/liquidation.ts
@@ -1,4 +1,13 @@
-import { absBigInt, applyBps, getLeverageConstant, toBigInt } from "./math";
+import {
+  absBigInt,
+  applyBps,
+  applyBpsCeil,
+  divCeil,
+  getLeverageConstant,
+  getLimitOrderRiskFactor,
+  maxBigInt,
+  toBigInt,
+} from "./math";
 import type {
   NormalizedMarketParams,
   NormalizedMarketParamsBySymbol,
@@ -12,8 +21,24 @@ import type {
 const QUOTE_LOTS_PER_USD = 1_000_000;
 const EPSILON = 1e-12;
 const BPS_DENOMINATOR = 10_000;
-const U64_MAX_NUMBER = Number(2n ** 64n - 1n);
+const MAX_HAWKEYE_LIQUIDATION_TICKS = 0xffff_ffffn;
 
+export type LiquidationLimitOrderState = {
+  totalNonReduceOnlyAskBaseLots: bigint;
+  totalReduceOnlyAskBaseLots: bigint;
+  totalNonReduceOnlyBidBaseLots: bigint;
+  totalReduceOnlyBidBaseLots: bigint;
+  lowestAsk: bigint;
+  highestBid: bigint;
+};
+
+/**
+ * Inputs for the static/current-state liquidation equation.
+ *
+ * This equation answers the Hawkeye-style question: "at what target-market
+ * mark would this current account state become liquidatable if only the mark
+ * changed?" It does not simulate resting orders filling before that boundary.
+ */
 export interface CalculateLiquidationPriceUsdInput {
   positionSize: number;
   entryPriceUsd: number;
@@ -23,6 +48,12 @@ export interface CalculateLiquidationPriceUsdInput {
   collateralUsd: number;
   otherAssetUnrealizedPnlUsd?: number;
   otherAssetMaintenanceMarginUsd?: number;
+  /**
+   * Target-market limit-order maintenance in USD per $1 move in the target
+   * mark price. This keeps same-market order margin price-dependent while the
+   * root is solved.
+   */
+  targetLimitOrderMaintenanceCoefficient?: number;
   /**
    * By default, non-positive liquidation prices return null because they are
    * not actionable prices. Set this to true when callers need the raw equation
@@ -52,11 +83,25 @@ export interface TraderLiquidationPricesResult {
 }
 
 /**
- * Solves the SDK liquidation-price preview equation.
+ * Solves the static/current-state SDK liquidation-price preview equation.
  *
- * Assumptions: target-market limit-order maintenance is supplied as a fixed
- * outside term by callers, soft-stale oracle margin inflation is not modeled,
- * and positive target-market uPnL is discounted with `upnlRiskFactorBps`.
+ * This is the closed-form version of the Hawkeye-compatible boundary used by
+ * {@link computeMarketLiquidationPriceFromMargin}. Use it when integrators
+ * need the liquidation price for the current account state, such as API
+ * snapshots, parity checks, or liquidation eligibility previews.
+ *
+ * This function does not mutate the account state while the price moves. In
+ * particular, target-market resting orders remain limit-order exposure only;
+ * they are not filled, removed, or used to change entry price/collateral. For
+ * "what if my orders fill before liquidation?" displays, use
+ * {@link computeProjectedLiquidation} or
+ * {@link computeSubaccountProjectedLiquidationFromMargin} alongside the static
+ * value.
+ *
+ * Assumptions: target-market limit-order maintenance is linear in the target
+ * mark price over the solved regime, soft-stale oracle margin inflation is not
+ * modeled, and positive target-market uPnL is discounted with
+ * `upnlRiskFactorBps`.
  */
 export const calculateLiquidationPriceUsd = ({
   positionSize,
@@ -67,6 +112,7 @@ export const calculateLiquidationPriceUsd = ({
   collateralUsd,
   otherAssetUnrealizedPnlUsd = 0,
   otherAssetMaintenanceMarginUsd = 0,
+  targetLimitOrderMaintenanceCoefficient = 0,
   allowNonPositive = false,
 }: CalculateLiquidationPriceUsdInput): number | null => {
   if (
@@ -86,6 +132,7 @@ export const calculateLiquidationPriceUsd = ({
     collateralUsd,
     otherAssetUnrealizedPnlUsd,
     otherAssetMaintenanceMarginUsd,
+    targetLimitOrderMaintenanceCoefficient,
   });
   if (price === null) {
     return null;
@@ -107,6 +154,7 @@ export const calculateLiquidationPriceUsd = ({
           collateralUsd,
           otherAssetUnrealizedPnlUsd,
           otherAssetMaintenanceMarginUsd,
+          targetLimitOrderMaintenanceCoefficient,
         })
       : price;
 
@@ -130,6 +178,7 @@ const solveLiquidationPriceUsd = ({
   collateralUsd,
   otherAssetUnrealizedPnlUsd,
   otherAssetMaintenanceMarginUsd,
+  targetLimitOrderMaintenanceCoefficient,
 }: Required<
   Pick<
     CalculateLiquidationPriceUsdInput,
@@ -140,10 +189,20 @@ const solveLiquidationPriceUsd = ({
     | "collateralUsd"
     | "otherAssetUnrealizedPnlUsd"
     | "otherAssetMaintenanceMarginUsd"
+    | "targetLimitOrderMaintenanceCoefficient"
   >
 > & { targetUpnlMultiplier: number }): number | null => {
+  if (
+    !Number.isFinite(targetLimitOrderMaintenanceCoefficient) ||
+    targetLimitOrderMaintenanceCoefficient < 0
+  ) {
+    return null;
+  }
+
   const maintenanceRatio = maintenanceMarginBps / BPS_DENOMINATOR / leverage;
-  const maintenanceCoefficient = Math.abs(positionSize) * maintenanceRatio;
+  const maintenanceCoefficient =
+    Math.abs(positionSize) * maintenanceRatio +
+    targetLimitOrderMaintenanceCoefficient;
   const numerator =
     collateralUsd +
     otherAssetUnrealizedPnlUsd -
@@ -166,6 +225,13 @@ const targetUnrealizedPnlUsd = (
   priceUsd: number
 ): number => positionSize * (priceUsd - entryPriceUsd);
 
+/**
+ * Computes Hawkeye-compatible static liquidation prices for a subaccount.
+ *
+ * These prices use the current margin snapshot and do not simulate any future
+ * fills. They are the canonical value to compare against program/Hawkeye
+ * output for the current state.
+ */
 export const computeSubaccountLiquidationPricesFromMargin = (
   subaccount: SubaccountMarginResult,
   marketsBySymbol: NormalizedMarketParamsBySymbol
@@ -186,6 +252,10 @@ export const computeSubaccountLiquidationPricesFromMargin = (
   }),
 });
 
+/**
+ * Computes Hawkeye-compatible static liquidation prices for every subaccount
+ * in a trader margin result.
+ */
 export const computeTraderLiquidationPricesFromMargin = (
   trader: TraderMarginResult,
   marketsBySymbol: NormalizedMarketParamsBySymbol
@@ -197,6 +267,14 @@ export const computeTraderLiquidationPricesFromMargin = (
   ),
 });
 
+/**
+ * Computes one market's static/current-state liquidation price from a margin
+ * result.
+ *
+ * The returned boundary assumes only the target-market mark changes. Resting
+ * orders affect current maintenance margin through the supplied margin result,
+ * but they do not fill along the price path.
+ */
 export const computeMarketLiquidationPriceFromMargin = (
   market: MarketMarginResult,
   subaccount: SubaccountMarginResult,
@@ -228,34 +306,30 @@ export const computeMarketLiquidationPriceFromMargin = (
   const entryPriceUsd =
     quoteLotsToUsd(absBigInt(virtualQuotePositionLots)) /
     Math.abs(basePositionUnits);
-  const collateralUsd = quoteLotsToUsd(
-    toBigInt(subaccount.margin.collateralBalanceQuoteLots) +
-      toBigInt(subaccount.margin.unsettledFundingQuoteLots)
-  );
-  const otherAssetUnrealizedPnlUsd = quoteLotsToUsd(
-    toBigInt(subaccount.margin.discountedUnrealizedPnlQuoteLots) -
-      toBigInt(market.discountedUnrealizedPnlQuoteLots)
-  );
-  const otherAssetMaintenanceMarginUsd = quoteLotsToUsd(
-    otherAssetMaintenanceMarginQuoteLots(market, subaccount, marketParams)
-  );
-  const leverage = Number(
-    getLeverageConstant(marketParams.leverageTiers, absBigInt(basePositionLots))
-  );
-  const maintenanceBps = Number(
-    marketParams.riskFactors.maintenanceMarginFactorBps
-  );
+  const currentMarkTicks = toBigInt(marketParams.markPriceTicks);
 
-  const liquidationPriceUsd = calculateLiquidationPriceUsd({
-    positionSize: basePositionUnits,
-    entryPriceUsd,
-    leverage,
-    maintenanceMarginBps: maintenanceBps,
-    upnlRiskFactorBps: Number(marketParams.upnlRiskFactor),
-    collateralUsd,
-    otherAssetUnrealizedPnlUsd,
-    otherAssetMaintenanceMarginUsd,
-  });
+  if (
+    isLiquidatableAtTicks(currentMarkTicks, market, subaccount, marketParams)
+  ) {
+    return {
+      symbol: market.symbol,
+      basePositionLots: market.basePositionLots,
+      basePositionUnits,
+      entryPriceUsd,
+      liquidationPriceUsd: markPriceUsdFromParams(marketParams),
+      liquidationPriceTicks: currentMarkTicks.toString(),
+    };
+  }
+
+  const liquidationPriceTicks = findLiquidationBoundaryTicks(
+    market,
+    subaccount,
+    marketParams
+  );
+  const liquidationPriceUsd =
+    liquidationPriceTicks === null
+      ? null
+      : ticksToPriceUsd(liquidationPriceTicks, marketParams);
 
   return {
     symbol: market.symbol,
@@ -263,46 +337,22 @@ export const computeMarketLiquidationPriceFromMargin = (
     basePositionUnits,
     entryPriceUsd,
     liquidationPriceUsd,
-    liquidationPriceTicks:
-      liquidationPriceUsd === null
-        ? null
-        : priceUsdToRoundedTicks(liquidationPriceUsd, marketParams),
+    liquidationPriceTicks: liquidationPriceTicks?.toString() ?? null,
   };
 };
 
-const otherAssetMaintenanceMarginQuoteLots = (
+const otherMarketMaintenanceMarginQuoteLots = (
   market: MarketMarginResult,
-  subaccount: SubaccountMarginResult,
-  marketParams: NormalizedMarketParams
+  subaccount: SubaccountMarginResult
 ): bigint => {
-  const targetPositionOnlyMaintenanceMargin =
-    positionOnlyMaintenanceMarginQuoteLots(market, marketParams);
   const portfolioMaintenanceMargin = toBigInt(
     subaccount.margin.maintenanceMarginQuoteLots
   );
 
   return checkedSubtractQuoteLots(
     portfolioMaintenanceMargin,
-    targetPositionOnlyMaintenanceMargin,
-    `Portfolio maintenance margin underflow for symbol ${market.symbol}`
-  );
-};
-
-const positionOnlyMaintenanceMarginQuoteLots = (
-  market: MarketMarginResult,
-  marketParams: NormalizedMarketParams
-): bigint => {
-  const maintenanceBps = marketParams.riskFactors.maintenanceMarginFactorBps;
-  const discountedLimitOrderMaintenanceMargin = applyBps(
-    toBigInt(market.limitOrderMarginQuoteLots),
-    maintenanceBps
-  );
-
-  // Mirrors phoenix-state Margin::position_only_maintenance_margin.
-  return checkedSubtractQuoteLots(
     toBigInt(market.maintenanceMarginQuoteLots),
-    discountedLimitOrderMaintenanceMargin,
-    `Position maintenance margin underflow for symbol ${market.symbol}`
+    `Portfolio maintenance margin underflow for symbol ${market.symbol}`
   );
 };
 
@@ -341,25 +391,967 @@ const quoteLotsToUsd = (quoteLots: bigint): number =>
 const baseLotsToUnits = (baseLots: bigint, baseLotDecimals: number): number =>
   Number(baseLots) / Math.pow(10, baseLotDecimals);
 
-const priceUsdToRoundedTicks = (
-  priceUsd: number,
+const ticksToPriceUsd = (
+  ticks: bigint,
   marketParams: NormalizedMarketParams
-): string | null => {
-  if (!Number.isFinite(priceUsd) || priceUsd <= 0) {
+): number => {
+  const markPriceQuoteLotsPerBaseLot = Number(
+    ticks * toBigInt(marketParams.tickSize)
+  );
+  return (
+    (markPriceQuoteLotsPerBaseLot *
+      Math.pow(10, marketParams.baseLotDecimals)) /
+    QUOTE_LOTS_PER_USD
+  );
+};
+
+const markPriceUsdFromParams = (marketParams: NormalizedMarketParams): number =>
+  ticksToPriceUsd(toBigInt(marketParams.markPriceTicks), marketParams);
+
+const findLiquidationBoundaryTicks = (
+  market: MarketMarginResult,
+  subaccount: SubaccountMarginResult,
+  marketParams: NormalizedMarketParams
+): bigint | null => {
+  const basePositionLots = toBigInt(market.basePositionLots);
+  if (basePositionLots === 0n) {
     return null;
   }
 
-  const tickSize = Number(marketParams.tickSize);
-  const baseLotsPerBaseUnit = Math.pow(10, marketParams.baseLotDecimals);
-  const denominator = tickSize * baseLotsPerBaseUnit;
-  if (!Number.isFinite(denominator) || denominator <= 0) {
+  const currentMarkTicks = toBigInt(marketParams.markPriceTicks);
+  if (currentMarkTicks <= 0n) {
     return null;
   }
 
-  const ticks = Math.round((priceUsd * QUOTE_LOTS_PER_USD) / denominator);
-  if (!Number.isFinite(ticks) || ticks < 0 || ticks > U64_MAX_NUMBER) {
+  if (basePositionLots > 0n) {
+    if (!isLiquidatableAtTicks(0n, market, subaccount, marketParams)) {
+      return null;
+    }
+
+    let low = 0n;
+    let high = currentMarkTicks;
+    while (low + 1n < high) {
+      const mid = low + (high - low) / 2n;
+      if (isLiquidatableAtTicks(mid, market, subaccount, marketParams)) {
+        low = mid;
+      } else {
+        high = mid;
+      }
+    }
+
+    return low;
+  }
+
+  if (
+    !isLiquidatableAtTicks(
+      MAX_HAWKEYE_LIQUIDATION_TICKS,
+      market,
+      subaccount,
+      marketParams
+    )
+  ) {
     return null;
   }
 
-  return BigInt(ticks).toString();
+  let low = currentMarkTicks;
+  let high = MAX_HAWKEYE_LIQUIDATION_TICKS;
+  while (low + 1n < high) {
+    const mid = low + (high - low) / 2n;
+    if (isLiquidatableAtTicks(mid, market, subaccount, marketParams)) {
+      high = mid;
+    } else {
+      low = mid;
+    }
+  }
+
+  return high;
+};
+
+const isLiquidatableAtTicks = (
+  ticks: bigint,
+  market: MarketMarginResult,
+  subaccount: SubaccountMarginResult,
+  marketParams: NormalizedMarketParams
+): boolean => {
+  const basePositionLots = toBigInt(market.basePositionLots);
+  const virtualQuotePositionLots = toBigInt(market.virtualQuotePositionLots);
+  const tickSize = toBigInt(marketParams.tickSize);
+  const rawTargetPnl =
+    virtualQuotePositionLots + basePositionLots * ticks * tickSize;
+  const upnlRiskFactor = toBigInt(marketParams.upnlRiskFactor);
+  const targetDiscountedPnl =
+    rawTargetPnl > 0n
+      ? applyBpsCeil(rawTargetPnl, upnlRiskFactor)
+      : rawTargetPnl;
+  const effectiveCollateral =
+    toBigInt(subaccount.margin.collateralBalanceQuoteLots) +
+    toBigInt(subaccount.margin.unsettledFundingQuoteLots) +
+    (toBigInt(subaccount.margin.discountedUnrealizedPnlQuoteLots) -
+      toBigInt(market.discountedUnrealizedPnlQuoteLots)) +
+    targetDiscountedPnl;
+  if (effectiveCollateral < 0n) {
+    return true;
+  }
+
+  const targetMaintenance = maintenanceMarginAtTicks(
+    ticks,
+    market,
+    subaccount,
+    marketParams
+  );
+  const maintenance =
+    otherMarketMaintenanceMarginQuoteLots(market, subaccount) +
+    targetMaintenance;
+  return effectiveCollateral < maintenance;
+};
+
+const maintenanceMarginAtTicks = (
+  ticks: bigint,
+  market: MarketMarginResult,
+  subaccount: SubaccountMarginResult,
+  marketParams: NormalizedMarketParams
+): bigint => {
+  const basePositionLots = toBigInt(market.basePositionLots);
+  const limitOrderState = aggregateLimitOrderState(
+    market,
+    subaccount,
+    toBigInt(marketParams.markPriceTicks)
+  );
+  const initialMargin = initialMarginForAssetAtTicks(
+    basePositionLots,
+    limitOrderState,
+    ticks,
+    marketParams
+  );
+  const maintenanceBps = toBigInt(
+    marketParams.riskFactors.maintenanceMarginFactorBps
+  );
+  return applyBps(initialMargin, maintenanceBps);
+};
+
+const aggregateLimitOrderState = (
+  market: MarketMarginResult,
+  subaccount: SubaccountMarginResult,
+  markPriceTicks: bigint
+): LiquidationLimitOrderState =>
+  aggregateLimitOrderStateFromOrders(
+    subaccount.limitOrders
+      .filter((order) => order.symbol === market.symbol)
+      .map((order) => ({
+        side: order.side,
+        priceTicks: toBigInt(order.priceTicks),
+        baseLotsRemaining: toBigInt(order.tradeSizeRemainingLots),
+        reduceOnly: order.reduceOnly,
+      })),
+    toBigInt(market.basePositionLots),
+    markPriceTicks
+  );
+
+/**
+ * Aggregates resting orders into the limit-order margin state used by the
+ * liquidation predicates. Best-price sentinels are built relative to the
+ * given mark: only orders that could cross at that mark reserve fill-loss
+ * margin, mirroring the canonical adverse-only sentinel semantics.
+ */
+export const aggregateLimitOrderStateFromOrders = (
+  orders: ProjectedLiquidationOrderInput[],
+  basePositionLots: bigint,
+  markPriceTicks: bigint
+): LiquidationLimitOrderState => {
+  let totalNonReduceOnlyAskBaseLots = 0n;
+  let totalReduceOnlyAskBaseLots = 0n;
+  let totalNonReduceOnlyBidBaseLots = 0n;
+  let totalReduceOnlyBidBaseLots = 0n;
+  let lowestAsk = 0n;
+  let highestBid = 0n;
+
+  for (const order of orders) {
+    const size = order.baseLotsRemaining;
+    const priceTicks = order.priceTicks;
+    if (order.side === "ask") {
+      if (priceTicks < markPriceTicks) {
+        lowestAsk =
+          lowestAsk === 0n ? priceTicks : minBigInt(lowestAsk, priceTicks);
+      }
+      if (order.reduceOnly) {
+        totalReduceOnlyAskBaseLots += size;
+      } else {
+        totalNonReduceOnlyAskBaseLots += size;
+      }
+    } else {
+      if (priceTicks > markPriceTicks) {
+        highestBid = maxBigInt(highestBid, priceTicks);
+      }
+      if (order.reduceOnly) {
+        totalReduceOnlyBidBaseLots += size;
+      } else {
+        totalNonReduceOnlyBidBaseLots += size;
+      }
+    }
+  }
+
+  if (basePositionLots >= 0n) {
+    totalReduceOnlyAskBaseLots = minBigInt(
+      totalReduceOnlyAskBaseLots,
+      basePositionLots
+    );
+    totalReduceOnlyBidBaseLots = 0n;
+  } else {
+    totalReduceOnlyAskBaseLots = 0n;
+    totalReduceOnlyBidBaseLots = minBigInt(
+      totalReduceOnlyBidBaseLots,
+      absBigInt(basePositionLots)
+    );
+  }
+
+  return {
+    totalNonReduceOnlyAskBaseLots,
+    totalReduceOnlyAskBaseLots,
+    totalNonReduceOnlyBidBaseLots,
+    totalReduceOnlyBidBaseLots,
+    lowestAsk,
+    highestBid,
+  };
+};
+
+const initialMarginForAssetAtTicks = (
+  position: bigint,
+  limitOrderState: LiquidationLimitOrderState,
+  ticks: bigint,
+  marketParams: NormalizedMarketParams
+): bigint => {
+  const totalBid = limitOrderState.totalNonReduceOnlyBidBaseLots;
+  const totalAsk = limitOrderState.totalNonReduceOnlyAskBaseLots;
+  const totalBidAll = totalBid + limitOrderState.totalReduceOnlyBidBaseLots;
+  const totalAskAll = totalAsk + limitOrderState.totalReduceOnlyAskBaseLots;
+  if (
+    position === 0n &&
+    totalBid === 0n &&
+    totalAsk === 0n &&
+    totalBidAll === 0n &&
+    totalAskAll === 0n
+  ) {
+    return 0n;
+  }
+
+  const tickSize = toBigInt(marketParams.tickSize);
+  const assetUnitPrice = ticks * tickSize;
+  let collateralRequired = 0n;
+  let existingPositionMarginOffset = 0n;
+
+  if (position !== 0n) {
+    const absolutePositionSize = absBigInt(position);
+    const absoluteBookValue = assetUnitPrice * absolutePositionSize;
+    const leverage = getLeverageConstant(
+      marketParams.leverageTiers,
+      absolutePositionSize
+    );
+    const leverageBasedMargin = divCeil(absoluteBookValue, leverage);
+    collateralRequired += leverageBasedMargin;
+    existingPositionMarginOffset = leverageBasedMargin;
+  }
+
+  const marginBid =
+    totalBid > 0n
+      ? marginIncreaseForBids(
+          position,
+          totalBid,
+          assetUnitPrice,
+          marketParams.leverageTiers,
+          existingPositionMarginOffset
+        )
+      : 0n;
+  const marginAsk =
+    totalAsk > 0n
+      ? marginIncreaseForAsks(
+          position,
+          totalAsk,
+          assetUnitPrice,
+          marketParams.leverageTiers,
+          existingPositionMarginOffset
+        )
+      : 0n;
+
+  collateralRequired += maxBigInt(marginBid, marginAsk);
+  collateralRequired +=
+    totalBidAll > 0n
+      ? limitOrderFillLoss(
+          "bid",
+          totalBidAll,
+          limitOrderState.highestBid,
+          assetUnitPrice,
+          tickSize
+        )
+      : 0n;
+  collateralRequired +=
+    totalAskAll > 0n
+      ? limitOrderFillLoss(
+          "ask",
+          totalAskAll,
+          limitOrderState.lowestAsk,
+          assetUnitPrice,
+          tickSize
+        )
+      : 0n;
+
+  return collateralRequired;
+};
+
+const marginIncreaseForBids = (
+  position: bigint,
+  bidSize: bigint,
+  assetUnitPrice: bigint,
+  tiers: NormalizedMarketParams["leverageTiers"],
+  existingPositionMarginOffset: bigint
+): bigint => {
+  const newExposureSigned = bidSize + position - absBigInt(position);
+  if (newExposureSigned <= 0n) {
+    return 0n;
+  }
+
+  const totalExposure = absBigInt(position + bidSize);
+  const totalGrossValue = assetUnitPrice * totalExposure;
+  const totalLeverage = getLeverageConstant(tiers, totalExposure);
+  const totalMargin = divCeil(totalGrossValue, totalLeverage);
+  const incrementalMargin = maxBigInt(
+    totalMargin - existingPositionMarginOffset,
+    0n
+  );
+  return applyBpsCeil(
+    incrementalMargin,
+    getLimitOrderRiskFactor(tiers, totalExposure)
+  );
+};
+
+const marginIncreaseForAsks = (
+  position: bigint,
+  askSize: bigint,
+  assetUnitPrice: bigint,
+  tiers: NormalizedMarketParams["leverageTiers"],
+  existingPositionMarginOffset: bigint
+): bigint => {
+  const newExposureSigned = askSize - position - absBigInt(position);
+  if (newExposureSigned <= 0n) {
+    return 0n;
+  }
+
+  const totalExposure = absBigInt(position - askSize);
+  const totalGrossValue = assetUnitPrice * totalExposure;
+  const totalLeverage = getLeverageConstant(tiers, totalExposure);
+  const totalMargin = divCeil(totalGrossValue, totalLeverage);
+  const incrementalMargin = maxBigInt(
+    totalMargin - existingPositionMarginOffset,
+    0n
+  );
+  return applyBpsCeil(
+    incrementalMargin,
+    getLimitOrderRiskFactor(tiers, totalExposure)
+  );
+};
+
+const limitOrderFillLoss = (
+  side: "bid" | "ask",
+  size: bigint,
+  limitPriceTicks: bigint,
+  assetUnitPrice: bigint,
+  tickSize: bigint
+): bigint => {
+  if (limitPriceTicks === 0n) {
+    return 0n;
+  }
+  const limitPrice = limitPriceTicks * tickSize;
+  if (side === "bid") {
+    return limitPrice > assetUnitPrice
+      ? size * (limitPrice - assetUnitPrice)
+      : 0n;
+  }
+  return limitPrice < assetUnitPrice
+    ? size * (assetUnitPrice - limitPrice)
+    : 0n;
+};
+
+const minBigInt = (a: bigint, b: bigint): bigint => (a < b ? a : b);
+
+const I64_MIN = -(2n ** 63n);
+const I64_MAX = 2n ** 63n - 1n;
+
+/**
+ * A resting order considered by the projected liquidation path.
+ *
+ * Only visible target-market orders are needed here. The projected path will
+ * consider non-reduce-only orders that increase the current position direction
+ * and will ignore reduce-only or opposite-side orders.
+ */
+export interface ProjectedLiquidationOrderInput {
+  side: "bid" | "ask";
+  priceTicks: bigint;
+  baseLotsRemaining: bigint;
+  reduceOnly: boolean;
+}
+
+/** A resting-order fill applied along the projected liquidation path. */
+export interface ProjectedLiquidationFill {
+  side: "bid" | "ask";
+  priceTicks: bigint;
+  baseLots: bigint;
+}
+
+/**
+ * Result of the projected (path-dependent) liquidation price calculation.
+ *
+ * `liquidationPriceTicks` is `null` when the account cannot become
+ * liquidatable at any tick in the adverse direction, even after every
+ * projected fill is applied. `staticLiquidationPriceTicks` is the ordinary
+ * current-state boundary for the same inputs, computed as the projection's
+ * first path segment.
+ *
+ * When `fills` is empty, the projected and static boundaries are the same.
+ * When `fills` is non-empty, `liquidationPriceTicks` is a scenario estimate for
+ * the post-fill account state and should be displayed as projected risk rather
+ * than as the canonical Hawkeye liquidation price.
+ */
+export interface ProjectedLiquidationResult {
+  liquidationPriceTicks: bigint | null;
+  staticLiquidationPriceTicks: bigint | null;
+  /** Fills applied before the boundary, in path order. */
+  fills: ProjectedLiquidationFill[];
+}
+
+/**
+ * Inputs for {@link computeProjectedLiquidation}.
+ *
+ * The portfolio fields carry the same aggregates the static liquidation search
+ * uses; the target fields are the target market's contribution to those
+ * aggregates at the current mark. The first path segment therefore starts from
+ * the same account state as {@link computeMarketLiquidationPriceFromMargin}.
+ */
+export interface ProjectedLiquidationInput {
+  basePositionLots: bigint;
+  virtualQuotePositionLots: bigint;
+  /**
+   * Target-market limit-order margin state for the current state (canonical
+   * when available).
+   */
+  limitOrderState: LiquidationLimitOrderState;
+  /** The trader's visible resting orders in the target market. */
+  visibleOrders: ProjectedLiquidationOrderInput[];
+  collateralBalanceQuoteLots: bigint;
+  portfolioUnsettledFundingQuoteLots: bigint;
+  portfolioDiscountedUnrealizedPnlQuoteLots: bigint;
+  portfolioMaintenanceMarginQuoteLots: bigint;
+  targetDiscountedUnrealizedPnlQuoteLots: bigint;
+  targetMaintenanceMarginQuoteLots: bigint;
+}
+
+/**
+ * Computes a projected liquidation price by re-solving the static boundary
+ * after simulating the trader's own risk-increasing resting orders filling
+ * along the adverse price path.
+ *
+ * This answers a different question than the static/Hawkeye liquidation price.
+ * Static liquidation asks where the current state becomes liquidatable if only
+ * the mark changes. Projected liquidation asks where the trader would become
+ * liquidatable if the mark trades through their position-side resting orders,
+ * those orders fill at their limit prices, and each post-fill state is
+ * re-evaluated.
+ *
+ * Use the projected value as a risk/explainer estimate for dashboards,
+ * portfolio tools, and pre-trade education when resting orders can materially
+ * change the future position. Do not use it as the source of truth for current
+ * liquidation eligibility or for parity with Hawkeye/program output; keep the
+ * static value visible for that.
+ *
+ * The path model is deliberately minimal and deterministic:
+ * - Only non-reduce-only orders on the position side fill (bids for a long,
+ *   asks for a short), fully and exactly at their limit price, most adverse
+ *   first. Fees, slippage, contra liquidity, trigger orders, and
+ *   opposite-side (risk-reducing) fills are not modeled.
+ * - Fills extend the position in its current direction, so no PnL is
+ *   realized and collateral stays constant; funding is treated as settled at
+ *   the current rate.
+ * - Non-target markets stay fixed at their snapshot aggregates, exactly like
+ *   the static liquidation search.
+ *
+ * When no orders would fill before the boundary this returns the static
+ * result.
+ */
+export const computeProjectedLiquidation = (
+  input: ProjectedLiquidationInput,
+  marketParams: NormalizedMarketParams
+): ProjectedLiquidationResult => {
+  const fills: ProjectedLiquidationFill[] = [];
+  let basePositionLots = input.basePositionLots;
+  let virtualQuotePositionLots = input.virtualQuotePositionLots;
+  if (basePositionLots === 0n) {
+    return {
+      liquidationPriceTicks: null,
+      staticLiquidationPriceTicks: null,
+      fills,
+    };
+  }
+  const isLong = basePositionLots > 0n;
+  let simMarkTicks = toBigInt(marketParams.markPriceTicks);
+  if (simMarkTicks <= 0n) {
+    return {
+      liquidationPriceTicks: null,
+      staticLiquidationPriceTicks: null,
+      fills,
+    };
+  }
+
+  const consumed = input.visibleOrders.map(() => false);
+  const fillOrder = input.visibleOrders
+    .map((_, index) => index)
+    .filter((index) => {
+      const order = input.visibleOrders[index];
+      return !order.reduceOnly && (order.side === "bid" ? isLong : !isLong);
+    })
+    // Most adverse first: highest bid for a long, lowest ask for a short.
+    .sort((a, b) => {
+      const priceA = input.visibleOrders[a].priceTicks;
+      const priceB = input.visibleOrders[b].priceTicks;
+      const ordered = isLong ? priceB - priceA : priceA - priceB;
+      return ordered > 0n ? 1 : ordered < 0n ? -1 : 0;
+    });
+
+  let limitOrderState = input.limitOrderState;
+  let staticLiquidationPriceTicks: bigint | null = null;
+  let nextFill = 0;
+  for (;;) {
+    if (
+      isProjectedLiquidatableAtTicks(
+        simMarkTicks,
+        basePositionLots,
+        virtualQuotePositionLots,
+        limitOrderState,
+        input,
+        marketParams
+      )
+    ) {
+      return {
+        liquidationPriceTicks: simMarkTicks,
+        staticLiquidationPriceTicks:
+          nextFill === 0 ? simMarkTicks : staticLiquidationPriceTicks,
+        fills,
+      };
+    }
+
+    const boundary = findProjectedLiquidationBoundaryTicks(
+      basePositionLots,
+      virtualQuotePositionLots,
+      limitOrderState,
+      simMarkTicks,
+      input,
+      marketParams
+    );
+    if (nextFill === 0) {
+      staticLiquidationPriceTicks = boundary;
+    }
+    if (nextFill >= fillOrder.length) {
+      return {
+        liquidationPriceTicks: boundary,
+        staticLiquidationPriceTicks,
+        fills,
+      };
+    }
+    const order = input.visibleOrders[fillOrder[nextFill]];
+    if (boundary !== null) {
+      const boundaryBeforeFill = isLong
+        ? boundary >= order.priceTicks
+        : boundary <= order.priceTicks;
+      if (boundaryBeforeFill) {
+        return {
+          liquidationPriceTicks: boundary,
+          staticLiquidationPriceTicks,
+          fills,
+        };
+      }
+    }
+
+    // Fill the order fully at its limit price. Projected fills are always on
+    // the position side, so the position grows in place and no PnL is
+    // realized.
+    const deltaBaseLots =
+      order.side === "bid" ? order.baseLotsRemaining : -order.baseLotsRemaining;
+    const fillUnitPrice = order.priceTicks * toBigInt(marketParams.tickSize);
+    basePositionLots += deltaBaseLots;
+    virtualQuotePositionLots -= deltaBaseLots * fillUnitPrice;
+    if (
+      basePositionLots < I64_MIN ||
+      basePositionLots > I64_MAX ||
+      virtualQuotePositionLots < I64_MIN ||
+      virtualQuotePositionLots > I64_MAX
+    ) {
+      // Mirror the Rust engines, which report no boundary when the projected
+      // position overflows the on-chain integer domain.
+      return {
+        liquidationPriceTicks: null,
+        staticLiquidationPriceTicks,
+        fills,
+      };
+    }
+    consumed[fillOrder[nextFill]] = true;
+    fills.push({
+      side: order.side,
+      priceTicks: order.priceTicks,
+      baseLots: order.baseLotsRemaining,
+    });
+    nextFill += 1;
+    simMarkTicks = order.priceTicks;
+    limitOrderState = aggregateLimitOrderStateFromOrders(
+      input.visibleOrders.filter((_, index) => !consumed[index]),
+      basePositionLots,
+      simMarkTicks
+    );
+  }
+};
+
+const isProjectedLiquidatableAtTicks = (
+  ticks: bigint,
+  basePositionLots: bigint,
+  virtualQuotePositionLots: bigint,
+  limitOrderState: LiquidationLimitOrderState,
+  input: ProjectedLiquidationInput,
+  marketParams: NormalizedMarketParams
+): boolean => {
+  const tickSize = toBigInt(marketParams.tickSize);
+  const rawTargetPnl =
+    virtualQuotePositionLots + basePositionLots * ticks * tickSize;
+  const upnlRiskFactor = toBigInt(marketParams.upnlRiskFactor);
+  const targetDiscountedPnl =
+    rawTargetPnl > 0n
+      ? applyBpsCeil(rawTargetPnl, upnlRiskFactor)
+      : rawTargetPnl;
+  const effectiveCollateral =
+    input.collateralBalanceQuoteLots +
+    input.portfolioUnsettledFundingQuoteLots +
+    (input.portfolioDiscountedUnrealizedPnlQuoteLots -
+      input.targetDiscountedUnrealizedPnlQuoteLots) +
+    targetDiscountedPnl;
+  if (effectiveCollateral < 0n) {
+    return true;
+  }
+
+  const otherMaintenanceMargin = checkedSubtractQuoteLots(
+    input.portfolioMaintenanceMarginQuoteLots,
+    input.targetMaintenanceMarginQuoteLots,
+    "Portfolio maintenance margin underflow in projected liquidation"
+  );
+  const targetMaintenance = applyBps(
+    initialMarginForAssetAtTicks(
+      basePositionLots,
+      limitOrderState,
+      ticks,
+      marketParams
+    ),
+    toBigInt(marketParams.riskFactors.maintenanceMarginFactorBps)
+  );
+  return effectiveCollateral < otherMaintenanceMargin + targetMaintenance;
+};
+
+const findProjectedLiquidationBoundaryTicks = (
+  basePositionLots: bigint,
+  virtualQuotePositionLots: bigint,
+  limitOrderState: LiquidationLimitOrderState,
+  currentMarkTicks: bigint,
+  input: ProjectedLiquidationInput,
+  marketParams: NormalizedMarketParams
+): bigint | null => {
+  const liquidatable = (ticks: bigint): boolean =>
+    isProjectedLiquidatableAtTicks(
+      ticks,
+      basePositionLots,
+      virtualQuotePositionLots,
+      limitOrderState,
+      input,
+      marketParams
+    );
+
+  if (basePositionLots > 0n) {
+    if (!liquidatable(0n)) {
+      return null;
+    }
+
+    let low = 0n;
+    let high = currentMarkTicks;
+    while (low + 1n < high) {
+      const mid = low + (high - low) / 2n;
+      if (liquidatable(mid)) {
+        low = mid;
+      } else {
+        high = mid;
+      }
+    }
+
+    return low;
+  }
+
+  if (!liquidatable(MAX_HAWKEYE_LIQUIDATION_TICKS)) {
+    return null;
+  }
+
+  let low = currentMarkTicks;
+  let high = MAX_HAWKEYE_LIQUIDATION_TICKS;
+  while (low + 1n < high) {
+    const mid = low + (high - low) / 2n;
+    if (liquidatable(mid)) {
+      high = mid;
+    } else {
+      low = mid;
+    }
+  }
+
+  return high;
+};
+
+/** Per-market projected liquidation result with display USD at the edge. */
+export interface MarketProjectedLiquidationResult {
+  symbol: string;
+  basePositionLots: string;
+  liquidationPriceUsd: number | null;
+  liquidationPriceTicks: string | null;
+  staticLiquidationPriceTicks: string | null;
+  fills: ProjectedLiquidationFill[];
+}
+
+export interface SubaccountProjectedLiquidationResult {
+  subaccountIndex: number;
+  positions: MarketProjectedLiquidationResult[];
+}
+
+/**
+ * Computes the projected liquidation price for one market from computed margin
+ * results, mirroring {@link computeMarketLiquidationPriceFromMargin}.
+ *
+ * Use this alongside the static market liquidation price to show the difference
+ * between "current state" and "position-side orders fill first" risk. Returns
+ * `null` for markets without a position.
+ */
+export const computeMarketProjectedLiquidationFromMargin = (
+  market: MarketMarginResult,
+  subaccount: SubaccountMarginResult,
+  marketParams: NormalizedMarketParams,
+  compute: (
+    input: ProjectedLiquidationInput,
+    marketParams: NormalizedMarketParams
+  ) => ProjectedLiquidationResult = computeProjectedLiquidation
+): MarketProjectedLiquidationResult | null => {
+  const input = buildProjectedLiquidationInput(
+    market,
+    subaccount,
+    marketParams
+  );
+  if (input === null) {
+    return null;
+  }
+
+  const result = compute(input, marketParams);
+  return {
+    symbol: market.symbol,
+    basePositionLots: market.basePositionLots,
+    liquidationPriceUsd:
+      result.liquidationPriceTicks === null
+        ? null
+        : projectedTicksToPriceUsd(result.liquidationPriceTicks, marketParams),
+    liquidationPriceTicks: result.liquidationPriceTicks?.toString() ?? null,
+    staticLiquidationPriceTicks:
+      result.staticLiquidationPriceTicks?.toString() ?? null,
+    fills: result.fills,
+  };
+};
+
+/**
+ * Computes projected liquidation prices for every market with a position in
+ * the subaccount, mirroring
+ * {@link computeSubaccountLiquidationPricesFromMargin}.
+ *
+ * These values are scenario estimates and are additive to the static prices,
+ * not replacements. Pass a memoized `compute` from
+ * {@link createProjectedLiquidationCalculator} to reuse results across small
+ * target-market mark moves.
+ */
+export const computeSubaccountProjectedLiquidationFromMargin = (
+  subaccount: SubaccountMarginResult,
+  marketsBySymbol: NormalizedMarketParamsBySymbol,
+  compute?: (
+    input: ProjectedLiquidationInput,
+    marketParams: NormalizedMarketParams
+  ) => ProjectedLiquidationResult
+): SubaccountProjectedLiquidationResult => ({
+  subaccountIndex: subaccount.subaccountIndex,
+  positions: subaccount.marketMargins.flatMap((market) => {
+    const marketParams = marketsBySymbol[market.symbol];
+    if (!marketParams) {
+      throw new Error(`Missing market params for symbol ${market.symbol}`);
+    }
+
+    const projected = computeMarketProjectedLiquidationFromMargin(
+      market,
+      subaccount,
+      marketParams,
+      compute
+    );
+    return projected ? [projected] : [];
+  }),
+});
+
+const buildProjectedLiquidationInput = (
+  market: MarketMarginResult,
+  subaccount: SubaccountMarginResult,
+  marketParams: NormalizedMarketParams
+): ProjectedLiquidationInput | null => {
+  const basePositionLots = toBigInt(market.basePositionLots);
+  if (basePositionLots === 0n) {
+    return null;
+  }
+
+  const markPriceTicks = toBigInt(marketParams.markPriceTicks);
+  const visibleOrders: ProjectedLiquidationOrderInput[] = subaccount.limitOrders
+    .filter((order) => order.symbol === market.symbol)
+    .map((order) => ({
+      side: order.side,
+      priceTicks: toBigInt(order.priceTicks),
+      baseLotsRemaining: toBigInt(order.tradeSizeRemainingLots),
+      reduceOnly: order.reduceOnly,
+    }));
+
+  return {
+    basePositionLots,
+    virtualQuotePositionLots: toBigInt(market.virtualQuotePositionLots),
+    limitOrderState: aggregateLimitOrderStateFromOrders(
+      visibleOrders,
+      basePositionLots,
+      markPriceTicks
+    ),
+    visibleOrders,
+    collateralBalanceQuoteLots: toBigInt(
+      subaccount.margin.collateralBalanceQuoteLots
+    ),
+    portfolioUnsettledFundingQuoteLots: toBigInt(
+      subaccount.margin.unsettledFundingQuoteLots
+    ),
+    portfolioDiscountedUnrealizedPnlQuoteLots: toBigInt(
+      subaccount.margin.discountedUnrealizedPnlQuoteLots
+    ),
+    portfolioMaintenanceMarginQuoteLots: toBigInt(
+      subaccount.margin.maintenanceMarginQuoteLots
+    ),
+    targetDiscountedUnrealizedPnlQuoteLots: toBigInt(
+      market.discountedUnrealizedPnlQuoteLots
+    ),
+    targetMaintenanceMarginQuoteLots: toBigInt(
+      market.maintenanceMarginQuoteLots
+    ),
+  };
+};
+
+const projectedTicksToPriceUsd = (
+  ticks: bigint,
+  marketParams: NormalizedMarketParams
+): number => {
+  const quoteLotsPerBaseLot = Number(ticks * toBigInt(marketParams.tickSize));
+  return (
+    (quoteLotsPerBaseLot * Math.pow(10, marketParams.baseLotDecimals)) /
+    QUOTE_LOTS_PER_USD
+  );
+};
+
+/**
+ * Creates a memoizing wrapper around {@link computeProjectedLiquidation}.
+ *
+ * This is useful for live dashboards that display projected liquidation
+ * alongside mark updates. It avoids re-running the path simulation while the
+ * account state is unchanged and the mark remains on the safe side of the
+ * static boundary.
+ *
+ * The projected boundary is a function of the account state, not of the
+ * target market's mark: while the account stays non-liquidatable at the
+ * current mark, a target-market mark move changes neither the fill ladder
+ * nor any path segment's boundary. Cached results are therefore keyed on
+ * every input except the mark and reused while the mark stays on the safe
+ * side of the cached static boundary. Any change to positions, orders,
+ * collateral, funding, or other-market aggregates changes the key and
+ * recomputes.
+ */
+export const createProjectedLiquidationCalculator = (options?: {
+  maxCacheEntries?: number;
+}): ((
+  input: ProjectedLiquidationInput,
+  marketParams: NormalizedMarketParams
+) => ProjectedLiquidationResult) => {
+  const maxCacheEntries = options?.maxCacheEntries ?? 128;
+  const cache = new Map<string, ProjectedLiquidationResult>();
+
+  return (input, marketParams) => {
+    const key = projectedLiquidationCacheKey(input, marketParams);
+    const cached = cache.get(key);
+    if (cached) {
+      const markTicks = toBigInt(marketParams.markPriceTicks);
+      const boundary = cached.staticLiquidationPriceTicks;
+      const markStillSafe =
+        boundary === null
+          ? markTicks > 0n
+          : input.basePositionLots > 0n
+            ? markTicks > boundary
+            : markTicks < boundary;
+      if (markStillSafe) {
+        // Refresh LRU position.
+        cache.delete(key);
+        cache.set(key, cached);
+        return cached;
+      }
+      cache.delete(key);
+    }
+
+    const result = computeProjectedLiquidation(input, marketParams);
+    cache.set(key, result);
+    if (cache.size > maxCacheEntries) {
+      const oldest = cache.keys().next().value;
+      if (oldest !== undefined) {
+        cache.delete(oldest);
+      }
+    }
+    return result;
+  };
+};
+
+const projectedLiquidationCacheKey = (
+  input: ProjectedLiquidationInput,
+  marketParams: NormalizedMarketParams
+): string => {
+  const state = input.limitOrderState;
+  const orders = input.visibleOrders
+    .map(
+      (order) =>
+        `${order.side}:${order.priceTicks}:${order.baseLotsRemaining}:${order.reduceOnly ? 1 : 0}`
+    )
+    .join(",");
+  const tiers = marketParams.leverageTiers
+    .map(
+      (tier) =>
+        `${tier.upperBoundSize}:${tier.maxLeverage}:${tier.limitOrderRiskFactorBps}`
+    )
+    .join(",");
+  return [
+    marketParams.symbol,
+    input.basePositionLots,
+    input.virtualQuotePositionLots,
+    input.collateralBalanceQuoteLots,
+    input.portfolioUnsettledFundingQuoteLots,
+    input.portfolioDiscountedUnrealizedPnlQuoteLots,
+    input.portfolioMaintenanceMarginQuoteLots,
+    input.targetDiscountedUnrealizedPnlQuoteLots,
+    input.targetMaintenanceMarginQuoteLots,
+    state.totalNonReduceOnlyAskBaseLots,
+    state.totalReduceOnlyAskBaseLots,
+    state.totalNonReduceOnlyBidBaseLots,
+    state.totalReduceOnlyBidBaseLots,
+    state.lowestAsk,
+    state.highestBid,
+    orders,
+    marketParams.tickSize,
+    marketParams.upnlRiskFactor,
+    marketParams.riskFactors.maintenanceMarginFactorBps,
+    tiers,
+  ].join("|");
 };

--- a/ts/src/margin/snapshot.ts
+++ b/ts/src/margin/snapshot.ts
@@ -1,5 +1,3 @@
-import { buildLimitOrderMarginStateFromOrders } from "./inputs";
-import { toBigInt } from "./math";
 import type {
   LimitOrderMarginInput,
   MarginPositionState,
@@ -72,7 +70,7 @@ const toLimitOrderMarginInput = (
   status: order.status,
 });
 
-export { buildLimitOrderMarginStateFromOrders };
+export { buildLimitOrderMarginStateFromOrders } from "./inputs";
 
 export const buildMarginPositionStateFromSnapshot = (
   position: MarginSnapshotPosition
@@ -91,18 +89,12 @@ export const buildMarketMarginInputsFromSnapshot = (
 ): MarketMarginInputs => {
   const limitOrders = orders.map(toLimitOrderMarginInput);
   const activeOrders = limitOrders.filter(isActiveOrder);
-  const basePositionLots = position ? toBigInt(position.basePositionLots) : 0n;
-  const limitOrderMargin =
-    activeOrders.length > 0
-      ? buildLimitOrderMarginStateFromOrders(activeOrders, basePositionLots)
-      : undefined;
 
   return {
     symbol,
     position: position
       ? buildMarginPositionStateFromSnapshot(position)
       : undefined,
-    limitOrderMargin,
     limitOrders: activeOrders.length > 0 ? activeOrders : undefined,
   };
 };

--- a/ts/tests/margin-liquidation-price.test.ts
+++ b/ts/tests/margin-liquidation-price.test.ts
@@ -20,6 +20,15 @@ const quoteLots = (usd: number): string =>
 const priceTicks = (priceUsd: number): string =>
   Math.round((priceUsd * MICRO_USD) / BASE_LOTS_PER_UNIT).toString();
 
+const priceTicksWithParams = (
+  priceUsd: number,
+  tickSize: number,
+  baseLotDecimals: number
+): string =>
+  Math.round(
+    (priceUsd * MICRO_USD) / (tickSize * Math.pow(10, baseLotDecimals))
+  ).toString();
+
 const market = (
   symbol: string,
   assetId: number,
@@ -48,6 +57,24 @@ const market = (
   upnlRiskFactor: "10000",
   upnlRiskFactorForWithdrawals: "10000",
   isolatedOnly: false,
+});
+
+const snapshotMarket = (
+  symbol: string,
+  assetId: number,
+  markPriceUsd: number,
+  upperBoundSize: string
+): MarketParams => ({
+  ...market(symbol, assetId, markPriceUsd, 10, "10000"),
+  markPriceTicks: priceTicksWithParams(markPriceUsd, 10, 2),
+  tickSize: "10",
+  leverageTiers: [
+    {
+      upperBoundSize,
+      maxLeverage: "10",
+      limitOrderRiskFactorBps: "10000",
+    },
+  ],
 });
 
 const position = (
@@ -156,7 +183,7 @@ describe("margin liquidation price", () => {
     }
   );
 
-  it("solves long liquidation prices from portfolio margin and provided marks", () => {
+  it("returns the current mark for already-liquidatable long positions", () => {
     const calculator = createMarginCalculator([
       market("SOL-PERP", 1, 100, 50),
       market("ETH-PERP", 2, 100, 10),
@@ -179,8 +206,21 @@ describe("margin liquidation price", () => {
     expect(sol?.basePositionLots).toBe("100");
     expect(sol?.basePositionUnits).toBe(1);
     expect(sol?.entryPriceUsd).toBe(100);
-    expect(sol?.liquidationPriceUsd).toBeCloseTo(353.5353535, 5);
-    expect(sol?.liquidationPriceTicks).toBe("3535354");
+    expect(sol?.liquidationPriceUsd).toBe(100);
+    expect(sol?.liquidationPriceTicks).toBe("1000000");
+  });
+
+  it("returns the current mark for already-liquidatable short positions", () => {
+    const calculator = createMarginCalculator([market("SOL-PERP", 1, 200, 25)]);
+    const result = calculator.computeSubaccountLiquidationPricesFromInputs({
+      subaccountIndex: 0,
+      collateralBalanceQuoteLots: quoteLots(0),
+      markets: [position("SOL-PERP", -1, 200)],
+    });
+
+    const sol = findPosition(result, "SOL-PERP");
+    expect(sol?.liquidationPriceUsd).toBe(200);
+    expect(sol?.liquidationPriceTicks).toBe("2000000");
   });
 
   it("solves short liquidation prices from portfolio margin and provided marks", () => {
@@ -198,7 +238,7 @@ describe("margin liquidation price", () => {
     expect(sol?.basePositionLots).toBe("-200");
     expect(sol?.basePositionUnits).toBe(-2);
     expect(sol?.entryPriceUsd).toBe(200);
-    expect(sol?.liquidationPriceUsd).toBeCloseTo(264.70588235, 5);
+    expect(sol?.liquidationPriceUsd).toBeCloseTo(264.7059, 8);
     expect(sol?.liquidationPriceTicks).toBe("2647059");
   });
 
@@ -220,10 +260,10 @@ describe("margin liquidation price", () => {
 
     expect(
       findPosition(withoutFunding, "SOL-PERP")?.liquidationPriceUsd
-    ).toBeCloseTo(318.62745098, 5);
+    ).toBeCloseTo(318.6275, 8);
     expect(
       findPosition(withFunding, "SOL-PERP")?.liquidationPriceUsd
-    ).toBeCloseTo(367.64705882, 5);
+    ).toBeCloseTo(367.6471, 8);
   });
 
   it("matches the dashboard NVDA liquidation price case", () => {
@@ -274,10 +314,7 @@ describe("margin liquidation price", () => {
             calculator.markets.NVDA
           );
 
-    expect(liquidationPrice?.liquidationPriceUsd).toBeCloseTo(
-      213.15422199108983,
-      8
-    );
+    expect(liquidationPrice?.liquidationPriceUsd).toBe(214.18);
     expect(
       liquidationPrice?.liquidationPriceUsd?.toLocaleString("en-US", {
         style: "currency",
@@ -285,7 +322,7 @@ describe("margin liquidation price", () => {
         minimumFractionDigits: 2,
         maximumFractionDigits: 2,
       })
-    ).toBe("$213.15");
+    ).toBe("$214.18");
   });
 
   it("rejects inconsistent margin totals instead of clamping underflow", () => {
@@ -310,11 +347,11 @@ describe("margin liquidation price", () => {
     ).toThrow(/Portfolio maintenance margin underflow for symbol SOL-PERP/);
   });
 
-  it("keeps same-market limit-order maintenance in the equation", () => {
+  it("uses current-mark limit-order fill-loss sentinels for same-market liquidation", () => {
     const calculator = createMarginCalculator([market("SOL-PERP", 1, 100, 50)]);
     const result = calculator.computeSubaccountLiquidationPricesFromInputs({
       subaccountIndex: 0,
-      collateralBalanceQuoteLots: quoteLots(100),
+      collateralBalanceQuoteLots: quoteLots(99),
       markets: [
         {
           ...position("SOL-PERP", 1, -100),
@@ -333,8 +370,213 @@ describe("margin liquidation price", () => {
     });
 
     const sol = findPosition(result, "SOL-PERP");
-    expect(sol?.liquidationPriceUsd).toBeCloseTo(0.5050505, 5);
-    expect(sol?.liquidationPriceTicks).toBe("5051");
+    expect(sol?.liquidationPriceUsd).toBeCloseTo(1.0152, 8);
+    expect(sol?.liquidationPriceTicks).toBe("10152");
+  });
+
+  it("handles negative base-lot decimals when same-market limit orders affect liquidation", () => {
+    const calculator = createMarginCalculator([
+      {
+        ...market("XAU-PERP", 1, 100, 10, "10000"),
+        markPriceTicks: "10000",
+        tickSize: "1000000",
+        baseLotDecimals: -2,
+      },
+    ]);
+
+    const result = calculator.computeSubaccountLiquidationPricesFromInputs({
+      subaccountIndex: 0,
+      collateralBalanceQuoteLots: quoteLots(2_000),
+      markets: [
+        {
+          symbol: "XAU-PERP",
+          position: {
+            basePositionLots: "1",
+            virtualQuotePositionLots: quoteLots(-10_000),
+            entryPriceTicks: "10000",
+            unsettledFundingQuoteLots: "0",
+            accumulatedFundingQuoteLots: "0",
+          },
+          limitOrders: [
+            {
+              orderSequenceNumber: "1",
+              side: "bid",
+              priceTicks: "10000",
+              sizeRemainingLots: "1",
+              initialSizeLots: "1",
+              reduceOnly: false,
+            },
+          ],
+        },
+      ],
+    });
+
+    const xau = findPosition(result, "XAU-PERP");
+    expect(xau?.basePositionUnits).toBe(100);
+    expect(xau?.liquidationPriceUsd).toBeCloseTo(88.88, 8);
+    expect(xau?.liquidationPriceTicks).toBe("8888");
+  });
+
+  it("matches provided HYPE liquidation price with target and other-market orders", () => {
+    const calculator = createMarginCalculator([
+      snapshotMarket("HYPE", 4, 71.9, "4000000"),
+      snapshotMarket("ZEC", 10, 506.16, "1250657"),
+    ]);
+
+    const result = calculator.computeSubaccountLiquidationPricesFromInputs({
+      subaccountIndex: 0,
+      collateralBalanceQuoteLots: "4559664733",
+      markets: [
+        {
+          symbol: "HYPE",
+          position: {
+            basePositionLots: "12488",
+            entryPriceTicks: "71394",
+            virtualQuotePositionLots: "-8915750122",
+            unsettledFundingQuoteLots: "0",
+            accumulatedFundingQuoteLots: "-2312216",
+          },
+          limitOrders: [
+            {
+              orderSequenceNumber: "18446744073683662222",
+              side: "bid",
+              priceTicks: "70400",
+              sizeRemainingLots: "1500",
+              initialSizeLots: "1500",
+              reduceOnly: false,
+            },
+          ],
+        },
+        {
+          symbol: "ZEC",
+          limitOrders: [
+            {
+              orderSequenceNumber: "18446744073709527386",
+              side: "bid",
+              priceTicks: "47900",
+              sizeRemainingLots: "1035",
+              initialSizeLots: "1035",
+              reduceOnly: false,
+            },
+            {
+              orderSequenceNumber: "18446744073709527387",
+              side: "bid",
+              priceTicks: "48700",
+              sizeRemainingLots: "1035",
+              initialSizeLots: "1035",
+              reduceOnly: false,
+            },
+          ],
+        },
+      ],
+    });
+
+    const hype = findPosition(result, "HYPE");
+    expect(hype?.liquidationPriceUsd).toBeCloseTo(41.395, 8);
+    expect(hype?.liquidationPriceTicks).toBe("41395");
+  });
+
+  it("matches Hawkeye for a ZEC long with passive same-market bids", () => {
+    const calculator = createMarginCalculator([
+      {
+        symbol: "ZEC",
+        assetId: 10,
+        markPriceTicks: "46100",
+        tickSize: "100",
+        baseLotDecimals: 2,
+        leverageTiers: [
+          {
+            upperBoundSize: "1250657",
+            maxLeverage: "10",
+            limitOrderRiskFactorBps: "10000",
+          },
+        ],
+        riskFactors: {
+          maintenanceMarginFactorBps: "5000",
+          backstopMarginFactorBps: "2000",
+          highRiskMarginFactorBps: "1000",
+        },
+        cancelOrderRiskFactorBps: "7500",
+        upnlRiskFactor: "10000",
+        upnlRiskFactorForWithdrawals: "100",
+        isolatedOnly: false,
+      },
+      {
+        symbol: "ETH",
+        assetId: 2,
+        markPriceTicks: "17353",
+        tickSize: "100",
+        baseLotDecimals: 3,
+        leverageTiers: [
+          {
+            upperBoundSize: "12894433",
+            maxLeverage: "20",
+            limitOrderRiskFactorBps: "10000",
+          },
+        ],
+        riskFactors: {
+          maintenanceMarginFactorBps: "5000",
+          backstopMarginFactorBps: "2000",
+          highRiskMarginFactorBps: "1000",
+        },
+        cancelOrderRiskFactorBps: "7000",
+        upnlRiskFactor: "10000",
+        upnlRiskFactorForWithdrawals: "100",
+        isolatedOnly: false,
+      },
+    ]);
+
+    const result = calculator.computeSubaccountLiquidationPricesFromInputs({
+      subaccountIndex: 0,
+      collateralBalanceQuoteLots: "4358740700",
+      markets: [
+        {
+          symbol: "ZEC",
+          position: {
+            basePositionLots: "1500",
+            virtualQuotePositionLots: "-6811070900",
+            entryPriceTicks: "45407",
+            unsettledFundingQuoteLots: "0",
+            accumulatedFundingQuoteLots: "16320",
+          },
+          limitOrders: [
+            {
+              orderSequenceNumber: "18446744073709527200",
+              side: "bid",
+              priceTicks: "42322",
+              sizeRemainingLots: "5045",
+              initialSizeLots: "5045",
+              reduceOnly: false,
+            },
+            {
+              orderSequenceNumber: "18446744073709527199",
+              side: "bid",
+              priceTicks: "44485",
+              sizeRemainingLots: "500",
+              initialSizeLots: "500",
+              reduceOnly: false,
+            },
+          ],
+        },
+        {
+          symbol: "ETH",
+          limitOrders: [
+            {
+              orderSequenceNumber: "58234622",
+              side: "ask",
+              priceTicks: "17480",
+              sizeRemainingLots: "4500",
+              initialSizeLots: "4500",
+              reduceOnly: false,
+            },
+          ],
+        },
+      ],
+    });
+
+    const zec = findPosition(result, "ZEC");
+    expect(zec?.liquidationPriceUsd).toBeCloseTo(230.67, 8);
+    expect(zec?.liquidationPriceTicks).toBe("23067");
   });
 
   it("returns null for invalid and non-actionable solver inputs by default", () => {
@@ -442,8 +684,8 @@ describe("margin liquidation price", () => {
     });
     expect(result.liquidationPrice?.entryPriceUsd).toBe(120);
     expect(result.liquidationPrice?.liquidationPriceUsd).toBeCloseTo(
-      257.425742,
-      5
+      257.4258,
+      8
     );
   });
 
@@ -536,8 +778,8 @@ describe("margin liquidation price", () => {
       isolated.liquidationPrice?.liquidationPriceUsd ?? Number.POSITIVE_INFINITY
     );
     expect(isolated.liquidationPrice?.liquidationPriceUsd).toBeCloseTo(
-      50.50505,
-      5
+      50.505,
+      8
     );
   });
 

--- a/ts/tests/margin-projected-liquidation.test.ts
+++ b/ts/tests/margin-projected-liquidation.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregateLimitOrderStateFromOrders,
+  computeProjectedLiquidation,
+  createProjectedLiquidationCalculator,
+  type NormalizedMarketParams,
+  type ProjectedLiquidationInput,
+  type ProjectedLiquidationOrderInput,
+} from "@/margin";
+
+/**
+ * ZEC market parameters and account state from
+ * `tools/margin-math-parity/fixtures/diff/snapshot_1783529040.wincode.zst`
+ * for authority `4nHxBXGUdoTG262JXfyH56G7vFaQgAPrauLfHQ8zTu2k`; see
+ * `tools/margin-math-parity/docs/liquidation-price-calculation.md`.
+ */
+const zecMarketParams = (markPriceTicks: bigint): NormalizedMarketParams => ({
+  symbol: "ZEC",
+  assetId: 10,
+  markPriceTicks,
+  tickSize: 100n,
+  baseLotDecimals: 2,
+  leverageTiers: [
+    {
+      upperBoundSize: 1_250_657n,
+      maxLeverage: 10n,
+      limitOrderRiskFactorBps: 10_000n,
+    },
+    {
+      upperBoundSize: 1_250_658n,
+      maxLeverage: 1n,
+      limitOrderRiskFactorBps: 10_000n,
+    },
+    {
+      upperBoundSize: 1_250_659n,
+      maxLeverage: 1n,
+      limitOrderRiskFactorBps: 10_000n,
+    },
+    {
+      upperBoundSize: 1_250_660n,
+      maxLeverage: 1n,
+      limitOrderRiskFactorBps: 10_000n,
+    },
+  ],
+  riskFactors: {
+    maintenanceMarginFactorBps: 5_000n,
+    backstopMarginFactorBps: 2_000n,
+    highRiskMarginFactorBps: 1_000n,
+  },
+  cancelOrderRiskFactorBps: 7_500n,
+  upnlRiskFactor: 10_000n,
+  upnlRiskFactorForWithdrawals: 100n,
+  isolatedOnly: false,
+});
+
+const zecVisibleOrders: ProjectedLiquidationOrderInput[] = [
+  {
+    side: "bid",
+    priceTicks: 44_485n,
+    baseLotsRemaining: 500n,
+    reduceOnly: false,
+  },
+  {
+    side: "bid",
+    priceTicks: 42_322n,
+    baseLotsRemaining: 5_045n,
+    reduceOnly: false,
+  },
+];
+
+const zecInput = (markPriceTicks: bigint): ProjectedLiquidationInput => ({
+  basePositionLots: 1_500n,
+  virtualQuotePositionLots: -6_811_070_900n,
+  limitOrderState: aggregateLimitOrderStateFromOrders(
+    zecVisibleOrders,
+    1_500n,
+    markPriceTicks
+  ),
+  visibleOrders: zecVisibleOrders,
+  collateralBalanceQuoteLots: 4_358_740_700n,
+  portfolioUnsettledFundingQuoteLots: 0n,
+  portfolioDiscountedUnrealizedPnlQuoteLots: 103_929_100n,
+  portfolioMaintenanceMarginQuoteLots: 1_819_093_750n,
+  targetDiscountedUnrealizedPnlQuoteLots: 103_929_100n,
+  targetMaintenanceMarginQuoteLots: 1_623_872_500n,
+});
+
+describe("computeProjectedLiquidation", () => {
+  it("fills passive bids before solving the boundary for the ZEC snapshot account", () => {
+    const result = computeProjectedLiquidation(
+      zecInput(46_100n),
+      zecMarketParams(46_100n)
+    );
+
+    expect(result.fills).toEqual([
+      { side: "bid", priceTicks: 44_485n, baseLots: 500n },
+      { side: "bid", priceTicks: 42_322n, baseLots: 5_045n },
+    ]);
+    expect(result.staticLiquidationPriceTicks).toBe(23_067n);
+    expect(result.liquidationPriceTicks).toBe(39_181n);
+  });
+
+  it("matches the static boundary when no position-side orders rest", () => {
+    const input: ProjectedLiquidationInput = {
+      ...zecInput(46_100n),
+      limitOrderState: aggregateLimitOrderStateFromOrders([], 1_500n, 46_100n),
+      visibleOrders: [],
+      portfolioMaintenanceMarginQuoteLots: 540_971_250n,
+      targetMaintenanceMarginQuoteLots: 345_750_000n,
+    };
+    const result = computeProjectedLiquidation(input, zecMarketParams(46_100n));
+
+    expect(result.fills).toEqual([]);
+    expect(result.liquidationPriceTicks).toBe(
+      result.staticLiquidationPriceTicks
+    );
+    expect(result.liquidationPriceTicks).not.toBeNull();
+  });
+
+  it("reports no liquidation price when the account can never be liquidated", () => {
+    const input: ProjectedLiquidationInput = {
+      ...zecInput(46_100n),
+      collateralBalanceQuoteLots: 1_000_000_000_000_000n,
+    };
+    const result = computeProjectedLiquidation(input, zecMarketParams(46_100n));
+
+    expect(result.liquidationPriceTicks).toBeNull();
+    expect(result.staticLiquidationPriceTicks).toBeNull();
+    expect(result.fills).toHaveLength(2);
+  });
+
+  it("returns the mark when the account is already liquidatable", () => {
+    const result = computeProjectedLiquidation(
+      zecInput(23_000n),
+      zecMarketParams(23_000n)
+    );
+
+    expect(result.liquidationPriceTicks).toBe(23_000n);
+    expect(result.staticLiquidationPriceTicks).toBe(23_000n);
+    expect(result.fills).toEqual([]);
+  });
+});
+
+describe("createProjectedLiquidationCalculator", () => {
+  it("reuses the cached result across target-market mark moves", () => {
+    const compute = createProjectedLiquidationCalculator();
+
+    const first = compute(zecInput(46_100n), zecMarketParams(46_100n));
+    // A small mark move changes neither the fill ladder nor the boundary;
+    // the cached result object is returned as-is.
+    const second = compute(zecInput(45_900n), zecMarketParams(45_900n));
+    expect(second).toBe(first);
+    expect(second.liquidationPriceTicks).toBe(39_181n);
+  });
+
+  it("recomputes when the mark crosses the cached static boundary", () => {
+    const compute = createProjectedLiquidationCalculator();
+
+    const first = compute(zecInput(46_100n), zecMarketParams(46_100n));
+    expect(first.staticLiquidationPriceTicks).toBe(23_067n);
+
+    // At a mark at or below the static boundary the account is already
+    // liquidatable, so the cached result no longer applies.
+    const crossed = compute(zecInput(23_067n), zecMarketParams(23_067n));
+    expect(crossed).not.toBe(first);
+    expect(crossed.liquidationPriceTicks).toBe(23_067n);
+  });
+
+  it("recomputes when account state changes", () => {
+    const compute = createProjectedLiquidationCalculator();
+
+    const first = compute(zecInput(46_100n), zecMarketParams(46_100n));
+    const withMoreCollateral = compute(
+      {
+        ...zecInput(46_100n),
+        collateralBalanceQuoteLots: 5_000_000_000n,
+      },
+      zecMarketParams(46_100n)
+    );
+    expect(withMoreCollateral).not.toBe(first);
+  });
+});


### PR DESCRIPTION
Generated by `.github/scripts/sync_rise.py`.

## Source

- Phoenix commit: `6051225fb045fbb5b6a454bd445e7fc2e31e5722`
- Mode: automatic
- Synced paths:

- `rise/ts` -> `ts`
- `rise/README.md` -> `README.md`
- `rise/instructions.json` -> `instructions.json`
- `rise/programs` -> `programs`
- `rise/test-fixtures` -> `test-fixtures`

## Changelog Draft

This draft was also appended to package changelog file(s) in this PR so it can be manually edited before merge:

- `ts/CHANGELOG.md`

### Summary

- Rewrote the SDK's liquidation-price search to use a numeric mark-price boundary search instead of the previous closed-form equation, fixing incorrect results for already-liquidatable positions and for same-market resting orders.
- Added a new "projected liquidation" API — `computeProjectedLiquidation`, `computeMarketProjectedLiquidationFromMargin`, `computeSubaccountProjectedLiquidationFromMargin`, `createProjectedLiquidationCalculator`, `aggregateLimitOrderStateFromOrders`, and related types — that estimates liquidation risk after a trader's own resting orders fill along the adverse price path.
- Limit-order margin best-bid/best-ask sentinels are now computed relative to the current mark price via the new `buildLimitOrderMarginStateFromOrdersAtMark`, so only orders that could actually cross at the current mark reserve fill-loss margin.

### Breaking Changes

- `computeMarketLiquidationPriceFromMargin`, `computeSubaccountLiquidationPricesFromMargin`, and `computeTraderLiquidationPricesFromMargin` now return the current mark price for already-liquidatable positions and otherwise use the new boundary-search algorithm — expect different numeric outputs than 0.4.65 for identical inputs.
- `buildMarketMarginInputsFromSnapshot` no longer populates `limitOrderMargin` on its returned `MarketMarginInputs`; margin/liquidation computation now derives limit-order sentinels internally from `limitOrders` and the market's mark price. Code reading `.limitOrderMargin` directly off this helper's output will now see `undefined`.
- Same-market limit-order maintenance margin is now mark-price-dependent (only crossing-side resting orders count toward fill-loss margin), changing computed margin/liquidation values for accounts with resting orders on the far side of the mark.

### Consumer Notes

- Treat the existing static liquidation-price functions as the canonical current-state ("Hawkeye-compatible") value; use the new projected-liquidation functions only for scenario/risk displays, not for liquidation-eligibility or program parity checks.
- `calculateLiquidationPriceUsd` gained an optional `targetLimitOrderMaintenanceCoefficient` input, defaulting to `0` for backward compatibility.
- `buildLimitOrderMarginStateFromOrders` keeps its prior signature/behavior for existing callers; switch to `buildLimitOrderMarginStateFromOrdersAtMark` where mark-relative sentinels are needed.